### PR TITLE
Update init and overview skills to reduce friction to setup DV MCP.

### DIFF
--- a/.github/plugins/dataverse/skills/init/SKILL.md
+++ b/.github/plugins/dataverse/skills/init/SKILL.md
@@ -44,22 +44,24 @@ The output is the tenant GUID. Use it directly in `.env`.
 
 ### 3. Create .env if missing
 
-Ask the user for each value, then write the file:
+Ask the user for `DATAVERSE_URL` and `SOLUTION_NAME`, then present the authentication choice clearly:
 
-```
-DATAVERSE_URL=https://<org>.crm.dynamics.com
-TENANT_ID=<guid>
-SOLUTION_NAME=<UniqueName>
-PAC_AUTH_PROFILE=nonprod
-CLIENT_ID=<app-registration-client-id>
-CLIENT_SECRET=<app-registration-secret>
-```
+**Prompt for values:**
+- `DATAVERSE_URL`: "What is your Dataverse environment URL?" (e.g., `https://myorg.crm10.dynamics.com`)
+- `TENANT_ID`: Auto-discover from the URL above. Only ask if discovery fails.
+- `SOLUTION_NAME`: "What is the unique name of your solution?" (allow skipping for now)
 
-How to prompt the user:
-- `DATAVERSE_URL`: "What is your Dataverse environment URL?"
-- `TENANT_ID`: Auto-discover from the URL above before asking. Only ask if discovery fails.
-- `SOLUTION_NAME`: "What is the unique name of your solution?"
-- `CLIENT_ID` / `CLIENT_SECRET`: Only needed for service principal auth. If the user authenticates via browser (interactive login), skip these. When omitted, auth.py uses interactive device code flow with AuthenticationRecord persistence (no browser re-prompt on subsequent runs).
+**Present authentication options — always ask this explicitly:**
+
+> How would you like to authenticate with Dataverse?
+>
+> 1. **Interactive login (recommended for personal use)** — Sign in via your browser. No app registration needed. You'll authenticate once and it stays cached.
+> 2. **Service principal (for CI/CD or shared environments)** — Uses a CLIENT_ID and CLIENT_SECRET from an Azure app registration. Required for unattended/automated scenarios.
+
+- If **Interactive**: skip `CLIENT_ID` and `CLIENT_SECRET`. `auth.py` uses device code flow with persistent token caching — no re-prompt on subsequent runs.
+- If **Service principal**: ask for `CLIENT_ID` and `CLIENT_SECRET`.
+
+The `.env` file format:
 
 Write the file directly — do not instruct the user to create it:
 

--- a/.github/plugins/dataverse/skills/mcp-configure/SKILL.md
+++ b/.github/plugins/dataverse/skills/mcp-configure/SKILL.md
@@ -283,23 +283,46 @@ Store this command as `CLAUDE_COMMAND` for use in step 9.
 
 Proceed to step 7.
 
-### 7. Confirm admin consent is granted
+### 7. Enable the MCP client in the environment
+
+The MCP client must be whitelisted in the Dataverse environment. There are two ways to do this — the PPAC portal method does NOT require Azure AD admin permissions and is the recommended approach for most users.
 
 List out the parameters chosen in previous steps:
-- Tool type (Copilot or claude) from step 0
-- Scope (list possible options based on tool) from step 1
+- Tool type (Copilot or Claude) from step 0
+- Scope from step 1
 - Environment URL from step 4
 - Endpoint (GA or Preview) from step 5
+- MCP Client ID from step 0
 
-Ask the user if their Azure tenant administrator has granted admin consent for the MCP client ID to access the environment (which is a one-time action). If not, provide instructions to grant consent and share the following URL with them, replacing `{TENANT_ID}` with their tenant ID from `.env` and `{MCP_CLIENT_ID}` with the client ID determined in step 0:
+Then present both options:
 
