### PR TITLE
Add CODEOWNERS for maintainer approval

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,8 @@
+# CODEOWNERS for Dataverse Skills
+# This file defines who gets automatically requested for review when PRs are opened.
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Global ownership - fallback for any files not covered by more specific rules
+* @microsoft/dataverse-skills-maintainers
+#   Team is found here:
+#   https://github.com/orgs/microsoft/teams/dataverse-skills-maintainers


### PR DESCRIPTION
## Summary
- Add `CODEOWNERS` file requiring `@microsoft/dataverse-skills-maintainers` team approval on all PRs
- Matches the pattern used by [PowerPlatform-DataverseClient-Python](https://github.com/microsoft/PowerPlatform-DataverseClient-Python/blob/main/CODEOWNERS)

## Prerequisites (manual steps)
1. Create the `dataverse-skills-maintainers` team at https://github.com/orgs/microsoft/teams
2. Grant the team **Write** access to this repo
3. Add maintainers as team members

The org ruleset already enforces `require_code_owner_review: true`, so once this file is on `main` and the team exists, every PR will require approval from a team member.

## Test plan
- [ ] Create the GitHub team before merging
- [ ] After merge, verify new PRs show the team as required reviewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)