### PR TITLE
Improve metadata, overview and python-sdk skills based on support agent scenario evaluation

### DIFF
--- a/.github/plugins/dataverse/skills/metadata/SKILL.md
+++ b/.github/plugins/dataverse/skills/metadata/SKILL.md
@@ -11,6 +11,16 @@ description: >
 
 # Skill: Metadata — Making Changes
 
+## Before You Start: Environment Confirmation
+
+**Before any metadata change** (creating tables, columns, relationships, forms, or views), confirm the target environment with the user:
+
+> "I'm about to make schema changes to `<DATAVERSE_URL>`. Is this the correct environment?"
+
+Run `pac org who` to verify the active connection matches. Do not proceed until the user confirms. This prevents accidental changes to production or shared environments.
+
+---
+
 ## How Changes Are Made: Environment-First
 
 **Do not write solution XML by hand to create new tables, columns, forms, or views.**
@@ -95,10 +105,13 @@ attribute = {
                     "LocalizedLabels": [{"@odata.type": "Microsoft.Dynamics.CRM.LocalizedLabel",
                                           "Label": "Description", "LanguageCode": 1033}]},
     "RequiredLevel": {"Value": "None"},
-    "MaxLength": 500
+    "MaxLength": 500,
+    "FormatName": {"Value": "Text"}   # Always use "Text" — see FormatName reference below
 }
 # POST to /api/data/v9.2/EntityDefinitions(LogicalName='new_projectbudget')/Attributes
 ```
+
+**Valid FormatName values for StringAttributeMetadata:** `Text`, `TextArea`, `Url`, `TickerSymbol`, `PhoneticGuide`, `VersionNumber`, `Phone`. Note: `Email` is **not** a valid FormatName despite being a common assumption — use `Text` for email columns.
 
 **Currency column:**
 ```python
@@ -384,6 +397,65 @@ When creating forms via the Web API (`POST /api/data/v9.2/systemforms`), FormXml
 - **Control `classid` values** are fixed per control type (e.g., `{4273EDBD-AC1D-40d3-9FB2-095C621B552D}` for text, `{270BD3DB-D9AF-4782-9025-509E298DEC0A}` for lookup, `{3EF39988-22BB-4f0b-BBBE-64B5A3748AEE}` for picklist/choice).
 
 **Tip:** To avoid FormXml issues, create forms through the Dynamics maker portal and pull via `pac solution export` — then use the pulled XML as a template for programmatic creation.
+
+---
+
+## After Creating Columns: Report Logical Names
+
+After creating columns (via Web API or MCP), **always report the actual logical names** to the user. Column names may be normalized or prefixed in ways the user doesn't expect. Summarize in a table:
+
+| Display Name | Logical Name | Type |
+|---|---|---|
+| Email | cr9ac_email | String |
+| Tier | cr9ac_tier | Picklist |
+| Customer | cr9ac_customerid | Lookup |
+
+This prevents downstream failures when the user tries to insert data using incorrect column names.
+
+---
+
+## Common Web API Error Codes
+
+| Error Code | Meaning | Recovery |
+|---|---|---|
+| `0x80040216` | Transient metadata cache error. Column or table metadata not yet propagated. | Wait 3-5 seconds and retry. Usually succeeds on second attempt. |
+| `0x80048d19` | Invalid property in payload. A field name doesn't match any column on the table. | Check logical column names — use `EntityDefinitions(LogicalName='...')/Attributes` to verify. |
+| `0x80040237` | Schema name already exists. | Verify the column/table exists before creating a new one — it may have been created by a previous timed-out call. |
+| `0x8004431a` | Publisher prefix mismatch. | Ensure all schema names use the solution's publisher prefix. |
+| `0x80060891` | Metadata cache not ready after table creation. | Call `GET EntityDefinitions(LogicalName='...')` first to force cache refresh, then retry. |
+
+Always translate error codes to plain English before presenting them to the user.
+
+---
+
+## Metadata Propagation Delays
+
+After creating tables or columns via the Web API, metadata propagation can take 3-10 seconds. Common symptoms:
+
+- Picklist columns fail with `0x80040216` immediately after table creation
+- Lookup `@odata.bind` operations fail with "Invalid property" shortly after column creation
+- `update_table` (MCP) fails with "EntityId not found in MetadataCache"
+
+**Mitigation:** Add a 3-5 second delay after table creation before adding columns. After creating lookup columns, wait 5-10 seconds before inserting records that use `@odata.bind` on those lookups. If a column creation fails, verify it doesn't already exist, then retry once.
+
+---
+
+## Session Closing: Pull to Repo
+
+**After every metadata session, perform the pull-to-repo sequence.** This is not optional — work that exists only in the environment is lost if the environment is reset.
+
+```bash
+pac solution export --name <SOLUTION_NAME> --path ./solutions/<SOLUTION_NAME>.zip --managed false
+pac solution unpack --zipfile ./solutions/<SOLUTION_NAME>.zip --folder ./solutions/<SOLUTION_NAME>
+rm ./solutions/<SOLUTION_NAME>.zip
+git add ./solutions/<SOLUTION_NAME>
+git commit -m "feat: <description of change>"
+```
+
+If you used the `MSCRM.SolutionName` header during creation, verify components are in the solution before exporting:
+```bash
+pac solution list-components --solutionUniqueName <SOLUTION_NAME> --environment <url>
+```
 
 ---
 

