### PR TITLE
Improving the wording in the init skill to ensure the environment URL is confirmed and no steps are skipped

### DIFF
--- a/.github/plugins/dataverse/skills/init/SKILL.md
+++ b/.github/plugins/dataverse/skills/init/SKILL.md
@@ -12,9 +12,9 @@ description: >
 
 > **Environment-First Rule** — All metadata (solutions, columns, tables, forms, views) and plugin registrations are created **in the Dynamics environment** via API or scripts, then pulled into the repo. Never write or edit solution XML by hand to create new components. This rule applies to every step in both scenarios below.
 
-Two scenarios — handle both.
+**Execute every numbered step in order.** Do not skip ahead to a later step, even if it appears more relevant to the user's immediate goal. Steps that seem unrelated to the current task (e.g., MCP setup when the user asked about tables) are still required — they enable the user's workflow in future sessions.
 
-Do not skip steps unless explicitly noted, and follow through to the full sequence for the appropriate scenario. In particular, by the end of either scenario the user should have a working `.env`, be connected to their environment via PAC CLI, have the MCP server configured, and have the git repository created if it does not already exist.
+Two scenarios — handle both.
 
 ---
 
@@ -194,7 +194,7 @@ Use the resulting GUID as `TENANT_ID` in `.env`. Only ask the user if this comma
 
 Follow steps 3–4 from Scenario A above. Ask the user for SOLUTION_NAME if not already known (but use the DATAVERSE_URL you obtained and confirmed in step 2).
 
-Set up MCP following step 5 from Scenario A. Skip CLIENT_ID/CLIENT_SECRET if the user authenticates interactively. Device code tokens are cached automatically via AuthenticationRecord persistence.
+Set up MCP following step 5 from Scenario A.
 
 ### 4. Create the directory structure
 

--- a/.github/plugins/dataverse/skills/init/SKILL.md
+++ b/.github/plugins/dataverse/skills/init/SKILL.md
@@ -14,7 +14,7 @@ description: >
 
 Two scenarios — handle both.
 
-Do not skip steps unless explicitly noted, and follow through to the full sequence for the appropriate scenario. In particular, by the end of either scenario the user should have a working `.env`, be connected to their environment via PAC CLI, have the MCP server configured, and have the repository set up.
+Do not skip steps unless explicitly noted, and follow through to the full sequence for the appropriate scenario. In particular, by the end of either scenario the user should have a working `.env`, be connected to their environment via PAC CLI, have the MCP server configured, and have the git repository created if it does not already exist.
 
 ---
 
@@ -176,9 +176,11 @@ Verify you are at the repo root.
 
 ### 2. Discover TENANT_ID
 
-Always ask the user to confirm the Dataverse environment URL before proceeding, even if you can derive it from `pac auth list` or other sources. Do not assume.
+Always ask the user to confirm the Dataverse environment URL and pause to let the user respond even if you can derive it from `pac auth list` or other sources.
 
-Before writing `.env`, auto-discover `TENANT_ID` from the Dataverse URL:
+Do not perform any subsequent or parallel operations until the user answers. Do not assume.
+
+Before writing `.env`, auto-discover `TENANT_ID` from the Dataverse URL confirmed by the user:
 
 ```bash
 curl -sI https://<org>.crm.dynamics.com/api/data/v9.2/ \

--- a/.github/plugins/dataverse/skills/init/SKILL.md
+++ b/.github/plugins/dataverse/skills/init/SKILL.md
@@ -14,6 +14,8 @@ description: >
 
 Two scenarios — handle both.
 
+Do not skip steps unless explicitly noted, and follow through to the full sequence for the appropriate scenario. In particular, by the end of either scenario the user should have a working `.env`, be connected to their environment via PAC CLI, have the MCP server configured, and have the repository set up.
+
 ---
 
 ## Scenario A: New Machine (repo already exists)
@@ -174,7 +176,9 @@ Verify you are at the repo root.
 
 ### 2. Discover TENANT_ID
 
-Before writing `.env`, auto-discover `TENANT_ID` from the Dataverse URL (the user must provide the URL first):
+Always ask the user to confirm the Dataverse environment URL before proceeding, even if you can derive it from `pac auth list` or other sources. Do not assume.
+
+Before writing `.env`, auto-discover `TENANT_ID` from the Dataverse URL:
 
 ```bash
 curl -sI https://<org>.crm.dynamics.com/api/data/v9.2/ \
@@ -186,7 +190,9 @@ Use the resulting GUID as `TENANT_ID` in `.env`. Only ask the user if this comma
 
 ### 3. Create .env, MCP config, and .gitignore
 
-Follow steps 3–4 from Scenario A above. Ask the user for DATAVERSE_URL and SOLUTION_NAME if not already known. Set up MCP following step 5 from Scenario A. Skip CLIENT_ID/CLIENT_SECRET if the user authenticates interactively. Device code tokens are cached automatically via AuthenticationRecord persistence.
+Follow steps 3–4 from Scenario A above. Ask the user for SOLUTION_NAME if not already known (but use the DATAVERSE_URL you obtained and confirmed in step 2).
+
+Set up MCP following step 5 from Scenario A. Skip CLIENT_ID/CLIENT_SECRET if the user authenticates interactively. Device code tokens are cached automatically via AuthenticationRecord persistence.
 
 ### 4. Create the directory structure
 

--- a/.github/plugins/dataverse/skills/mcp-configure/SKILL.md
+++ b/.github/plugins/dataverse/skills/mcp-configure/SKILL.md
@@ -330,6 +330,8 @@ Offer to the user to install the Dataverse MCP server by running {CLAUDE_COMMAND
 > - Create, update, or delete records
 > - Explore your schema and relationships
 
+If you installed the MCP server, pause and give the user a chance to restart the session to enable it before proceeding. Do not perform any subsequent or parallel operations until the user responds.
+
 Otherwise provide the command with instructions:
 > To install the Dataverse MCP server, exit claude and run:
 >


### PR DESCRIPTION
This PR modifies the wording to prevent two issues:
- The environment URL being assumed based on `pac auth list` without confirmation (also reported by others during validation)
- The MCP configuration step being skipped