### PR TITLE
fix: ensure pip install always fetches latest packages

### DIFF
--- a/.github/plugins/dataverse/scripts/auth.py
+++ b/.github/plugins/dataverse/scripts/auth.py
@@ -99,7 +99,7 @@ def get_credential():
             TokenCachePersistenceOptions,
         )
     except ImportError:
-        print("ERROR: azure-identity not installed. Run: pip install azure-identity", flush=True)
+        print("ERROR: azure-identity not installed. Run: pip install --upgrade azure-identity", flush=True)
         sys.exit(1)
 
     # Warn if only one of CLIENT_ID / CLIENT_SECRET is set

--- a/.github/plugins/dataverse/skills/mcp-configure/SKILL.md
+++ b/.github/plugins/dataverse/skills/mcp-configure/SKILL.md
@@ -439,4 +439,8 @@ If something goes wrong, help the user check:
   - If the command fails, check that `npx` and `npm` are installed
   - After running the command, they must restart Claude Code for the changes to take effect
   - They can verify the installation with `claude mcp list`
+  - If the MCP proxy version seems outdated or behaves unexpectedly, clear the npx cache and retry:
+    ```
+    npx clear-npx-cache
+    ```
 

--- a/.github/plugins/dataverse/skills/python-sdk/SKILL.md
+++ b/.github/plugins/dataverse/skills/python-sdk/SKILL.md
@@ -21,7 +21,7 @@ Use the official Microsoft Power Platform Dataverse Client Python SDK for data o
 **Status:** Preview — breaking changes are possible
 
 ```
-pip install PowerPlatform-Dataverse-Client
+pip install --upgrade PowerPlatform-Dataverse-Client
 ```
 
 ---
@@ -475,7 +475,7 @@ For interactive analysis with visualizations.
 ### Prerequisites
 
 ```bash
-pip install PowerPlatform-Dataverse-Client pandas matplotlib seaborn azure-identity
+pip install --upgrade PowerPlatform-Dataverse-Client pandas matplotlib seaborn azure-identity
 ```
 
 ### Notebook structure

--- a/.github/plugins/dataverse/skills/setup/SKILL.md
+++ b/.github/plugins/dataverse/skills/setup/SKILL.md
@@ -52,7 +52,7 @@ If `pac` works directly in your shell, skip the PowerShell wrapper — it's only
 
 After Python is confirmed available:
 ```
-pip install azure-identity requests PowerPlatform-Dataverse-Client
+pip install --upgrade azure-identity requests PowerPlatform-Dataverse-Client
 ```
 
 If `winget` is unavailable:


### PR DESCRIPTION
## Summary
- Added `--upgrade` flag to all `pip install` commands across **setup**, **python-sdk** skills, and the **auth.py** error message — ensures users always get the latest `PowerPlatform-Dataverse-Client` (preview, frequently updated) and `azure-identity` (security patches)
- Added `npx clear-npx-cache` troubleshooting tip to **mcp-configure** for cases where the MCP proxy version is stale

## Why
Without `--upgrade`, `pip install` silently skips if any version is already installed. Users on older SDK versions hit bugs that are already fixed upstream but never see the update.

## Test plan
- [ ] Run `pip install --upgrade PowerPlatform-Dataverse-Client` and confirm it pulls latest from PyPI
- [ ] Run plugin init flow from scratch and verify packages are installed at latest versions
- [ ] Verify `npx clear-npx-cache` resolves stale MCP proxy issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)