### PR TITLE
Refine navigation property terminology and improve skills

### DIFF
--- a/.github/plugins/dataverse/scripts/auth.py
+++ b/.github/plugins/dataverse/scripts/auth.py
@@ -28,7 +28,7 @@ Usage:
     load_env()
     client = DataverseClient(os.environ["DATAVERSE_URL"], get_credential())
 
-Reads from .env in the current working directory or from environment variables:
+Reads from .env in the repo root (parent of scripts/) or current working directory:
     DATAVERSE_URL      — required
     TENANT_ID          — required
     CLIENT_ID          — optional, enables service principal auth
@@ -44,9 +44,18 @@ _AUTH_RECORD_PATH = Path(os.environ.get("LOCALAPPDATA") or Path.home()) / ".Iden
 
 
 def load_env():
-    """Load key=value pairs from .env into os.environ (does not overwrite existing vars)."""
-    env_path = Path(".env")
-    if env_path.exists():
+    """Load key=value pairs from .env into os.environ (does not overwrite existing vars).
+
+    Searches for .env in two locations (first match wins):
+      1. The repo root (parent of the directory containing this script)
+      2. The current working directory
+    This ensures ``cd scripts && python auth.py`` works the same as
+    ``python scripts/auth.py`` from the repo root.
+    """
+    script_dir = Path(__file__).resolve().parent
+    candidates = [script_dir.parent / ".env", Path(".env")]
+    env_path = next((p for p in candidates if p.exists()), None)
+    if env_path is not None:
         for line in env_path.read_text().splitlines():
             line = line.strip()
             if line and not line.startswith("#") and "=" in line:

--- a/.github/plugins/dataverse/skills/init/SKILL.md
+++ b/.github/plugins/dataverse/skills/init/SKILL.md
@@ -12,7 +12,12 @@ description: >
 
 > **Environment-First Rule** — All metadata (solutions, columns, tables, forms, views) and plugin registrations are created **in the Dynamics environment** via API or scripts, then pulled into the repo. Never write or edit solution XML by hand to create new components. This rule applies to every step in both scenarios below.
 
