### PR TITLE
fix(python-sdk): document CreateMultiple @odata.bind casing bug

### DIFF
--- a/.github/plugins/dataverse/skills/overview/SKILL.md
+++ b/.github/plugins/dataverse/skills/overview/SKILL.md
@@ -60,7 +60,7 @@ For data operations (CRUD, bulk, queries) and schema operations (table/column/re
 
 Only fall back to raw Web API for: forms, views, global option sets, N:N `$ref` associations, N:N `$expand`, `$apply` aggregation, memo columns, and unbound actions.
 
-**Field casing:** `$select`/`$filter` use lowercase logical names (`new_name`). `$expand` and `@odata.bind` use Navigation Property Names that are case-sensitive and must match `$metadata` (e.g., `new_AccountId`). Getting this wrong causes 400 errors. The SDK handles this correctly for `@odata.bind` keys.
+**Field casing:** `$select`/`$filter` use lowercase logical names (`new_name`). `$expand` and `@odata.bind` use Navigation Property Names that are case-sensitive and must match `$metadata` (e.g., `new_AccountId`). Getting this wrong causes 400 errors. **⚠️ Known SDK bug:** Bulk creates (`CreateMultiple`) lowercase `@odata.bind` keys — use single-record creates for records with lookups. See the python-sdk skill.
 
 **Publisher prefix:** Never hardcode a prefix (especially not `new`). Always query existing publishers in the environment and ask the user which to use. The prefix is permanent on every component created with it. See the solution skill's publisher discovery flow.
 

--- a/.github/plugins/dataverse/skills/python-sdk/SKILL.md
+++ b/.github/plugins/dataverse/skills/python-sdk/SKILL.md
@@ -73,7 +73,25 @@ Dataverse uses two different naming conventions for properties. Getting this wro
 - **`@odata.bind` keys**: Navigation Property Name, case-sensitive (`new_AccountId@odata.bind`)
 - **Record payloads** (create/update data): lowercase logical names for regular fields; `@odata.bind` keys preserve the navigation property casing
 
-The SDK handles this correctly: it lowercases structural property keys but preserves `@odata.bind` key casing.
+The SDK handles casing differently depending on the code path:
+- **Single-record create** (`client.records.create(table, dict)`): Correctly lowercases structural keys while preserving `@odata.bind` key casing. ✅
+- **Bulk create** (`client.records.create(table, list)`): **Lowercases ALL keys including `@odata.bind` keys.** This is a known SDK bug — `CreateMultiple` turns `new_AccountId@odata.bind` into `new_accountid@odata.bind`, causing 400 errors. ⚠️
+
+**Workaround for bulk creates with lookups:** Use a single-record loop instead of passing a list:
+
+```python
+# WRONG — bulk create lowercases @odata.bind keys
+guids = client.records.create("new_interview", [
+    {"new_name": "Interview 1", "new_CandidateId@odata.bind": "/contacts(...)"},
+    ...
+])
+
+# CORRECT — single-record creates preserve @odata.bind casing
+for record in records:
+    client.records.create("new_interview", record)
+```
+
+Bulk create without `@odata.bind` keys (no lookups) works fine.
 
 ---
 
@@ -152,6 +170,15 @@ records = [{"new_name": f"Budget {i}"} for i in range(100)]
 guids = client.records.create("new_projectbudget", records)
 print(f"Created {len(guids)} records")
 ```
+
+> **⚠️ Bulk create + `@odata.bind`:** `CreateMultiple` lowercases all keys, including `@odata.bind` navigation property names. This causes 400 errors for records with lookup bindings. If your records contain `@odata.bind` keys, use a single-record loop instead:
+>
+> ```python
+> for record in records:
+>     client.records.create("new_projectbudget", record)
+> ```
+>
+> Bulk create without `@odata.bind` keys works correctly.
 
 ### Bulk update (broadcast same change to multiple records)
 ```python
@@ -409,6 +436,13 @@ for row in rows:
 guids = client.records.create("new_ticket", records)
 print(f"Created {len(guids)} tickets")
 ```
+
+> **⚠️ `@odata.bind` in bulk creates:** The CSV example above includes `@odata.bind` keys. Due to the `CreateMultiple` casing bug, this will fail. Use a single-record loop instead:
+>
+> ```python
+> for record in records:
+>     client.records.create("new_ticket", record)
+> ```
 
 ### Required field discovery
 


### PR DESCRIPTION
## Problem

The skills claim 'The SDK handles this correctly: it lowercases structural property keys but preserves `@odata.bind` key casing.' This is **wrong for bulk operations**.

The SDK's `CreateMultiple` (used internally by `client.records.create(table, list)`) lowercases ALL keys including `@odata.bind` navigation property names. For example, `zava_CandidateId@odata.bind` becomes `zava_candidateid@odata.bind`, causing 400 errors ('undeclared property').

Single-record creates preserve casing correctly.

## Solution

Updated documentation in both skills to warn about this bug and provide the workaround:

**Workaround:** Use a single-record loop instead of passing a list when records contain `@odata.bind` keys:

`python
# Instead of bulk create (broken with @odata.bind):
# guids = client.records.create(table, list_of_records)

# Use single-record loop:
for record in records:
    client.records.create(table, record)
`

## Changes

- `python-sdk/SKILL.md` (+34/-1)
  - **Field Name Casing Rule**: Replaced false claim with detailed warning explaining single-record vs bulk behavior
  - **Bulk create section**: Added warning box with workaround
  - **CSV import section**: Added warning since the example uses `@odata.bind` in bulk create
- `overview/SKILL.md` (+2/-1)
  - Updated field casing note to warn about the bug instead of claiming SDK handles it