--- a/.github/plugins/dataverse/skills/metadata/SKILL.md
+++ b/.github/plugins/dataverse/skills/metadata/SKILL.md
@@ -11,7 +11,7 @@ description: >
 
 # Skill: Metadata — Making Changes
 
-**Before any metadata change, confirm the target environment with the user.** See the Multi-Environment Rule in the overview skill for the full confirmation flow.
+**Before the first metadata change in a session, confirm the target environment with the user.** See the Multi-Environment Rule in the overview skill for the full confirmation flow.
 
 ---
 

--- a/.github/plugins/dataverse/skills/metadata/SKILL.md
+++ b/.github/plugins/dataverse/skills/metadata/SKILL.md
@@ -11,13 +11,7 @@ description: >
 
 # Skill: Metadata — Making Changes
 
-## Before You Start: Environment Confirmation
-
-**Before any metadata change** (creating tables, columns, relationships, forms, or views), confirm the target environment with the user:
-
-> "I'm about to make schema changes to `<DATAVERSE_URL>`. Is this the correct environment?"
-
-Run `pac org who` to verify the active connection matches. Do not proceed until the user confirms. This prevents accidental changes to production or shared environments.
+**Before any metadata change, confirm the target environment with the user.** See the Multi-Environment Rule in the overview skill for the full confirmation flow.
 
 ---
 

--- a/.github/plugins/dataverse/skills/overview/SKILL.md
+++ b/.github/plugins/dataverse/skills/overview/SKILL.md
@@ -29,22 +29,21 @@ Skills exist as **Claude's knowledge**, not as user-facing commands. Each skill 
 
 ---
 
-## Multi-Environment Rule
+## Multi-Environment Rule (MANDATORY)
 
 Pro-dev scenarios involve multiple environments (dev, test, staging, prod) and multiple sets of credentials. **Never assume** the active PAC auth profile, values in `.env`, or anything from memory or a previous session reflects the correct target for the current task.
 
-**Before any operation that touches a specific environment** — deploying a plugin, pushing a solution, registering a step, running a script against the Web API — ask the user:
+**Before the FIRST operation that touches a specific environment** — creating a table, deploying a plugin, pushing a solution, inserting data — you MUST:
 
-> "Which environment should I target for this? Please confirm the URL."
+1. Show the user the environment URL you intend to use
+2. Ask them to confirm it is correct
+3. Run `pac org who` to verify the active connection matches
 
-Then verify the active PAC profile matches:
+> "I'm about to make changes to `<URL>`. Is this the correct target environment?"
 
-```bash
-pac auth list
-pac org who
-```
+**Do not proceed until the user explicitly confirms.** This is the single most important safety check in the plugin. Skipping it risks making irreversible changes to the wrong environment.
 
-The more impactful the operation (plugin deploy, solution import, step registration), the more important this confirmation is. Do not proceed against an environment the user hasn't explicitly confirmed in the current session.
+Once confirmed for a session, you do not need to re-confirm for every subsequent operation in the same session against the same environment.
 
 ---
 
@@ -112,9 +111,22 @@ Any Web API call that goes beyond a one-off query should be written as a Python 
 
 ---
 
-## After Any Change: Pull to Repo
+## Before Any Metadata Change: Confirm Solution
 