-```
-https://login.microsoftonline.com/{TENANT_ID}/adminconsent?client_id={MCP_CLIENT_ID}
-```
+> The MCP client needs to be allowed in your Dataverse environment. This is a one-time setup.
+>
+> **Option A: Power Platform Admin Center (recommended — no Azure AD admin needed)**
+>
+> 1. Go to [Power Platform Admin Center](https://admin.powerplatform.microsoft.com/)
+> 2. Select **Environments** in the left navigation
+> 3. Click on your environment (e.g., `{environment name from USER_URL}`)
+> 4. Click **Settings** in the top toolbar
+> 5. Expand **Product** and click **Features**
+> 6. Scroll down to the **MCP Server** section
+> 7. Toggle **Enable MCP Server** to **On** (if not already)
+> 8. Under **Allowed clients**, click **Add client**
+> 9. Paste the MCP Client ID: `{MCP_CLIENT_ID}`
+> 10. Click **Save**
+>
+> **Option B: Admin consent URL (requires Azure AD Global Admin or Privileged Role Admin)**
+>
+> If you have Azure AD admin permissions, open this URL in your browser and click Accept:
+> ```
+> https://login.microsoftonline.com/{TENANT_ID}/adminconsent?client_id={MCP_CLIENT_ID}
+> ```
 
-### 8. Add the client ID to the allowed clients list
+Ask the user to confirm once they have completed either option, then proceed.
 
-Run the `scripts/enable-mcp-client.py` script to add the MCP client ID (from step 0) to the Allowed Clients list for the environment (which will require a new app registration when using the VSCode extension for Claude Code but will work with standard client IDs for Copilot and Claude CLI). Do not ask for user confirmation.
+### 8. Add the client ID to the allowed clients list (programmatic)
+
+If the user completed step 7 via the PPAC portal, this step may already be done. Attempt to run `scripts/enable-mcp-client.py` to verify or add the MCP client ID programmatically. If it reports the client is already enabled, continue. Do not ask for user confirmation.
 
 ### 9. Confirm success and provide next steps
 
@@ -364,8 +387,11 @@ If something goes wrong, help the user check:
 - The URL format is correct (`https://<org>.<region>.dynamics.com`)
 - They have access to the Dataverse environment
 - The environment URL matches what's shown in the Power Platform Admin Center
-- Their Environment Admin has enabled "Dataverse CLI MCP" in the Allowed Clients list
-- Their Environment has Dataverse MCP enabled, and if they're trying to use the preview endpoint that is enabled
+- The MCP client ID has been added to the environment's allowed clients list. To check or fix this:
+  1. Go to [Power Platform Admin Center](https://admin.powerplatform.microsoft.com/) > Environments > your environment > Settings > Product > Features
+  2. Verify **MCP Server** is toggled **On**
+  3. Verify the MCP Client ID appears under **Allowed clients**
+- If using the Preview endpoint, verify that the Preview MCP endpoint is also enabled in the same Features page
 - **If TOOL_TYPE is `copilot`:**
   - For project-scoped configuration, ensure the `.mcp/copilot/mcp.json` file was created successfully
   - For global configuration, check permissions on the `~/.copilot/` directory

--- a/.github/plugins/dataverse/skills/metadata/SKILL.md
+++ b/.github/plugins/dataverse/skills/metadata/SKILL.md
@@ -11,6 +11,16 @@ description: >
 
 # Skill: Metadata — Making Changes
 
+## Before You Start: Environment Confirmation
+
+**Before any metadata change** (creating tables, columns, relationships, forms, or views), confirm the target environment with the user:
+
+> "I'm about to make schema changes to `<DATAVERSE_URL>`. Is this the correct environment?"
+
+Run `pac org who` to verify the active connection matches. Do not proceed until the user confirms. This prevents accidental changes to production or shared environments.
+
+---
+
 ## How Changes Are Made: Environment-First
 
 **Do not write solution XML by hand to create new tables, columns, forms, or views.**
@@ -95,10 +105,13 @@ attribute = {
                     "LocalizedLabels": [{"@odata.type": "Microsoft.Dynamics.CRM.LocalizedLabel",
                                           "Label": "Description", "LanguageCode": 1033}]},
     "RequiredLevel": {"Value": "None"},
-    "MaxLength": 500
+    "MaxLength": 500,
+    "FormatName": {"Value": "Text"}   # Always use "Text" — see FormatName reference below
 }
 # POST to /api/data/v9.2/EntityDefinitions(LogicalName='new_projectbudget')/Attributes
 ```
+
+**Valid FormatName values for StringAttributeMetadata:** `Text`, `TextArea`, `Url`, `TickerSymbol`, `PhoneticGuide`, `VersionNumber`, `Phone`. Note: `Email` is **not** a valid FormatName despite being a common assumption — use `Text` for email columns.
 
 **Currency column:**
 ```python
@@ -384,6 +397,65 @@ When creating forms via the Web API (`POST /api/data/v9.2/systemforms`), FormXml
 - **Control `classid` values** are fixed per control type (e.g., `{4273EDBD-AC1D-40d3-9FB2-095C621B552D}` for text, `{270BD3DB-D9AF-4782-9025-509E298DEC0A}` for lookup, `{3EF39988-22BB-4f0b-BBBE-64B5A3748AEE}` for picklist/choice).
 
 **Tip:** To avoid FormXml issues, create forms through the Dynamics maker portal and pull via `pac solution export` — then use the pulled XML as a template for programmatic creation.
+
+---
+
+## After Creating Columns: Report Logical Names
+
+After creating columns (via Web API or MCP), **always report the actual logical names** to the user. Column names may be normalized or prefixed in ways the user doesn't expect. Summarize in a table:
+
+| Display Name | Logical Name | Type |
+|---|---|---|
+| Email | cr9ac_email | String |
+| Tier | cr9ac_tier | Picklist |
+| Customer | cr9ac_customerid | Lookup |
+
+This prevents downstream failures when the user tries to insert data using incorrect column names.
+
+---
+
+## Common Web API Error Codes
+
+| Error Code | Meaning | Recovery |
+|---|---|---|
+| `0x80040216` | Transient metadata cache error. Column or table metadata not yet propagated. | Wait 3-5 seconds and retry. Usually succeeds on second attempt. |
+| `0x80048d19` | Invalid property in payload. A field name doesn't match any column on the table. | Check logical column names — use `EntityDefinitions(LogicalName='...')/Attributes` to verify. |
+| `0x80040237` | Schema name already exists. | Verify the column/table exists before creating a new one — it may have been created by a previous timed-out call. |
+| `0x8004431a` | Publisher prefix mismatch. | Ensure all schema names use the solution's publisher prefix. |
+| `0x80060891` | Metadata cache not ready after table creation. | Call `GET EntityDefinitions(LogicalName='...')` first to force cache refresh, then retry. |
+
+Always translate error codes to plain English before presenting them to the user.
+
+---
+
+## Metadata Propagation Delays
+
+After creating tables or columns via the Web API, metadata propagation can take 3-10 seconds. Common symptoms:
+
+- Picklist columns fail with `0x80040216` immediately after table creation
+- Lookup `@odata.bind` operations fail with "Invalid property" shortly after column creation
+- `update_table` (MCP) fails with "EntityId not found in MetadataCache"
+
+**Mitigation:** Add a 3-5 second delay after table creation before adding columns. After creating lookup columns, wait 5-10 seconds before inserting records that use `@odata.bind` on those lookups. If a column creation fails, verify it doesn't already exist, then retry once.
+
+---
+
+## Session Closing: Pull to Repo
+
+**After every metadata session, perform the pull-to-repo sequence.** This is not optional — work that exists only in the environment is lost if the environment is reset.
+
+```bash
+pac solution export --name <SOLUTION_NAME> --path ./solutions/<SOLUTION_NAME>.zip --managed false
+pac solution unpack --zipfile ./solutions/<SOLUTION_NAME>.zip --folder ./solutions/<SOLUTION_NAME>
+rm ./solutions/<SOLUTION_NAME>.zip
+git add ./solutions/<SOLUTION_NAME>
+git commit -m "feat: <description of change>"
+```
+
+If you used the `MSCRM.SolutionName` header during creation, verify components are in the solution before exporting:
+```bash
+pac solution list-components --solutionUniqueName <SOLUTION_NAME> --environment <url>
+```
 
 ---
 

--- a/.github/plugins/dataverse/skills/metadata/SKILL.md
+++ b/.github/plugins/dataverse/skills/metadata/SKILL.md
@@ -11,7 +11,7 @@ description: >
 
 # Skill: Metadata — Making Changes
 
-**Before any metadata change, confirm the target environment with the user.** See the Multi-Environment Rule in the overview skill for the full confirmation flow.
+**Before the first metadata change in a session, confirm the target environment with the user.** See the Multi-Environment Rule in the overview skill for the full confirmation flow.
 
 ---
 

--- a/.github/plugins/dataverse/skills/metadata/SKILL.md
+++ b/.github/plugins/dataverse/skills/metadata/SKILL.md
@@ -11,13 +11,7 @@ description: >
 
 # Skill: Metadata — Making Changes
 
-## Before You Start: Environment Confirmation
-
-**Before any metadata change** (creating tables, columns, relationships, forms, or views), confirm the target environment with the user:
-
-> "I'm about to make schema changes to `<DATAVERSE_URL>`. Is this the correct environment?"
-
-Run `pac org who` to verify the active connection matches. Do not proceed until the user confirms. This prevents accidental changes to production or shared environments.
+**Before any metadata change, confirm the target environment with the user.** See the Multi-Environment Rule in the overview skill for the full confirmation flow.
 
 ---
 

--- a/.github/plugins/dataverse/skills/overview/SKILL.md
+++ b/.github/plugins/dataverse/skills/overview/SKILL.md
@@ -29,7 +29,7 @@ ls .env scripts/auth.py 2>/dev/null
 ```
 
 - If BOTH exist: workspace is initialized. Proceed to the relevant task.
-- If EITHER is missing: **STOP. Run the init flow first** (see the init skill). Do not create your own `.env`, `requirements.txt`, `.env.example`, or auth scripts. The init skill handles all of this.
+- If EITHER is missing: **Automatically run the init flow** (see the init skill). Do NOT ask the user whether to initialize — just do it. Do not create your own `.env`, `requirements.txt`, `.env.example`, or auth scripts. The init skill handles all of this.
 
 Do NOT create `requirements.txt`, `.env.example`, or scaffold files manually. The init flow produces the correct file structure. Skipping init is the #1 cause of broken setups.
 

--- a/.github/plugins/dataverse/skills/overview/SKILL.md
+++ b/.github/plugins/dataverse/skills/overview/SKILL.md
@@ -29,22 +29,21 @@ Skills exist as **Claude's knowledge**, not as user-facing commands. Each skill 
 
 ---
 
-## Multi-Environment Rule
+## Multi-Environment Rule (MANDATORY)
 
 Pro-dev scenarios involve multiple environments (dev, test, staging, prod) and multiple sets of credentials. **Never assume** the active PAC auth profile, values in `.env`, or anything from memory or a previous session reflects the correct target for the current task.
 
-**Before any operation that touches a specific environment** — deploying a plugin, pushing a solution, registering a step, running a script against the Web API — ask the user:
+**Before the FIRST operation that touches a specific environment** — creating a table, deploying a plugin, pushing a solution, inserting data — you MUST:
 
-> "Which environment should I target for this? Please confirm the URL."
+1. Show the user the environment URL you intend to use
+2. Ask them to confirm it is correct
+3. Run `pac org who` to verify the active connection matches
 
-Then verify the active PAC profile matches:
+> "I'm about to make changes to `<URL>`. Is this the correct target environment?"
 
-```bash
-pac auth list
-pac org who
-```
+**Do not proceed until the user explicitly confirms.** This is the single most important safety check in the plugin. Skipping it risks making irreversible changes to the wrong environment.
 
-The more impactful the operation (plugin deploy, solution import, step registration), the more important this confirmation is. Do not proceed against an environment the user hasn't explicitly confirmed in the current session.
+Once confirmed for a session, you do not need to re-confirm for every subsequent operation in the same session against the same environment.
 
 ---
 
@@ -112,9 +111,22 @@ Any Web API call that goes beyond a one-off query should be written as a Python 
 
 ---
 
-## After Any Change: Pull to Repo
+## Before Any Metadata Change: Confirm Solution
 
-Any time you make a metadata change (via MCP, Web API, or the maker portal), end the session by pulling:
+Before creating tables, columns, or other metadata, ensure a solution exists to contain the work:
+
+1. Ask the user: "What solution should these components go into?"
+2. If a solution name is in `.env` (`SOLUTION_NAME`), confirm it with the user
+3. If no solution exists yet, create one (see the `solution` skill)
+4. Use the `MSCRM.SolutionName` header on all Web API metadata calls to auto-add components
+
+Creating metadata without a solution means it exists only in the default solution and cannot be cleanly exported or deployed. Always solution-first.
+
+---
+
+## After Any Change: Pull to Repo (MANDATORY)
+
+Any time you make a metadata change (via MCP, Web API, or the maker portal), **you must** end the session by pulling:
 
 ```bash
 pac solution export --name <SOLUTION_NAME> --path ./solutions/<SOLUTION_NAME>.zip --managed false

--- a/.github/plugins/dataverse/skills/python-sdk/SKILL.md
+++ b/.github/plugins/dataverse/skills/python-sdk/SKILL.md
@@ -92,6 +92,11 @@ result = client.entity("new_projectbudget").create({
 # Returns the new record GUID
 ```
 
+**Lookup binding (`@odata.bind`) notes:**
+- If you just created lookup columns, wait 5-10 seconds before inserting records that reference them. Metadata propagation delays can cause "Invalid property" errors.
+- Choice (picklist) columns use integer values, not strings: `"new_status": 100000000` (not `"Draft"`).
+- If a record insert fails with "Invalid property", verify the lookup column's logical name and navigation property name by querying `EntityDefinitions(LogicalName='...')/Attributes`.
+
 ### Query records
 ```python
 records = client.entity("new_projectbudget").read(

--- a/.github/plugins/dataverse/skills/solution/SKILL.md
+++ b/.github/plugins/dataverse/skills/solution/SKILL.md
@@ -63,6 +63,24 @@ Common component type codes:
 
 Repeat the command for each component you need to add.
 
+### Alternative: Auto-add via MSCRM.SolutionName Header
+
+When creating metadata via the Web API, include the `MSCRM.SolutionName` header to auto-add components to the solution:
+```python
+headers = {
+    "Authorization": f"Bearer {token}",
+    "Content-Type": "application/json",
+    "MSCRM.SolutionName": "<UniqueName>"
+}
+```
+
+**Important:** After using this approach, verify components were added by listing them:
+```bash
+pac solution list-components --solutionUniqueName <UniqueName> --environment <url>
+```
+
+If the header was misspelled or the solution doesn't exist, components will be created in the default solution instead — silently. Always verify.
+
 ## Find the Solution Name
 
 Before exporting, confirm the exact unique name:


### PR DESCRIPTION
  **Overview skill (overview/SKILL.md):**                                                                                                                           
  - Changed init check from "STOP and ask" to "Automatically run init — don't ask, just do it"
                                                                                                                                                                 
 **Init skill (init/SKILL.md):**                                                                                                                                   
  - Replaced the vague auth prompt with an explicit two-option choice: Interactive login (recommended, no app registration) vs Service principal (CLIENT_ID +
  SECRET for CI/CD)
  - Clear descriptions so non-developers understand what each option means

  **MCP Configure skill (mcp-configure/SKILL.md):**
  - Replaced admin-only consent URL as the primary path with PPAC portal steps (step-by-step: Admin Center > Environment > Settings > Features > MCP Server >   
  Add client)
  - Kept the admin consent URL as a secondary "Option B" for users who have Azure AD admin access
  - Updated troubleshooting to reference the PPAC portal steps instead of vague "ask your admin" language