### PR TITLE
Flipped the default MCP config scope for GitHub Copilot CLI to global

### DIFF
--- a/.github/plugins/dataverse/skills/mcp-configure/SKILL.md
+++ b/.github/plugins/dataverse/skills/mcp-configure/SKILL.md
@@ -42,8 +42,8 @@ Choose the configuration scope based on the tool. Use the scope explicitly menti
 **If TOOL_TYPE is `copilot`:**
 
 The options are:
-1. **Globally** (available in all projects)
-2. **Project-only** (default, available only in this project)
+1. **Globally** (default, available in all projects)
+2. **Project-only** (available only in this project)
 
 Based on the scope, set the `CONFIG_PATH` variable:
 - **Global**: `~/.copilot/mcp-config.json` (use the user's home directory)

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ copilot plugin install dataverse@awesome-copilot
 - **Templates** for CLAUDE.md project files
 
 ## Local development
+### Claude Code
 
 Test the plugin locally without installing from a marketplace:
 
@@ -49,10 +50,36 @@ claude --plugin-dir "c:/repos/Dataverse-Skills/.github/plugins/dataverse"
 
 The `--plugin-dir` path **must be in double quotes** if it contains spaces or special characters. Use the absolute path to the plugin directory in your local clone of this repo.
 
-For GitHub Copilot:
+### GitHub Copilot CLI
+
+#### Registering the local marketplace
+
+To register the local plugin marketplace from the cloned repository and install the plugin:
 
 ```bash
-copilot plugin install ./.github/plugins/dataverse
+copilot plugin marketplace add <path/to/repo>/Dataverse-skills
+copilot plugin install dataverse@dataverse-skills
+```
+
+To reinstall the plugin after pulling or making local changes:
+
+```bash
+copilot plugin uninstall dataverse@dataverse-skills
+copilot plugin install dataverse@dataverse-skills
+```
+
+#### Installing the local plugin directly
+
+To install the local version of the plugin directly without marketplace registration:
+
+```bash
+copilot plugin install <path/to/repo>/.github/plugins/dataverse
+```
+
+To uninstall it later (for reinstalling an updated version):
+
+```bash
+copilot plugin uninstall dataverse
 ```
 
 ## Contributing


### PR DESCRIPTION
This PR flips the default MCP config scope for GitHub Copilot CLI to global (stored in user's home directory) as that is the only one Copilot has a default path for.

Also updating README to cover registering and using a local Copilot plugin marketplace.