-**Execute every numbered step in order.** Do not skip ahead to a later step, even if it appears more relevant to the user's immediate goal. Steps that seem unrelated to the current task (e.g., MCP setup when the user asked about tables) are still required — they enable the user's workflow in future sessions.
+**Execute every numbered step in order.** Do not skip ahead to a later step, even if it appears more relevant to the user's immediate goal.
+
+**MCP setup exception:** MCP configuration (step 5 in Scenario A, step 3's MCP part in Scenario B) requires a Claude Code restart, which loses all session context. Therefore:
+- **Skip MCP setup entirely** if an MCP server is already configured (`.mcp.json` exists with a Dataverse server entry, or `claude mcp list` shows one).
+- **Defer MCP setup to the very last step** — after all scripts have been created and run, all metadata is live, and commits are done. This way the restart only loses the "done" state, not in-progress work.
+- Before triggering the restart, **write a brief status summary to `CLAUDE.md`** (or append to existing) so the next session knows what was completed.
 
 Two scenarios — handle both.
 
@@ -50,6 +55,7 @@ Ask the user for each value, then write the file:
 DATAVERSE_URL=https://<org>.crm.dynamics.com
 TENANT_ID=<guid>
 SOLUTION_NAME=<UniqueName>
+PUBLISHER_PREFIX=<prefix>
 PAC_AUTH_PROFILE=nonprod
 CLIENT_ID=<app-registration-client-id>
 CLIENT_SECRET=<app-registration-secret>
@@ -59,6 +65,7 @@ How to prompt the user:
 - `DATAVERSE_URL`: "What is your Dataverse environment URL?"
 - `TENANT_ID`: Auto-discover from the URL above before asking. Only ask if discovery fails.
 - `SOLUTION_NAME`: "What is the unique name of your solution?"
+- `PUBLISHER_PREFIX`: Do **not** ask yet — this is discovered in the solution creation step (step 7 in Scenario B). Leave it blank in `.env` for now; the `create_solution.py` script will query existing publishers and ask the user. Once confirmed, update `.env` with the chosen prefix.
 - `CLIENT_ID` / `CLIENT_SECRET`: Only needed for service principal auth. If the user authenticates via browser (interactive login), skip these. When omitted, auth.py uses interactive device code flow with AuthenticationRecord persistence (no browser re-prompt on subsequent runs).
 
 Write the file directly — do not instruct the user to create it:
@@ -69,6 +76,7 @@ with open(".env", "w") as f:
     f.write(f"DATAVERSE_URL={dataverse_url}\n")
     f.write(f"TENANT_ID={tenant_id}\n")
     f.write(f"SOLUTION_NAME={solution_name}\n")
+    f.write(f"PUBLISHER_PREFIX=\n")  # filled in during solution creation step
     f.write(f"PAC_AUTH_PROFILE=nonprod\n")
     if client_id:
         f.write(f"CLIENT_ID={client_id}\n")
@@ -101,11 +109,7 @@ if missing:
         f.write("\n" + "\n".join(missing) + "\n")
 ```
 
-### 5. Configure MCP server
-
-Use the `dataverse-mcp-configure` skill to set up the MCP server for GitHub Copilot or Claude Code.
-
-### 6. Ensure PAC CLI is on PATH
+### 5. Ensure PAC CLI is on PATH
 
 Find the path (this may be slow, wait for it to finish):
 
@@ -121,7 +125,7 @@ echo 'export PATH="$PATH:/c/Users/$USER/.dotnet/tools"' >> ~/.bashrc
 source ~/.bashrc
 ```
 
-### 7. Connect to the environment
+### 6. Connect to the environment
 
 Ask the user which environment they are setting up for. Do not assume.
 
@@ -155,14 +159,30 @@ pac auth create --name <profile-name> \
 
 > **Multi-environment repos:** If the team deploys to multiple environments from the same repo, each developer's `.env` represents their current target. Consider `.env.dev`, `.env.staging`, etc., with a pattern like `cp .env.dev .env` to switch targets. Each developer manages their own local `.env`.
 
-### 8. Verify the connection
+### 7. Verify the connection
 
 ```
 pac org who
 python scripts/auth.py
 ```
 
-Both should succeed without error. Confirm the environment URL in the output matches the intended target. New machine setup is complete.
+Both should succeed without error. Confirm the environment URL in the output matches the intended target.
+
+### 8. Configure MCP server (if not already configured)
+
+**Skip this step entirely** if any of the following are true:
+- `.mcp.json` already exists and contains a Dataverse server entry
+- `claude mcp list` shows a `dataverse-*` server already registered
+- The user's immediate task does not require MCP (e.g., they asked to create tables, import data, or build a solution — all of which use the SDK or PAC CLI, not MCP)
+
+If MCP is needed and not yet configured, use the `dataverse-mcp-configure` skill. **This is always the last step** because `claude mcp add` requires a Claude Code restart, which ends the current session.
+
+Before triggering the MCP install command, inform the user:
+
+> MCP setup requires restarting Claude Code. All other setup steps are complete.
+> After restart, you can verify MCP works by asking: "List the tables in my Dataverse environment."
+
+New machine setup is complete.
 
 ---
 
@@ -190,11 +210,9 @@ curl -sI https://<org>.crm.dynamics.com/api/data/v9.2/ \
 
 Use the resulting GUID as `TENANT_ID` in `.env`. Only ask the user if this command fails.
 
-### 3. Create .env, MCP config, and .gitignore
+### 3. Create .env and .gitignore
 
 Follow steps 3–4 from Scenario A above. Ask the user for SOLUTION_NAME if not already known (but use the DATAVERSE_URL you obtained and confirmed in step 2).
-
-Set up MCP following step 5 from Scenario A.
 
 ### 4. Create the directory structure
 
@@ -214,6 +232,7 @@ cp .dataverse/scripts/enable-mcp-client.py scripts/
 Copy `templates/CLAUDE.md` from the plugin to the repo root. Replace placeholders:
 - `{{DATAVERSE_URL}}` → environment URL
 - `{{SOLUTION_NAME}}` → solution unique name
+- `{{PUBLISHER_PREFIX}}` → leave as `TBD` for now (filled in after step 7 when the publisher is confirmed)
 - `{{PAC_AUTH_PROFILE}}` → `nonprod`
 
 ### 6. Connect to the environment
@@ -245,16 +264,24 @@ Continue to the next steps.
 
 **This is where changes go into Dynamics first — never into the repo directly.**
 
-Write and run `scripts/create_solution.py` to create the publisher and solution in the environment via Web API. Follow the pattern in the `dataverse-solution` skill. Run it:
+Write and run `scripts/create_solution.py` to create the publisher and solution in the environment using the Python SDK. The script **must** follow the publisher discovery flow from the `dataverse-solution` skill:
+
+1. **Query existing publishers** in the environment (excluding Microsoft system publishers)
+2. **If a custom publisher exists**, show it to the user and ask: "Should I reuse this publisher (prefix: `<prefix>_`)?"
+3. **If no custom publisher exists**, ask the user: "What publisher prefix should I use? (e.g., `contoso`, `sa`, `lit` — 2-8 lowercase chars, not `new`)"
+4. **Never hardcode a prefix.** Never default to `new`. Always get user confirmation.
+5. After the publisher is confirmed/created, **update `.env`** with `PUBLISHER_PREFIX=<chosen_prefix>`
+
+Run it:
 
 ```
 python scripts/create_solution.py
 ```
 
-Then write and run any scripts needed to create columns, tables, or other metadata in the environment. Each script should POST to the Dataverse MetadataService API with `MSCRM.SolutionUniqueName` header so the changes are automatically included in the solution. Run them:
+Then write and run any scripts needed to create tables, columns, or other metadata. **All custom schema names must use the confirmed publisher prefix** (from `PUBLISHER_PREFIX` in `.env`). Each script should use the SDK with `solution=SOLUTION` so changes are automatically included in the solution. Run them:
 
 ```
-python scripts/add_<whatever>_column.py
+python scripts/create_tables.py
 ```
 
 ### 8. Pull the environment state to the repo
@@ -314,6 +341,21 @@ To remove demo data later, call `UninstallSampleData` the same way.
 git add .gitignore CLAUDE.md solutions/ plugins/ scripts/
 git commit -m "chore: initialize Dataverse workspace"
 ```
+
+### 11. Configure MCP server (if not already configured)
+
+**Skip this step entirely** if any of the following are true:
+
+- `.mcp.json` already exists and contains a Dataverse server entry
+- `claude mcp list` shows a `dataverse-*` server already registered
+- The user's immediate task does not require MCP (e.g., they asked to create tables, import data, or build a solution — all of which use the SDK or PAC CLI, not MCP)
+
+If MCP is needed and not yet configured, use the `dataverse-mcp-configure` skill. **This is always the last step** because `claude mcp add` requires a Claude Code restart, which ends the current session.
+
+Before triggering the MCP install command, inform the user:
+
+> MCP setup requires restarting Claude Code. All other setup steps are complete — your solution, tables, and scripts are committed.
+> After restart, you can verify MCP works by asking: "List the tables in my Dataverse environment."
 
 ---
 

--- a/.github/plugins/dataverse/skills/metadata/SKILL.md
+++ b/.github/plugins/dataverse/skills/metadata/SKILL.md
@@ -45,84 +45,71 @@ info = client.tables.create(
 print(f"Created: {info['table_schema_name']}")
 ```
 
-**Web API approach (needed for full control over metadata — OwnershipType, HasActivities, etc.):**
+**Web API approach (needed for full control — OwnershipType, HasActivities, etc.):**
 
 ```python
-# create_table.py — run via: python scripts/create_table.py
-import os, json, urllib.request
-from auth import get_token, load_env
-
-load_env()
-env = os.environ["DATAVERSE_URL"].rstrip("/")
-token = get_token()
+# Helper for Label boilerplate
+def label(text):
+    return {"@odata.type": "Microsoft.Dynamics.CRM.Label",
+            "LocalizedLabels": [{"@odata.type": "Microsoft.Dynamics.CRM.LocalizedLabel",
+                                  "Label": text, "LanguageCode": 1033}]}
 
 entity = {
     "@odata.type": "Microsoft.Dynamics.CRM.EntityMetadata",
     "SchemaName": "new_ProjectBudget",
-    "DisplayName": {"@odata.type": "Microsoft.Dynamics.CRM.Label",
-                    "LocalizedLabels": [{"@odata.type": "Microsoft.Dynamics.CRM.LocalizedLabel",
-                                         "Label": "Project Budget", "LanguageCode": 1033}]},
-    "DisplayCollectionName": {"@odata.type": "Microsoft.Dynamics.CRM.Label",
-                               "LocalizedLabels": [{"@odata.type": "Microsoft.Dynamics.CRM.LocalizedLabel",
-                                                    "Label": "Project Budgets", "LanguageCode": 1033}]},
-    "Description": {"@odata.type": "Microsoft.Dynamics.CRM.Label",
-                    "LocalizedLabels": [{"@odata.type": "Microsoft.Dynamics.CRM.LocalizedLabel",
-                                         "Label": "", "LanguageCode": 1033}]},
+    "DisplayName": label("Project Budget"),
+    "DisplayCollectionName": label("Project Budgets"),
+    "Description": label(""),
     "OwnershipType": "UserOwned",
-    "HasActivities": False,
-    "HasNotes": False,
-    "IsActivity": False,
+    "HasActivities": False, "HasNotes": False, "IsActivity": False,
     "PrimaryNameAttribute": "new_name",
-    "Attributes": [
-        {
-            "@odata.type": "Microsoft.Dynamics.CRM.StringAttributeMetadata",
-            "SchemaName": "new_name",
-            "DisplayName": {"@odata.type": "Microsoft.Dynamics.CRM.Label",
-                            "LocalizedLabels": [{"@odata.type": "Microsoft.Dynamics.CRM.LocalizedLabel",
-                                                  "Label": "Name", "LanguageCode": 1033}]},
-            "RequiredLevel": {"Value": "ApplicationRequired"},
-            "MaxLength": 100,
-            "IsPrimaryName": True,
-        }
-    ]
+    "Attributes": [{
+        "@odata.type": "Microsoft.Dynamics.CRM.StringAttributeMetadata",
+        "SchemaName": "new_name",
+        "DisplayName": label("Name"),
+        "RequiredLevel": {"Value": "ApplicationRequired"},
+        "MaxLength": 100, "IsPrimaryName": True,
+    }]
 }
-
-req = urllib.request.Request(
-    f"{env}/api/data/v9.2/EntityDefinitions",
-    data=json.dumps(entity).encode(),
-    headers={"Authorization": f"Bearer {token}",
-             "Content-Type": "application/json",
-             "OData-MaxVersion": "4.0",
-             "OData-Version": "4.0"},
-    method="POST"
-)
-with urllib.request.urlopen(req) as resp:
-    print(f"Created. EntityId: {resp.headers.get('OData-EntityId')}")
+# POST to /api/data/v9.2/EntityDefinitions with MSCRM.SolutionUniqueName header
 ```
 
 ---
 
-## Adding a Column
+## Adding Columns
 
-**Text column:**
+**SDK approach (preferred):**
+
 ```python
-attribute = {
-    "@odata.type": "Microsoft.Dynamics.CRM.StringAttributeMetadata",
-    "SchemaName": "new_description",
-    "DisplayName": {"@odata.type": "Microsoft.Dynamics.CRM.Label",
-                    "LocalizedLabels": [{"@odata.type": "Microsoft.Dynamics.CRM.LocalizedLabel",
-                                          "Label": "Description", "LanguageCode": 1033}]},
-    "RequiredLevel": {"Value": "None"},
-    "MaxLength": 500,
-    "FormatName": {"Value": "Text"}   # Always use "Text" — see FormatName reference below
-}
-# POST to /api/data/v9.2/EntityDefinitions(LogicalName='new_projectbudget')/Attributes
+created = client.tables.add_columns(
+    "new_ProjectBudget",
+    {"new_Description": "string", "new_Amount": "decimal", "new_Active": "bool"},
+)
+print(created)  # ['new_Description', 'new_Amount', 'new_Active']
 ```
 
-**Valid FormatName values for StringAttributeMetadata:** `Text`, `TextArea`, `Url`, `TickerSymbol`, `PhoneticGuide`, `VersionNumber`, `Phone`. Note: `Email` is **not** a valid FormatName despite being a common assumption — use `Text` for email columns.
+Supported type strings: `"string"` / `"text"`, `"int"` / `"integer"`, `"decimal"` / `"money"`, `"float"` / `"double"`, `"datetime"` / `"date"`, `"bool"` / `"boolean"`, `"file"`, and `Enum` subclasses (for local option sets).
 
-**Currency column:**
+**Choice (picklist) column via SDK:**
+
 ```python
+from enum import IntEnum
+
+class BudgetStatus(IntEnum):
+    DRAFT = 100000000
+    APPROVED = 100000001
+    REJECTED = 100000002
+
+created = client.tables.add_columns(
+    "new_ProjectBudget",
+    {"new_Status": BudgetStatus},
+)
+```
+
+**Web API approach (needed for column types the SDK doesn't support — e.g., currency with precision, memo with custom max length):**
+
+```python
+# Currency column
 attribute = {
     "@odata.type": "Microsoft.Dynamics.CRM.MoneyAttributeMetadata",
     "SchemaName": "new_amount",
@@ -135,39 +122,71 @@ attribute = {
     "Precision": 2,
     "PrecisionSource": 2
 }
+# POST to /api/data/v9.2/EntityDefinitions(LogicalName='new_projectbudget')/Attributes
 ```
 
-**Choice (picklist) column:**
+---
+
+## Lookup Columns and Relationships
+
+**SDK approach — simple lookup (preferred):**
+
 ```python
-attribute = {
-    "@odata.type": "Microsoft.Dynamics.CRM.PicklistAttributeMetadata",
-    "SchemaName": "new_status",
-    "DisplayName": {"@odata.type": "Microsoft.Dynamics.CRM.Label",
-                    "LocalizedLabels": [{"@odata.type": "Microsoft.Dynamics.CRM.LocalizedLabel",
-                                          "Label": "Status", "LanguageCode": 1033}]},
-    "RequiredLevel": {"Value": "None"},
-    "OptionSet": {
-        "@odata.type": "Microsoft.Dynamics.CRM.OptionSetMetadata",
-        "IsGlobal": False,
-        "OptionSetType": "Picklist",
-        "Options": [
-            {"Value": 100000000, "Label": {"@odata.type": "Microsoft.Dynamics.CRM.Label",
-             "LocalizedLabels": [{"@odata.type": "Microsoft.Dynamics.CRM.LocalizedLabel",
-                                   "Label": "Draft", "LanguageCode": 1033}]}},
-            {"Value": 100000001, "Label": {"@odata.type": "Microsoft.Dynamics.CRM.Label",
-             "LocalizedLabels": [{"@odata.type": "Microsoft.Dynamics.CRM.LocalizedLabel",
-                                   "Label": "Approved", "LanguageCode": 1033}]}},
-            {"Value": 100000002, "Label": {"@odata.type": "Microsoft.Dynamics.CRM.Label",
-             "LocalizedLabels": [{"@odata.type": "Microsoft.Dynamics.CRM.LocalizedLabel",
-                                   "Label": "Rejected", "LanguageCode": 1033}]}}
-        ]
-    }
-}
+result = client.tables.create_lookup_field(
+    referencing_table="new_projectbudget",
+    lookup_field_name="new_AccountId",
+    referenced_table="account",
+    display_name="Account",
+    solution="MySolution",
+)
+print(f"Created lookup: {result.lookup_schema_name}")
 ```
 
-**Lookup column + relationship (Web API):**
+**SDK approach — full control over 1:N relationship:**
 
-Lookups require creating a relationship, not just an attribute. Use the `OneToManyRelationships` endpoint:
+```python
+from PowerPlatform.Dataverse.models.relationship import (
+    LookupAttributeMetadata,
+    OneToManyRelationshipMetadata,
+    CascadeConfiguration,
+)
+from PowerPlatform.Dataverse.models.labels import Label, LocalizedLabel
+from PowerPlatform.Dataverse.common.constants import CASCADE_BEHAVIOR_REMOVE_LINK
+
+lookup = LookupAttributeMetadata(
+    schema_name="new_AccountId",
+    display_name=Label(localized_labels=[LocalizedLabel(label="Account", language_code=1033)]),
+)
+
+relationship = OneToManyRelationshipMetadata(
+    schema_name="account_new_projectbudget",
+    referenced_entity="account",
+    referencing_entity="new_projectbudget",
+    referenced_attribute="accountid",
+    cascade_configuration=CascadeConfiguration(delete=CASCADE_BEHAVIOR_REMOVE_LINK),
+)
+
+result = client.tables.create_one_to_many_relationship(lookup, relationship, solution="MySolution")
+print(f"Created: {result.relationship_schema_name}")
+```
+
+**SDK approach — many-to-many relationship:**
+
+```python
+from PowerPlatform.Dataverse.models.relationship import ManyToManyRelationshipMetadata
+
+relationship = ManyToManyRelationshipMetadata(
+    schema_name="new_ticket_knowledgebase",
+    entity1_logical_name="new_ticket",
+    entity2_logical_name="new_knowledgebase",
+)
+
+result = client.tables.create_many_to_many_relationship(relationship, solution="MySolution")
+print(f"Created: {result.relationship_schema_name}")
+```
+
+**Web API approach (fallback when SDK patterns don't suffice):**
+
 ```python
 relationship = {
     "@odata.type": "Microsoft.Dynamics.CRM.OneToManyRelationshipMetadata",
@@ -186,27 +205,16 @@ relationship = {
 # POST to /api/data/v9.2/RelationshipDefinitions
 ```
 
-**Lookup column + relationship (SDK alternative — simpler):**
-```python
-result = client.tables.create_lookup_field(
-    referencing_table="new_projectbudget",
-    lookup_field_name="new_AccountId",
-    referenced_table="account",
-    display_name="Account",
-    solution="MySolution",
-)
-```
-
 **After creating a lookup — the @odata.bind navigation property:**
 
-When you create records that set this lookup, you need the **navigation property name** for `@odata.bind`. The navigation property is the **SchemaName** (PascalCase) of the lookup field:
+When you create records that set this lookup, you need the **navigation property name** for `@odata.bind`. The navigation property name is case-sensitive and must match the entity's `$metadata` (usually the SchemaName of the lookup field, e.g., `new_AccountId`):
 
-| Lookup SchemaName | `@odata.bind` key | Entity set |
+| Navigation Property Name | `@odata.bind` key | Entity set |
 |---|---|---|
 | `new_AccountId` | `new_AccountId@odata.bind` | `/accounts(<guid>)` |
 | `new_ParentTicketId` | `new_ParentTicketId@odata.bind` | `/new_tickets(<guid>)` |
 
-**Common mistake:** Using the logical name (lowercase) like `new_accountid@odata.bind` — this returns a 400 error. Always use PascalCase SchemaName.
+**Common mistake:** Using the logical name (lowercase) like `new_accountid@odata.bind` returns a 400 error. Navigation property names are case-sensitive and must match the entity's `$metadata`.
 
 ---
 
@@ -395,20 +403,6 @@ Create business rules in the Power Apps maker portal. They are too complex to wr
 
 ---
 
-## After Any API Change: Pull to Repo
-
-Always end with a pull to sync the environment's state back to the repo:
-```
-pac solution export --name <SOLUTION_NAME> --path ./solutions/<SOLUTION_NAME>.zip --managed false
-pac solution unpack --zipfile ./solutions/<SOLUTION_NAME>.zip --folder ./solutions/<SOLUTION_NAME>
-rm ./solutions/<SOLUTION_NAME>.zip
-git add ./solutions/<SOLUTION_NAME>
-git commit -m "feat: add <description of change>"
-git push
-```
-
----
-
 ## Publisher Prefix
 
 All custom schema names must use your solution's publisher prefix (e.g., `new_`, `contoso_`). Find yours:
@@ -421,15 +415,13 @@ Or check `solutions/<SOLUTION_NAME>/Other/Solution.xml` after the first pull —
 
 ## FormXml Pitfalls
 
-When creating forms via the Web API (`POST /api/data/v9.2/systemforms`), FormXml schema validation is strict:
-
 - **All `id` attributes must be valid GUIDs** in `{xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}` format. Do not use strings like `"general"`.
 - **`labelid` is also a GUID** — not a human-readable string.
-- **Subgrid controls require a valid `<ViewId>`** — must be the GUID of an existing SavedQuery. Create the view first, then reference it in the form.
+- **Subgrid controls require a valid `<ViewId>`** — must be the GUID of an existing SavedQuery. Create the view first.
 - **Cell, section, tab, and control IDs must all be unique** across the entire form.
-- **Control `classid` values** are fixed per control type (e.g., `{4273EDBD-AC1D-40d3-9FB2-095C621B552D}` for text, `{270BD3DB-D9AF-4782-9025-509E298DEC0A}` for lookup, `{3EF39988-22BB-4f0b-BBBE-64B5A3748AEE}` for picklist/choice).
+- **Control `classid` values** — see the classid table above.
 
-**Tip:** To avoid FormXml issues, create forms through the Dynamics maker portal and pull via `pac solution export` — then use the pulled XML as a template for programmatic creation.
+**Tip:** Create forms in the maker portal and pull via `pac solution export` — use the pulled XML as a template for programmatic creation.
 
 ---
 

--- a/.github/plugins/dataverse/skills/overview/SKILL.md
+++ b/.github/plugins/dataverse/skills/overview/SKILL.md
@@ -54,7 +54,15 @@ If you find yourself about to run `npm` or create a `package.json`, STOP. You ar
 
 ### 2. Use the SDK, Not Raw HTTP
 
-For data operations (CRUD, bulk, queries) and schema operations (table/column/relationship creation), use the Python Dataverse SDK — not raw `requests`/`urllib` calls. The SDK handles auth, pagination, retries, and batching. See the python-sdk skill for correct patterns. Only fall back to raw Web API for things the SDK doesn't support (forms, views, global option sets).
+For data operations (CRUD, bulk, queries) and schema operations (table/column/relationship creation), use the Python Dataverse SDK — not raw `requests`/`urllib` calls. The SDK handles auth, URL encoding, pagination, retries, and batching. See the python-sdk skill for correct patterns.
+
+**This includes publisher and solution records** — they are standard Dataverse tables. Use `client.records.create("publisher", {...})` and `client.records.create("solution", {...})`, not raw HTTP.
+
+Only fall back to raw Web API for: forms, views, global option sets, N:N `$ref` associations, N:N `$expand`, `$apply` aggregation, memo columns, and unbound actions.
+
+**Field casing:** `$select`/`$filter` use lowercase logical names (`new_name`). `$expand` and `@odata.bind` use Navigation Property Names that are case-sensitive and must match `$metadata` (e.g., `new_CustomerId`). Getting this wrong causes 400 errors. The SDK handles this correctly for `@odata.bind` keys.
+
+**Publisher prefix:** Never hardcode a prefix (especially not `new`). Always query existing publishers in the environment and ask the user which to use. The prefix is permanent on every component created with it. See the solution skill's publisher discovery flow.
 
 ### 3. Use Documented Auth Patterns
 

--- a/.github/plugins/dataverse/skills/overview/SKILL.md
+++ b/.github/plugins/dataverse/skills/overview/SKILL.md
@@ -60,7 +60,7 @@ For data operations (CRUD, bulk, queries) and schema operations (table/column/re
 
 Only fall back to raw Web API for: forms, views, global option sets, N:N `$ref` associations, N:N `$expand`, `$apply` aggregation, memo columns, and unbound actions.
 
-**Field casing:** `$select`/`$filter` use lowercase logical names (`new_name`). `$expand` and `@odata.bind` use Navigation Property Names that are case-sensitive and must match `$metadata` (e.g., `new_CustomerId`). Getting this wrong causes 400 errors. The SDK handles this correctly for `@odata.bind` keys.
+**Field casing:** `$select`/`$filter` use lowercase logical names (`new_name`). `$expand` and `@odata.bind` use Navigation Property Names that are case-sensitive and must match `$metadata` (e.g., `new_AccountId`). Getting this wrong causes 400 errors. The SDK handles this correctly for `@odata.bind` keys.
 
 **Publisher prefix:** Never hardcode a prefix (especially not `new`). Always query existing publishers in the environment and ask the user which to use. The prefix is permanent on every component created with it. See the solution skill's publisher discovery flow.
 

--- a/.github/plugins/dataverse/skills/python-sdk/SKILL.md
+++ b/.github/plugins/dataverse/skills/python-sdk/SKILL.md
@@ -6,7 +6,7 @@ description: >
   "Python script for Dataverse", "read data", "write data", "upload file",
   "bulk import", "CSV import", "load data", "data profiling", "data quality",
   "analyze data", "Jupyter notebook", "pandas", "notebook".
-  DO NOT USE WHEN: creating forms/views/relationships (use dataverse-metadata with Web API),
+  DO NOT USE WHEN: creating forms/views (use dataverse-metadata with Web API),
   exporting solutions (use dataverse-solution with PAC CLI).
 ---
 
@@ -44,40 +44,55 @@ pip install PowerPlatform-Dataverse-Client
 - **Forms** (FormXml) — use the Web API directly (see `dataverse-metadata`)
 - **Views** (SavedQueries) — use the Web API directly
 - **Option sets** — use the Web API directly
-- **Record association** ($ref linking for N:N data, e.g., role assignments) — use the Web API directly
+- **N:N record association** ($ref linking for N:N data, e.g., role assignments) — use the Web API directly
 - DeleteMultiple, general OData batching
 
 For anything not in the "supports" list above, write a Web API script using `scripts/auth.py` for token acquisition.
+
+### SDK-First Rule
+
+**If an operation is in the "supports" list, you MUST use the SDK — not `urllib`, `requests`, or raw HTTP.** This applies to:
+- **All record CRUD** (create, read, update, delete) — use `client.records.create()`, `.get()`, `.update()`, `.delete()`
+- **All queries** with `$select`, `$filter`, `$orderby`, `$expand` on 1:N lookups — use `client.records.get()` with `select=`, `filter=`, `expand=`, `orderby=`
+- **Bulk operations** — pass a list to `client.records.create(table, [list])` instead of looping with individual HTTP POSTs
+- **Publisher and solution records** — these are standard Dataverse tables; use `client.records.create("publisher", {...})` and `client.records.create("solution", {...})`
+
+Raw HTTP is only acceptable for: forms, views, option sets, N:N `$ref` associations, N:N `$expand`, `$apply` aggregation, memo columns, and unbound actions.
+
+### Field Name Casing Rule
+
+Dataverse uses two different naming conventions for properties. Getting this wrong causes 400 errors.
+
+| Property type | Name convention | Example | When used |
+|---|---|---|---|
+| **Structural** (columns) | LogicalName (always lowercase) | `new_name`, `new_priority` | `$select`, `$filter`, `$orderby`, record payload keys |
+| **Navigation** (relationships / lookups) | Navigation Property Name (case-sensitive, must match `$metadata`) | `new_CustomerId`, `new_AgentId` | `$expand`, `@odata.bind` annotation keys |
+
+- **`$select`, `$filter`, `$orderby`**: always lowercase logical names (`new_name`, `new_priority`)
+- **`$expand` navigation properties**: Navigation Property Name, case-sensitive (`new_CustomerId`, `new_AgentId`)
+- **`@odata.bind` keys**: Navigation Property Name, case-sensitive (`new_CustomerId@odata.bind`)
+- **Record payloads** (create/update data): lowercase logical names for regular fields; `@odata.bind` keys preserve the navigation property casing
+
+The SDK handles this correctly: it lowercases structural property keys but preserves `@odata.bind` key casing.
 
 ---
 
 ## Setup
 
 ```python
-from azure.identity import InteractiveBrowserCredential
+import os, sys
+sys.path.insert(0, os.path.join(os.getcwd(), "scripts"))
+from auth import get_credential, load_env
 from PowerPlatform.Dataverse.client import DataverseClient
 
-credential = InteractiveBrowserCredential()
+load_env()
 client = DataverseClient(
-    resource_url=os.environ["DATAVERSE_URL"],
-    credential=credential,
+    base_url=os.environ["DATAVERSE_URL"],
+    credential=get_credential(),
 )
 ```
 
-For non-interactive (service principal) auth — preferred for dev tenants:
-```python
-from azure.identity import ClientSecretCredential
-
-credential = ClientSecretCredential(
-    tenant_id=os.environ["TENANT_ID"],
-    client_id=os.environ["CLIENT_ID"],
-    client_secret=os.environ["CLIENT_SECRET"],
-)
-client = DataverseClient(
-    resource_url=os.environ["DATAVERSE_URL"],
-    credential=credential,
-)
-```
+`get_credential()` returns `ClientSecretCredential` (if CLIENT_ID + CLIENT_SECRET are in `.env`) or `DeviceCodeCredential` (interactive fallback). See `scripts/auth.py`.
 
 ---
 
@@ -195,7 +210,7 @@ result = client.tables.create_lookup_field(
     solution="MySolution",
 )
 print(f"Created lookup: {result['lookup_schema_name']}")
-# The nav property for @odata.bind is the lookup SchemaName in PascalCase
+# The nav property for @odata.bind is the lookup's Navigation Property Name (case-sensitive)
 ```
 
 ### Create a many-to-many relationship
@@ -214,21 +229,6 @@ result = client.tables.create_many_to_many_relationship(
 
 ---
 
-## Where SDK Scripts Live
-
-Scripts using the SDK go in `/scripts/`. Keep them small and single-purpose:
-
-```text
-scripts/
-  auth.py              — Azure Identity token acquisition (used by all scripts)
-```
-
-Both the SDK and Web API scripts use Azure Identity for auth via `auth.py`. For Web API scripts (forms, views, relationships), use `get_token()`. For data scripts using this SDK, use `get_credential()` to get a `TokenCredential` directly.
-
-Post-import validation (table existence, form checks, role checks, import errors) is done inline using the SDK — see `/dataverse:solution` for patterns.
-
----
-
 ## @odata.bind Rules (Lookup Binding)
 
 When creating or updating a record that sets a lookup field, you must use `@odata.bind` with the correct **navigation property name**. Getting this wrong is the #1 cause of 400 errors.
@@ -239,7 +239,7 @@ When creating or updating a record that sets a lookup field, you must use `@odat
 <NavigationPropertyName>@odata.bind = "/<EntitySetName>(<target-guid>)"
 ```
 
-- **Navigation property name**: Use the **SchemaName** (PascalCase) of the lookup field, NOT the logical name (lowercase).
+- **Navigation property name**: Case-sensitive, must match the entity's `$metadata`. For custom lookups this is typically the SchemaName (e.g., `new_AccountId`). Do NOT use the lowercase logical name.
 - **Entity set name**: The plural collection name of the referenced table (e.g., `accounts`, `contacts`).
 
 ### Examples
@@ -257,7 +257,7 @@ When creating or updating a record that sets a lookup field, you must use `@odat
    ```
    GET /api/data/v9.2/EntityDefinitions(LogicalName='<entity>')/ManyToOneRelationships?$select=ReferencingEntityNavigationPropertyName,ReferencedEntity
    ```
-3. **Rule of thumb for custom lookups**: The navigation property name matches the lookup field's SchemaName (PascalCase with prefix, e.g., `new_AccountId`).
+3. **Rule of thumb for custom lookups**: The navigation property name matches the lookup field's SchemaName (e.g., `new_AccountId`). Always verify against `$metadata` if unsure.
 
 ---
 
@@ -281,7 +281,7 @@ To get the full related record instead, use `$expand`:
 ```python
 for page in client.records.get("opportunity",
     select=["name", "estimatedvalue"],
-    expand=["parentaccountid"],
+    expand=["parentaccountid"],  # system nav props are lowercase
     top=10,
 ):
     for r in page:
@@ -289,6 +289,50 @@ for page in client.records.get("opportunity",
         if account:
             print(account["name"])
 ```
+
+> **Note:** System table navigation properties (e.g., `parentaccountid`, `ownerid`) are lowercase. Custom lookup navigation properties are case-sensitive and must match `$metadata` (e.g., `new_CustomerId`). When in doubt, query the entity's `ManyToOneRelationships` metadata.
+
+### $expand with multiple custom lookups
+
+Use the correct navigation property names (case-sensitive, must match `$metadata`):
+
+```python
+# Expand multiple lookups — e.g., tickets with customer and agent details
+for page in client.records.get(
+    "sa_ticket",
+    select=["sa_ticketnumber", "sa_priority", "sa_status"],
+    filter="sa_status eq 100000002",
+    expand=["sa_CustomerId", "sa_AgentId"],
+    orderby=["sa_priority desc"],
+):
+    for ticket in page:
+        cust = ticket.get("sa_CustomerId") or {}
+        agent = ticket.get("sa_AgentId") or {}
+        print(f"{ticket['sa_ticketnumber']}: {cust.get('sa_name', '')} -> {agent.get('sa_name', '')}")
+```
+
+> **Important:** `expand` uses the navigation property name (case-sensitive, e.g., `sa_CustomerId`), not the lowercase logical name (`sa_customerid`). Using lowercase causes a 400 error.
+
+### $expand on N:N relationships
+
+N:N expand uses the relationship navigation property name (found in the ManyToManyRelationships metadata). The SDK does **not** support `$expand` on N:N collection-valued navigation properties in multi-record queries. For N:N traversal, use the Web API directly:
+
+```python
+# Fall back to Web API for N:N expand
+import urllib.request, json
+from auth import get_token
+
+token = get_token()
+url = f"{env}/api/data/v9.2/sa_knowledgearticles?$select=sa_title&$expand=sa_Ticket_KnowledgeArticle($select=sa_ticketnumber)"
+req = urllib.request.Request(url, headers={
+    "Authorization": f"Bearer {token}",
+    "OData-MaxVersion": "4.0", "OData-Version": "4.0", "Accept": "application/json",
+})
+with urllib.request.urlopen(req) as resp:
+    articles = json.loads(resp.read())["value"]
+```
+
+> **Use the SDK for all queries except N:N expand.** Do not fall back to `requests` or `urllib` for standard queries, lookups, or 1:N expand — the SDK handles these correctly.
 
 ---
 

--- a/.github/plugins/dataverse/skills/python-sdk/SKILL.md
+++ b/.github/plugins/dataverse/skills/python-sdk/SKILL.md
@@ -209,7 +209,7 @@ result = client.tables.create_lookup_field(
     display_name="Account",
     solution="MySolution",
 )
-print(f"Created lookup: {result['lookup_schema_name']}")
+print(f"Created lookup: {result.lookup_schema_name}")
 # The nav property for @odata.bind is the lookup's Navigation Property Name (case-sensitive)
 ```
 
@@ -252,7 +252,7 @@ When creating or updating a record that sets a lookup field, you must use `@odat
 
 ### How to find the navigation property name
 
-1. **After creating a lookup via SDK**: The `result['lookup_schema_name']` is the navigation property name.
+1. **After creating a lookup via SDK**: `result.lookup_schema_name` is the navigation property name.
 2. **For system tables**: Query the relationship metadata:
    ```
    GET /api/data/v9.2/EntityDefinitions(LogicalName='<entity>')/ManyToOneRelationships?$select=ReferencingEntityNavigationPropertyName,ReferencedEntity
@@ -386,7 +386,7 @@ from PowerPlatform.Dataverse.core.errors import HttpError
 
 load_env()
 client = DataverseClient(
-    resource_url=os.environ["DATAVERSE_URL"],
+    base_url=os.environ["DATAVERSE_URL"],
     credential=get_credential(),
 )
 
@@ -488,7 +488,7 @@ from PowerPlatform.Dataverse.client import DataverseClient
 
 credential = InteractiveBrowserCredential()
 client = DataverseClient(
-    resource_url="https://<org>.crm.dynamics.com",  # replace with your URL
+    base_url="https://<org>.crm.dynamics.com",  # replace with your URL
     credential=credential,
 )
 

--- a/.github/plugins/dataverse/skills/python-sdk/SKILL.md
+++ b/.github/plugins/dataverse/skills/python-sdk/SKILL.md
@@ -66,11 +66,11 @@ Dataverse uses two different naming conventions for properties. Getting this wro
 | Property type | Name convention | Example | When used |
 |---|---|---|---|
 | **Structural** (columns) | LogicalName (always lowercase) | `new_name`, `new_priority` | `$select`, `$filter`, `$orderby`, record payload keys |
-| **Navigation** (relationships / lookups) | Navigation Property Name (case-sensitive, must match `$metadata`) | `new_CustomerId`, `new_AgentId` | `$expand`, `@odata.bind` annotation keys |
+| **Navigation** (relationships / lookups) | Navigation Property Name (case-sensitive, must match `$metadata`) | `new_AccountId`, `new_DepartmentId` | `$expand`, `@odata.bind` annotation keys |
 
 - **`$select`, `$filter`, `$orderby`**: always lowercase logical names (`new_name`, `new_priority`)
-- **`$expand` navigation properties**: Navigation Property Name, case-sensitive (`new_CustomerId`, `new_AgentId`)
-- **`@odata.bind` keys**: Navigation Property Name, case-sensitive (`new_CustomerId@odata.bind`)
+- **`$expand` navigation properties**: Navigation Property Name, case-sensitive (`new_AccountId`, `new_DepartmentId`)
+- **`@odata.bind` keys**: Navigation Property Name, case-sensitive (`new_AccountId@odata.bind`)
 - **Record payloads** (create/update data): lowercase logical names for regular fields; `@odata.bind` keys preserve the navigation property casing
 
 The SDK handles this correctly: it lowercases structural property keys but preserves `@odata.bind` key casing.
@@ -290,28 +290,28 @@ for page in client.records.get("opportunity",
             print(account["name"])
 ```
 
-> **Note:** System table navigation properties (e.g., `parentaccountid`, `ownerid`) are lowercase. Custom lookup navigation properties are case-sensitive and must match `$metadata` (e.g., `new_CustomerId`). When in doubt, query the entity's `ManyToOneRelationships` metadata.
+> **Note:** System table navigation properties (e.g., `parentaccountid`, `ownerid`) are lowercase. Custom lookup navigation properties are case-sensitive and must match `$metadata` (e.g., `new_AccountId`). When in doubt, query the entity's `ManyToOneRelationships` metadata.
 
 ### $expand with multiple custom lookups
 
 Use the correct navigation property names (case-sensitive, must match `$metadata`):
 
 ```python
-# Expand multiple lookups — e.g., tickets with customer and agent details
+# Expand multiple lookups — e.g., project budgets with account and department details
 for page in client.records.get(
-    "sa_ticket",
-    select=["sa_ticketnumber", "sa_priority", "sa_status"],
-    filter="sa_status eq 100000002",
-    expand=["sa_CustomerId", "sa_AgentId"],
-    orderby=["sa_priority desc"],
+    "new_projectbudget",
+    select=["new_name", "new_amount", "new_status"],
+    filter="new_status eq 100000001",
+    expand=["new_AccountId", "new_DepartmentId"],
+    orderby=["new_amount desc"],
 ):
-    for ticket in page:
-        cust = ticket.get("sa_CustomerId") or {}
-        agent = ticket.get("sa_AgentId") or {}
-        print(f"{ticket['sa_ticketnumber']}: {cust.get('sa_name', '')} -> {agent.get('sa_name', '')}")
+    for budget in page:
+        acct = budget.get("new_AccountId") or {}
+        dept = budget.get("new_DepartmentId") or {}
+        print(f"{budget['new_name']}: {acct.get('name', '')} / {dept.get('new_name', '')}")
 ```
 
-> **Important:** `expand` uses the navigation property name (case-sensitive, e.g., `sa_CustomerId`), not the lowercase logical name (`sa_customerid`). Using lowercase causes a 400 error.
+> **Important:** `expand` uses the navigation property name (case-sensitive, e.g., `new_AccountId`), not the lowercase logical name (`new_accountid`). Using lowercase causes a 400 error.
 
 ### $expand on N:N relationships
 
@@ -323,7 +323,7 @@ import urllib.request, json
 from auth import get_token
 
 token = get_token()
-url = f"{env}/api/data/v9.2/sa_knowledgearticles?$select=sa_title&$expand=sa_Ticket_KnowledgeArticle($select=sa_ticketnumber)"
+url = f"{env}/api/data/v9.2/new_projectdocuments?$select=new_title&$expand=new_ProjectBudget_Documents($select=new_name)"
 req = urllib.request.Request(url, headers={
     "Authorization": f"Bearer {token}",
     "OData-MaxVersion": "4.0", "OData-Version": "4.0", "Accept": "application/json",
@@ -401,8 +401,8 @@ for row in rows:
         "new_name": row["Title"],
         "new_description": row["Description"],
         "new_priority": int(row["Priority"]),
-        # Lookup binding — use PascalCase nav property name
-        "new_CustomerId@odata.bind": f"/accounts({row['AccountGuid']})",
+        # Lookup binding — use navigation property name (case-sensitive)
+        "new_AccountId@odata.bind": f"/accounts({row['AccountGuid']})",
     })
 
 # Bulk create — SDK uses CreateMultiple internally

--- a/.github/plugins/dataverse/skills/solution/SKILL.md
+++ b/.github/plugins/dataverse/skills/solution/SKILL.md
@@ -14,21 +14,73 @@ Create, export, unpack, pack, import, and validate Dataverse solutions via PAC C
 
 ## Create a New Solution
 
-Creating a solution is a two-step process: create the solution record in Dataverse, then add components to it.
+**Use the Python SDK for publisher and solution record creation — not raw HTTP.** Publishers and solutions are standard Dataverse tables. `client.records.create()` and `client.records.get()` handle auth, pagination, and error handling automatically, avoiding the URL encoding, header boilerplate, and GUID-parsing bugs that raw `urllib` calls introduce.
 
-### Step 1: Find the Publisher
+### Step 1: Find or Create the Publisher
 
-Every solution belongs to a publisher. Look up the publisher that matches your table prefix:
-```sql
-SELECT publisherid, uniquename, customizationprefix FROM publisher
-WHERE customizationprefix = '<prefix>'
+Every solution belongs to a publisher. The publisher's `customizationprefix` (e.g., `contoso`, `sa`, `lit`) is prepended to every custom table, column, and relationship schema name. **This prefix is effectively permanent** — existing components keep their prefix forever, even if you change the publisher later.
+
+**Never use the default `new` prefix.** It provides no organizational identity, risks naming collisions, and signals the developer did not follow best practices.
+
+**Discovery flow — always run this before creating a publisher:**
+
+```python
+# 1. Query for existing non-Microsoft publishers
+pages = client.records.get(
+    "publisher",
+    filter="customizationprefix ne 'none' and uniquename ne 'MicrosoftCorporation' and uniquename ne 'Microsoftdynamic'",
+    select=["publisherid", "uniquename", "friendlyname", "customizationprefix"],
+    top=10,
+)
+publishers = [p for page in pages for p in page]
+
+if publishers:
+    # Show existing publishers and ask user which to use
+    print("Existing publishers in this environment:")
+    for p in publishers:
+        print(f"  {p['uniquename']} (prefix: {p['customizationprefix']}_)")
+    # ASK THE USER: "Which publisher should this solution use?"
+    # Or: "Should I reuse '<name>' (prefix: <prefix>_)?"
+    publisher_id = publishers[0]["publisherid"]  # after user confirms
+else:
+    # No custom publisher exists — ASK THE USER for prefix
+    # "What publisher prefix should I use? (e.g., 'contoso', 'sa', 'lit' — 2-8 lowercase chars)"
+    publisher_id = client.records.create("publisher", {
+        "uniquename": "<publisheruniquename>",
+        "friendlyname": "<Publisher Display Name>",
+        "customizationprefix": "<prefix>",   # from user input, NOT 'new'
+        "description": "<description>",
+    })
 ```
 
-If the publisher doesn't exist yet, create it first in make.powerapps.com or via Web API. The publisher prefix must match the prefix already used by your tables — you cannot mix prefixes within a solution.
+**Rules:**
+- **Always ask the user** before creating a new publisher or choosing a prefix. Never hardcode a prefix.
+- The prefix must match any tables already created in the solution — you cannot mix prefixes.
+- One publisher can own many solutions. Reuse an existing publisher when possible.
 
 ### Step 2: Create the Solution Record
 
-Create a record in the `solution` table via MCP, SDK, or Web API:
+Use the SDK to create the solution record (preferred over raw Web API):
+
+```python
+from PowerPlatform.Dataverse.client import DataverseClient
+from scripts.auth import get_credential, load_env
+import os
+
+load_env()
+client = DataverseClient(os.environ["DATAVERSE_URL"], get_credential())
+
+# Create the solution record
+solution_id = client.records.create("solution", {
+    "uniquename": "<UniqueName>",
+    "friendlyname": "<Display Name>",
+    "version": "1.0.0.0",
+    "publisherid@odata.bind": "/publishers(<publisher_guid>)",
+})
+print(f"Created solution: {solution_id}")
+```
+
+The required fields:
 ```
 Table:  solution
 Fields: uniquename    = "<UniqueName>"
@@ -36,6 +88,8 @@ Fields: uniquename    = "<UniqueName>"
         version       = "1.0.0.0"
         publisherid   = <publisher GUID from step 1>
 ```
+
+> **Note:** There is no `pac solution create` command. PAC CLI handles export/import/pack/unpack, not solution record creation. Use the SDK or Web API to create the record.
 
 ### Step 3: Add Components
 
@@ -189,15 +243,21 @@ views = [v for page in pages for v in page]
 
 ### Check a user's role assignment
 
+N:N `$expand` (like `systemuserroles_association`) is not supported by the SDK. Use the Web API:
+
 ```python
-pages = client.records.get(
-    "systemuser",
-    filter="internalemailaddress eq '<email>'",
-    expand=["systemuserroles_association"],
-    select=["fullname", "internalemailaddress"],
-    top=1,
-)
-users = [u for page in pages for u in page]
+# Web API fallback for N:N expand
+import urllib.request, json
+from auth import get_token
+
+token = get_token()
+url = f"{env}/api/data/v9.2/systemusers?$filter=internalemailaddress eq '<email>'&$select=fullname&$expand=systemuserroles_association($select=name)&$top=1"
+req = urllib.request.Request(url, headers={
+    "Authorization": f"Bearer {token}",
+    "OData-MaxVersion": "4.0", "OData-Version": "4.0", "Accept": "application/json",
+})
+with urllib.request.urlopen(req) as resp:
+    users = json.loads(resp.read()).get("value", [])
 if users:
     roles = [r["name"] for r in users[0].get("systemuserroles_association", [])]
     print(f"Roles: {', '.join(roles)}")

--- a/.github/plugins/dataverse/templates/CLAUDE.md
+++ b/.github/plugins/dataverse/templates/CLAUDE.md
@@ -3,6 +3,7 @@
 ## Environment
 - **URL:** {{DATAVERSE_URL}}
 - **Solution:** {{SOLUTION_NAME}}
+- **Publisher Prefix:** {{PUBLISHER_PREFIX}}
 - **PAC Auth Profile:** {{PAC_AUTH_PROFILE}}
 
 ## Repo Layout
@@ -51,7 +52,7 @@ print(f"[{'FAIL' if errors else 'PASS'}] {len(errors)} failed import(s)")
 ```
 
 ## Metadata Conventions
-- Table prefix: `new_` (confirm publisher prefix in `solutions/{{SOLUTION_NAME}}/Other/Solution.xml`)
+- Table prefix: `{{PUBLISHER_PREFIX}}_` (from `.env`; also visible in `solutions/{{SOLUTION_NAME}}/Other/Solution.xml`)
 - All GUIDs in form and view XML must be unique — generate with `python -c "import uuid; print(str(uuid.uuid4()).upper())"`
 - Business rules are stored as JSON in `Entities/<table>/Workflows/`
 

--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ mkdir my-test-project
 cd my-test-project
 
 # 2. Launch Claude Code with the plugin loaded from your local clone
-claude --plugin-dir "c:/repos/PowerPlatform-Dataverse-Skills/.github/plugins/dataverse"
+claude --plugin-dir "c:/repos/Dataverse-Skills/.github/plugins/dataverse"
 
 # 3. Start with a natural language prompt, e.g.:
 #    "Create a support ticket table with customer and agent lookups"
 ```
 
-The `--plugin-dir` path **must be in double quotes** if it contains spaces or special characters. Use the absolute path to the plugin directory in your local clone.
+The `--plugin-dir` path **must be in double quotes** if it contains spaces or special characters. Use the absolute path to the plugin directory in your local clone of this repo.
 
 For GitHub Copilot:
 

--- a/README.md
+++ b/README.md
@@ -36,10 +36,22 @@ copilot plugin install dataverse@awesome-copilot
 Test the plugin locally without installing from a marketplace:
 
 ```bash
-# Claude Code
-claude --plugin-dir ./.github/plugins/dataverse
+# 1. Create and cd into a fresh test folder
+mkdir my-test-project
+cd my-test-project
 
-# GitHub Copilot
+# 2. Launch Claude Code with the plugin loaded from your local clone
+claude --plugin-dir "c:/repos/PowerPlatform-Dataverse-Skills/.github/plugins/dataverse"
+
+# 3. Start with a natural language prompt, e.g.:
+#    "Create a support ticket table with customer and agent lookups"
+```
+
+The `--plugin-dir` path **must be in double quotes** if it contains spaces or special characters. Use the absolute path to the plugin directory in your local clone.
+
+For GitHub Copilot:
+
+```bash
 copilot plugin install ./.github/plugins/dataverse
 ```
 


### PR DESCRIPTION
## Summary

- **Navigation Property terminology**: Replace "PascalCase SchemaName" with "Navigation Property Name (case-sensitive, must match `$metadata`)" across metadata, python-sdk, and overview skills — matches SDK PR #137
- **Remove @odata.bind limitation**: SDK now preserves `@odata.bind` key casing, so remove it from "Web API only" fallback lists
- **auth.py .env discovery**: `load_env()` now searches the repo root (parent of `scripts/`) before falling back to cwd
- **Expanded SDK examples**: Added 1:N and N:N relationship SDK patterns to metadata skill, `$expand` with multiple custom lookups and N:N fallback to python-sdk skill
- **Skill improvements**: Enhanced init (clearer steps), solution (publisher discovery, validation), and overview (field casing rules, publisher prefix guidance) skills
- **README local dev workflow**: Added step-by-step instructions for testing the plugin locally with `--plugin-dir`

## Test plan

- [ ] Verify skill frontmatter triggers still route correctly in Claude Code
- [ ] Test local dev workflow: `mkdir test && cd test && claude --plugin-dir "<path>"`
- [ ] Confirm `auth.py` finds `.env` from `scripts/` subdirectory
- [ ] Review terminology consistency across all three updated skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)