### PR TITLE
Standardize plugin description across all manifests

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "dataverse",
-      "description": "Official Dataverse plugin for agent-guided development with MCP, PAC CLI, and Python SDK",
+      "description": "Agent skills for building on, analyzing, and managing Microsoft Dataverse — with Dataverse MCP, PAC CLI, and Dataverse Python SDK.",
       "source": "./.github/plugins/dataverse",
       "homepage": "https://github.com/microsoft/Dataverse-skills"
     }

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -11,7 +11,7 @@
   "plugins": [
     {
       "name": "dataverse",
-      "description": "Dataverse and Power Platform developer tools. Covers machine setup, workspace init, metadata authoring, solution management, Python SDK, MCP server configuration, and demo data.",
+      "description": "Agent skills for building on, analyzing, and managing Microsoft Dataverse — with Dataverse MCP, PAC CLI, and Dataverse Python SDK.",
       "source": "./.github/plugins/dataverse",
       "version": "1.0.0",
       "homepage": "https://github.com/microsoft/Dataverse-skills"

--- a/.github/plugins/dataverse/.claude-plugin/plugin.json
+++ b/.github/plugins/dataverse/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dataverse",
-  "description": "Dataverse and Power Platform developer tools. Covers machine setup, workspace init, metadata authoring, solution management, Python SDK, MCP server configuration, and demo data.",
+  "description": "Agent skills for building on, analyzing, and managing Microsoft Dataverse — with Dataverse MCP, PAC CLI, and Dataverse Python SDK.",
   "version": "1.0.0",
   "author": {
     "name": "Microsoft",

--- a/.github/plugins/dataverse/.github/plugin/plugin.json
+++ b/.github/plugins/dataverse/.github/plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dataverse",
-  "description": "Dataverse and Power Platform developer tools. Covers machine setup, workspace init, metadata authoring, solution management, Python SDK, MCP server configuration, and demo data.",
+  "description": "Agent skills for building on, analyzing, and managing Microsoft Dataverse — with Dataverse MCP, PAC CLI, and Dataverse Python SDK.",
   "version": "1.0.0",
   "author": {
     "name": "Microsoft",


### PR DESCRIPTION
## Summary

- Use a single generic description across all 4 manifest files (Claude Code + Copilot CLI, marketplace + plugin level)
- Description: *"Dataverse developer tools for agent-guided development with Dataverse MCP, PAC CLI, and Dataverse Python SDK."*
- Avoids listing specific skills so the description stays stable as skills are added/removed

## Files changed

- `.claude-plugin/marketplace.json`
- `.github/plugin/marketplace.json`
- `.github/plugins/dataverse/.claude-plugin/plugin.json`
- `.github/plugins/dataverse/.github/plugin/plugin.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)