-Any time you make a metadata change (via MCP, Web API, or the maker portal), end the session by pulling:
+Before creating tables, columns, or other metadata, ensure a solution exists to contain the work:
+
+1. Ask the user: "What solution should these components go into?"
+2. If a solution name is in `.env` (`SOLUTION_NAME`), confirm it with the user
+3. If no solution exists yet, create one (see the `solution` skill)
+4. Use the `MSCRM.SolutionName` header on all Web API metadata calls to auto-add components
+
+Creating metadata without a solution means it exists only in the default solution and cannot be cleanly exported or deployed. Always solution-first.
+
+---
+
+## After Any Change: Pull to Repo (MANDATORY)
+
+Any time you make a metadata change (via MCP, Web API, or the maker portal), **you must** end the session by pulling:
 
 ```bash
 pac solution export --name <SOLUTION_NAME> --path ./solutions/<SOLUTION_NAME>.zip --managed false

--- a/.github/plugins/dataverse/skills/python-sdk/SKILL.md
+++ b/.github/plugins/dataverse/skills/python-sdk/SKILL.md
@@ -92,6 +92,11 @@ result = client.entity("new_projectbudget").create({
 # Returns the new record GUID
 ```
 
+**Lookup binding (`@odata.bind`) notes:**
+- If you just created lookup columns, wait 5-10 seconds before inserting records that reference them. Metadata propagation delays can cause "Invalid property" errors.
+- Choice (picklist) columns use integer values, not strings: `"new_status": 100000000` (not `"Draft"`).
+- If a record insert fails with "Invalid property", verify the lookup column's logical name and navigation property name by querying `EntityDefinitions(LogicalName='...')/Attributes`.
+
 ### Query records
 ```python
 records = client.entity("new_projectbudget").read(

--- a/.github/plugins/dataverse/skills/solution/SKILL.md
+++ b/.github/plugins/dataverse/skills/solution/SKILL.md
@@ -63,6 +63,24 @@ Common component type codes:
 
 Repeat the command for each component you need to add.
 
+### Alternative: Auto-add via MSCRM.SolutionName Header
+
+When creating metadata via the Web API, include the `MSCRM.SolutionName` header to auto-add components to the solution:
+```python
+headers = {
+    "Authorization": f"Bearer {token}",
+    "Content-Type": "application/json",
+    "MSCRM.SolutionName": "<UniqueName>"
+}
+```
+
+**Important:** After using this approach, verify components were added by listing them:
+```bash
+pac solution list-components --solutionUniqueName <UniqueName> --environment <url>
+```
+
+If the header was misspelled or the solution doesn't exist, components will be created in the default solution instead — silently. Always verify.
+
 ## Find the Solution Name
 
 Before exporting, confirm the exact unique name:


### PR DESCRIPTION
Improves four Dataverse skills based on findings from running the            support agent end-to-end scenario and scoring against the [plugin test       rubric](../dataverse-plugin-test-rubric.md). The changes address the      
   top-scoring gaps: missing environment confirmation, no pull-to-repo
   enforcement, undocumented error codes, and metadata propagation
   pitfalls.

   ### metadata/SKILL.md
   - Add environment confirmation reminder (references overview skill to     
   avoid duplication)
   - Add `FormatName` reference for `StringAttributeMetadata` — documents    
   that `Email` is **not** a valid value
   - Add "Report Logical Names" guidance — after creating columns, surface   
    logical names to the user
   - Add common Web API error codes table (`0x80040216`, `0x80048d19`,       
   `0x80040237`, `0x8004431a`, `0x80060891`)
   - Add metadata propagation delays section with mitigation guidance        
   (wait times, retry patterns)
   - Add mandatory "Session Closing: Pull to Repo" section with solution     
   component verification

   ### overview/SKILL.md
   - Strengthen Multi-Environment Rule to MANDATORY with explicit 3-step     
   confirmation flow
   - Add "Before Any Metadata Change: Confirm Solution" section
   (solution-first workflow)
   - Mark pull-to-repo as MANDATORY

   ### python-sdk/SKILL.md
   - Add `@odata.bind` lookup binding notes (propagation delays, integer     
   values for choices, error recovery)

   ### solution/SKILL.md
   - Add `MSCRM.SolutionName` header auto-add pattern with verification      
   step