### PR TITLE
Enforce MCP → SDK → Web API tool priority across all skills

### DIFF
--- a/.github/plugins/dataverse/scripts/auth.py
+++ b/.github/plugins/dataverse/scripts/auth.py
@@ -18,15 +18,15 @@ Functions:
   get_token(scope=None) — returns a raw access token string
 
 Usage:
-    # For Web API scripts that need a Bearer token:
-    from auth import get_token, load_env
-    token = get_token()
-
-    # For scripts using the Dataverse Python SDK:
+    # PREFERRED — use the Python SDK for all supported operations:
     from auth import get_credential, load_env
     from PowerPlatform.Dataverse.client import DataverseClient
     load_env()
     client = DataverseClient(os.environ["DATAVERSE_URL"], get_credential())
+
+    # ONLY for operations the SDK does NOT support (forms, views, $ref, $apply):
+    from auth import get_token, load_env
+    token = get_token()
 
 Reads from .env in the repo root (parent of scripts/) or current working directory:
     DATAVERSE_URL      — required

--- a/.github/plugins/dataverse/skills/init/SKILL.md
+++ b/.github/plugins/dataverse/skills/init/SKILL.md
@@ -383,14 +383,14 @@ rm ./solutions/<SOLUTION_NAME>.zip
 If the user wants sample data for testing (accounts, contacts, opportunities), use the built-in Dataverse sample data feature:
 
 ```python
+import os, urllib.request
 from PowerPlatform.Dataverse.client import DataverseClient
 from auth import get_credential, load_env
-import requests, os
 
 load_env()
 env_url = os.environ["DATAVERSE_URL"].rstrip("/")
 
-# Check if already installed
+# Check if already installed (SDK)
 client = DataverseClient(base_url=env_url, credential=get_credential())
 pages = client.records.get(
     "organization",
@@ -401,19 +401,21 @@ orgs = [o for page in pages for o in page]
 if orgs and orgs[0].get("sampledataimported"):
     print("Demo data is already installed.")
 else:
-    # Install via Web API action (SDK doesn't support unbound actions)
+    # Web API required — SDK does not support unbound actions
     from auth import get_token
     token = get_token()
-    resp = requests.post(
+    req = urllib.request.Request(
         f"{env_url}/api/data/v9.2/InstallSampleData",
+        data=b"{}",
         headers={
             "Authorization": f"Bearer {token}",
             "OData-MaxVersion": "4.0",
             "OData-Version": "4.0",
             "Content-Type": "application/json",
         },
+        method="POST",
     )
-    resp.raise_for_status()
+    urllib.request.urlopen(req)
     print("Demo data installation started. Takes 2-10 minutes.")
 ```
 

--- a/.github/plugins/dataverse/skills/init/SKILL.md
+++ b/.github/plugins/dataverse/skills/init/SKILL.md
@@ -262,10 +262,11 @@ Both should succeed without error. Confirm the environment URL in the output mat
 
 ### 9. Configure MCP server (if not already configured)
 
-**Skip this step entirely** if any of the following are true:
+**Skip this step** if MCP is already configured:
 - `.mcp.json` already exists and contains a Dataverse server entry
 - `claude mcp list` shows a `dataverse-*` server already registered
-- The user's immediate task does not require MCP (e.g., they asked to create tables, import data, or build a solution — all of which use the SDK or PAC CLI, not MCP) **and** the user has not explicitly mentioned MCP or asked to connect via MCP
+
+**Defer (but don't skip)** if the user's immediate task can proceed without MCP (e.g., schema creation via SDK, solution import via PAC CLI). Complete the task first, then offer to configure MCP — it makes future conversational queries (reads, simple CRUD) much faster.
 
 If MCP is needed and not yet configured, use the `dataverse-mcp-configure` skill. **This is always the last step** because `claude mcp add` requires a Claude Code restart, which ends the current session.
 

--- a/.github/plugins/dataverse/skills/metadata/SKILL.md
+++ b/.github/plugins/dataverse/skills/metadata/SKILL.md
@@ -33,9 +33,18 @@ The only time you write files directly is when editing something that already ex
 
 ## Creating a Table
 
-**SDK approach (preferred for simple tables):**
+**ALWAYS use the SDK unless you need full control over OwnershipType, HasActivities, or other advanced properties.** Do NOT use `requests` or `urllib` for table creation when the SDK can handle it.
+
+**SDK approach (use this by default):**
 
 ```python
+from auth import get_credential, load_env
+from PowerPlatform.Dataverse.client import DataverseClient
+import os
+
+load_env()
+client = DataverseClient(os.environ["DATAVERSE_URL"], get_credential())
+
 info = client.tables.create(
     "new_ProjectBudget",
     {"new_Amount": "decimal", "new_Description": "string"},
@@ -45,7 +54,7 @@ info = client.tables.create(
 print(f"Created: {info['table_schema_name']}")
 ```
 
-**Web API approach (needed for full control — OwnershipType, HasActivities, etc.):**
+**Web API fallback (ONLY when you need OwnershipType, HasActivities, or other properties the SDK doesn't expose):**
 
 ```python
 # Helper for Label boilerplate

--- a/.github/plugins/dataverse/skills/overview/SKILL.md
+++ b/.github/plugins/dataverse/skills/overview/SKILL.md
@@ -52,13 +52,21 @@ All scripts, data operations, and automation MUST use **Python**. This plugin's 
 
 If you find yourself about to run `npm` or create a `package.json`, STOP. You are going off-rails. Re-read the python-sdk skill.
 
-### 2. Use the SDK, Not Raw HTTP
+### 2. Use the SDK, Not Raw HTTP — MANDATORY
 
-For data operations (CRUD, bulk, queries) and schema operations (table/column/relationship creation), use the Python Dataverse SDK — not raw `requests`/`urllib` calls. The SDK handles auth, URL encoding, pagination, retries, and batching. See the python-sdk skill for correct patterns.
+**NEVER use `requests`, `urllib`, or raw HTTP calls when the Python SDK supports the operation.** This is the most common mistake agents make. Before writing ANY script, check the SDK-first checklist below.
 
-**This includes publisher and solution records** — they are standard Dataverse tables. Use `client.records.create("publisher", {...})` and `client.records.create("solution", {...})`, not raw HTTP.
+**SDK-first checklist — evaluate EVERY time you write a script:**
+- Creating/reading/updating/deleting records? → `client.records.create()`, `.get()`, `.update()`, `.delete()`
+- Creating tables or columns? → `client.tables.create()`
+- Creating relationships? → `client.tables.create_lookup_field()` or `client.tables.create_many_to_many_relationship()`
+- Creating publishers or solutions? → `client.records.create("publisher", {...})`, `client.records.create("solution", {...})`
+- Bulk operations? → `client.records.create(table, [list_of_dicts])`
+- Querying with $select/$filter/$expand? → `client.records.get()` with `select=`, `filter=`, `expand=`
 
-Only fall back to raw Web API for: forms, views, global option sets, N:N `$ref` associations, N:N `$expand`, `$apply` aggregation, memo columns, and unbound actions.
+**If you are about to write `import requests` or `from auth import get_token` in a script, STOP.** Ask yourself: does the SDK support this operation? If yes, use `from auth import get_credential` + `DataverseClient` instead. The `get_token()` function exists ONLY for the narrow set of operations the SDK does not support.
+
+**Raw Web API is ONLY acceptable for:** forms, views, global option sets, N:N `$ref` associations, N:N `$expand`, `$apply` aggregation, memo columns, and unbound actions. Everything else MUST use the SDK.
 
 **Field casing:** `$select`/`$filter` use lowercase logical names (`new_name`). `$expand` and `@odata.bind` use Navigation Property Names that are case-sensitive and must match `$metadata` (e.g., `new_AccountId`). Getting this wrong causes 400 errors. The SDK handles this correctly for `@odata.bind` keys.
 

--- a/.github/plugins/dataverse/skills/overview/SKILL.md
+++ b/.github/plugins/dataverse/skills/overview/SKILL.md
@@ -52,11 +52,13 @@ All scripts, data operations, and automation MUST use **Python**. This plugin's 
 
 If you find yourself about to run `npm` or create a `package.json`, STOP. You are going off-rails. Re-read the python-sdk skill.
 
-### 2. Use the SDK, Not Raw HTTP — MANDATORY
+### 2. MCP → SDK → Web API (in that order)
 
-**NEVER use `requests`, `urllib`, or raw HTTP calls when the Python SDK supports the operation.** This is the most common mistake agents make. Before writing ANY script, check the SDK-first checklist below.
+**Before writing ANY code, ask: can MCP handle this?** If MCP tools are available in your tool list (`list_tables`, `describe_table`, `read_query`, `create_record`, etc.) and the task is a simple read, query, or small CRUD operation (≤10 records), **use MCP — no script needed.** Examples: "how many accounts have 'jeff' in the name?", "show me the columns on the contact table", "create an account named Contoso."
 
-**SDK-first checklist — evaluate EVERY time you write a script:**
+**If MCP can't handle it** (bulk operations, schema creation, multi-step workflows, analytics, or MCP tools aren't available), **use the Python SDK — not raw HTTP.** This is the most common mistake agents make.
+
+**SDK checklist — evaluate EVERY time you write a script:**
 - Creating/reading/updating/deleting records? → `client.records.create()`, `.get()`, `.update()`, `.delete()`
 - Creating tables or columns? → `client.tables.create()`
 - Creating relationships? → `client.tables.create_lookup_field()` or `client.tables.create_many_to_many_relationship()`
@@ -66,7 +68,7 @@ If you find yourself about to run `npm` or create a `package.json`, STOP. You ar
 
 **If you are about to write `import requests` or `from auth import get_token` in a script, STOP.** Ask yourself: does the SDK support this operation? If yes, use `from auth import get_credential` + `DataverseClient` instead. The `get_token()` function exists ONLY for the narrow set of operations the SDK does not support.
 
-**Raw Web API is ONLY acceptable for:** forms, views, global option sets, N:N `$ref` associations, N:N `$expand`, `$apply` aggregation, memo columns, and unbound actions. Everything else MUST use the SDK.
+**Raw Web API is ONLY acceptable for:** forms, views, global option sets, N:N `$ref` associations, N:N `$expand`, `$apply` aggregation, memo columns, and unbound actions. Everything else MUST use MCP (if available) or the SDK.
 
 **Field casing:** `$select`/`$filter` use lowercase logical names (`new_name`). `$expand` and `@odata.bind` use Navigation Property Names that are case-sensitive and must match `$metadata` (e.g., `new_AccountId`). Getting this wrong causes 400 errors. The SDK handles this correctly for `@odata.bind` keys.
 
@@ -152,7 +154,7 @@ Understanding the real limits of each tool prevents hallucinated paths. This is 
 | **Azure CLI** | App registrations, service principals, credential management | Dataverse-specific operations |
 | **GitHub CLI** | Repo management, GitHub secrets, Actions workflow status | Dataverse-specific operations |
 
-**When in doubt:** MCP tools not in your tool list? → Load `dataverse-mcp-configure` to set them up (see below). MCP for conversational data work (single records, simple queries) → Python SDK for scripted data, bulk operations, schema creation, and analysis → Web API for metadata the SDK doesn't cover (forms, views, option sets) → PAC CLI for solution lifecycle.
+**Tool priority (always follow this order):** MCP (if available) for simple reads, queries, and ≤10 record CRUD → Python SDK for scripted data, bulk operations, schema creation, and analysis → Web API for operations the SDK doesn't cover (forms, views, option sets) → PAC CLI for solution lifecycle. MCP tools not in your tool list? → Load `dataverse-mcp-configure` to set them up (see below).
 
 **Volume guidance:** MCP `create_record` is fine for 1–10 records. For 10+ records, use Python SDK `client.records.create(table, list_of_dicts)` — it uses `CreateMultiple` internally and handles batching. For data profiling and analytics beyond simple GROUP BY, use Python with pandas (see python-sdk skill). For aggregation queries (`$apply`), use the Web API directly.
 
@@ -162,13 +164,17 @@ Note: The Python SDK is in **preview** — breaking changes possible.
 
 If the user's request involves MCP — either explicitly ("connect via MCP", "use MCP", "query via MCP") or implicitly (conversational data queries where MCP would be the natural tool) — check whether Dataverse MCP tools are available in your current tool list (e.g., `list_tables`, `describe_table`, `read_query`, `create_record`).
 
-**If MCP tools are NOT available:**
+**If MCP tools are NOT available and the user explicitly asked for MCP:**
 1. **Do NOT silently fall back** to the Python SDK or Web API
 2. Tell the user: "Dataverse MCP tools aren't configured in this session yet."
 3. Load the `dataverse-mcp-configure` skill to set up the MCP server
 4. After MCP is configured, **stop here** — the session must be restarted for MCP tools to appear (if running in Claude Code, remind them to resume the session correctly: "Remember to **use `claude --continue` to resume the session** without losing context"). Do not fall back to the SDK or proceed with other tools. Wait for the user to restart and come back.
 
-**If MCP tools ARE available**, proceed normally with the user's task.
+**If MCP tools are NOT available and the user asked a simple data question** (e.g., "how many accounts with 'jeff'?"):
+1. Answer the question using the Python SDK (don't block the user)
+2. After answering, suggest: "This would be even simpler with MCP configured — want me to set that up?"
+
+**If MCP tools ARE available**, prefer MCP for simple reads/queries/small CRUD. Use the SDK only when a script is needed.
 
 ---
 

--- a/.github/plugins/dataverse/skills/python-sdk/SKILL.md
+++ b/.github/plugins/dataverse/skills/python-sdk/SKILL.md
@@ -26,6 +26,33 @@ pip install --upgrade PowerPlatform-Dataverse-Client
 
 ---
 
+## SDK-First Rule — Read This Before Writing ANY Script
+
+**If an operation is in the "supports" list below, you MUST use the SDK — not `urllib`, `requests`, or raw HTTP.** This is non-negotiable.
+
+**Before writing any Dataverse script, use this decision flow:**
+
+1. Does the operation involve records (CRUD, queries, bulk)? → **Use the SDK**
+2. Does it involve tables, columns, or relationships? → **Use the SDK**
+3. Does it involve publishers or solutions? → **Use the SDK** (these are standard Dataverse tables)
+4. Does it involve forms, views, option sets, N:N `$ref`, or `$apply`? → **Use raw Web API** (SDK doesn't support these)
+
+**Correct imports for SDK scripts:**
+```python
+from auth import get_credential, load_env
+from PowerPlatform.Dataverse.client import DataverseClient
+```
+
+**WRONG — do NOT use for SDK-supported operations:**
+```python
+from auth import get_token, load_env  # WRONG for SDK-supported ops
+import requests  # WRONG for SDK-supported ops
+```
+
+`get_token()` and `requests` exist ONLY for the narrow set of operations listed in "What This SDK Does NOT Support" below.
+
+---
+
 ## What This SDK Supports
 
 - Data CRUD: create, read, update, delete records
@@ -34,30 +61,26 @@ pip install --upgrade PowerPlatform-Dataverse-Client
 - OData queries: `select`, `filter`, `orderby`, `expand`, `top`, paging
 - SQL queries (read-only, via Web API `?sql=` parameter)
 - Table create, delete, and metadata (`tables.get()`, `tables.list()`)
-- Relationship metadata: create/delete 1:N and N:N relationship definitions
+- Relationship metadata: create/delete 1:N and N:N relationship **definitions** (schema-level)
 - Alternate key management
 - File column uploads (chunked for files >128MB)
 - Context manager support with HTTP connection pooling
 
 ## What This SDK Does NOT Support
 
+These are the ONLY operations where raw Web API (`get_token()` + `urllib`/`requests`) is acceptable:
+
 - **Forms** (FormXml) — use the Web API directly (see `dataverse-metadata`)
 - **Views** (SavedQueries) — use the Web API directly
-- **Option sets** — use the Web API directly
-- **N:N record association** ($ref linking for N:N data, e.g., role assignments) — use the Web API directly
+- **Global option sets** — use the Web API directly
+- **N:N record association** (linking two records at runtime via `$ref` POST — distinct from N:N relationship *creation*, which the SDK handles)
+- **N:N `$expand`** (collection-valued navigation) — use the Web API directly
+- **`$apply` aggregation** — use the Web API directly (or pull data with SDK + pandas)
+- **Memo columns** — use the Web API directly
+- **Unbound actions** (e.g., `InstallSampleData`) — use the Web API directly
 - DeleteMultiple, general OData batching
 
-For anything not in the "supports" list above, write a Web API script using `scripts/auth.py` for token acquisition.
-
-### SDK-First Rule
-
-**If an operation is in the "supports" list, you MUST use the SDK — not `urllib`, `requests`, or raw HTTP.** This applies to:
-- **All record CRUD** (create, read, update, delete) — use `client.records.create()`, `.get()`, `.update()`, `.delete()`
-- **All queries** with `$select`, `$filter`, `$orderby`, `$expand` on 1:N lookups — use `client.records.get()` with `select=`, `filter=`, `expand=`, `orderby=`
-- **Bulk operations** — pass a list to `client.records.create(table, [list])` instead of looping with individual HTTP POSTs
-- **Publisher and solution records** — these are standard Dataverse tables; use `client.records.create("publisher", {...})` and `client.records.create("solution", {...})`
-
-Raw HTTP is only acceptable for: forms, views, option sets, N:N `$ref` associations, N:N `$expand`, `$apply` aggregation, memo columns, and unbound actions.
+For anything not in this list, **use the SDK**. For anything in this list, use `scripts/auth.py` `get_token()` for token acquisition.
 
 ### Field Name Casing Rule
 
@@ -313,14 +336,14 @@ for page in client.records.get(
 
 > **Important:** `expand` uses the navigation property name (case-sensitive, e.g., `new_AccountId`), not the lowercase logical name (`new_accountid`). Using lowercase causes a 400 error.
 
-### $expand on N:N relationships
+### $expand on N:N relationships (Web API only)
 
-N:N expand uses the relationship navigation property name (found in the ManyToManyRelationships metadata). The SDK does **not** support `$expand` on N:N collection-valued navigation properties in multi-record queries. For N:N traversal, use the Web API directly:
+The SDK does **not** support `$expand` on N:N collection-valued navigation properties. This is one of the few cases where raw Web API is required:
 
 ```python
-# Fall back to Web API for N:N expand
+# Web API required — SDK does not support N:N $expand
 import urllib.request, json
-from auth import get_token
+from auth import get_token  # get_token() is correct here — SDK can't do this
 
 token = get_token()
 url = f"{env}/api/data/v9.2/new_projectdocuments?$select=new_title&$expand=new_ProjectBudget_Documents($select=new_name)"
@@ -422,14 +445,15 @@ Before bulk-creating records in a **system table** (account, contact, opportunit
 
 ---
 
-## Aggregation Queries (Web API $apply)
+## Aggregation Queries
 
-The SDK does not support OData `$apply` for aggregation. Use the Web API directly for GROUP BY, COUNT, SUM, AVG, etc.:
+For simple aggregation, pull data with the SDK and use pandas (preferred). For server-side `$apply` aggregation, the SDK does not support it — use the Web API:
 
 ```python
+# Web API required — SDK does not support $apply
 import os, json, urllib.request
 sys.path.insert(0, os.path.join(os.getcwd(), "scripts"))
-from auth import get_token, load_env
+from auth import get_token, load_env  # get_token() is correct here — SDK can't do this
 
 load_env()
 env = os.environ["DATAVERSE_URL"].rstrip("/")

--- a/.github/plugins/dataverse/skills/python-sdk/SKILL.md
+++ b/.github/plugins/dataverse/skills/python-sdk/SKILL.md
@@ -26,16 +26,21 @@ pip install --upgrade PowerPlatform-Dataverse-Client
 
 ---
 
-## SDK-First Rule — Read This Before Writing ANY Script
+## Before Writing ANY Script — Check MCP First
+
+**If MCP tools are available** (`list_tables`, `describe_table`, `read_query`, `create_record`) and the task is a simple query, single-record read, or small CRUD (≤10 records), **use MCP directly — no script needed.** Only write a Python script when the task requires bulk operations, multi-step logic, schema creation, or analytics.
+
+## SDK-First Rule — When You DO Write a Script
 
 **If an operation is in the "supports" list below, you MUST use the SDK — not `urllib`, `requests`, or raw HTTP.** This is non-negotiable.
 
-**Before writing any Dataverse script, use this decision flow:**
+**Decision flow:**
 
-1. Does the operation involve records (CRUD, queries, bulk)? → **Use the SDK**
-2. Does it involve tables, columns, or relationships? → **Use the SDK**
-3. Does it involve publishers or solutions? → **Use the SDK** (these are standard Dataverse tables)
-4. Does it involve forms, views, option sets, N:N `$ref`, or `$apply`? → **Use raw Web API** (SDK doesn't support these)
+1. Can MCP handle this without a script? → **Use MCP** (simple reads, queries, ≤10 record CRUD)
+2. Does the operation involve records (CRUD, queries, bulk)? → **Use the SDK**
+3. Does it involve tables, columns, or relationships? → **Use the SDK**
+4. Does it involve publishers or solutions? → **Use the SDK** (these are standard Dataverse tables)
+5. Does it involve forms, views, option sets, N:N `$ref`, or `$apply`? → **Use raw Web API** (SDK doesn't support these)
 
 **Correct imports for SDK scripts:**
 ```python

--- a/.github/plugins/dataverse/skills/solution/SKILL.md
+++ b/.github/plugins/dataverse/skills/solution/SKILL.md
@@ -241,14 +241,14 @@ pages = client.records.get(
 views = [v for page in pages for v in page]
 ```
 
-### Check a user's role assignment
+### Check a user's role assignment (Web API only)
 
-N:N `$expand` (like `systemuserroles_association`) is not supported by the SDK. Use the Web API:
+N:N `$expand` (like `systemuserroles_association`) is not supported by the SDK. This is one of the few cases where raw Web API is required:
 
 ```python
-# Web API fallback for N:N expand
+# Web API required — SDK does not support N:N $expand
 import urllib.request, json
-from auth import get_token
+from auth import get_token  # get_token() is correct here — SDK can't do this
 
 token = get_token()
 url = f"{env}/api/data/v9.2/systemusers?$filter=internalemailaddress eq '<email>'&$select=fullname&$expand=systemuserroles_association($select=name)&$top=1"


### PR DESCRIPTION
## Summary
- Establishes a consistent **MCP → SDK → Web API** tool priority across all plugin skills
- When MCP tools are available and the task is a simple read/query/small CRUD (≤10 records), agents use MCP directly — no script needed
- When a script is needed, agents MUST use the Python SDK — not `requests`/`urllib` — for all SDK-supported operations
- Raw Web API is only acceptable for the narrow set of unsupported operations (forms, views, option sets, N:N `$ref`, `$apply`, etc.)

## Why
In live testing, agents defaulted to writing Python scripts with raw HTTP for operations that either (a) MCP could handle with zero code, or (b) the SDK fully supports. The existing guidance wasn't strong enough to steer agents toward the simplest tool for the job.

## Files changed
| File | Change |
|---|---|
| `skills/overview/SKILL.md` | Rule #2 → "MCP → SDK → Web API", MCP-first check, split MCP availability handling |
| `skills/python-sdk/SKILL.md` | "Check MCP First" section, MCP as step 1 in decision flow, clarified supported/unsupported lists |
| `skills/metadata/SKILL.md` | SDK is default for table creation, Web API is fallback only |
| `skills/solution/SKILL.md` | Web API examples labeled with SDK-unsupported justification |
| `skills/init/SKILL.md` | MCP setup changed from "skip" to "defer", replaced `requests` with `urllib` for unbound action |
| `scripts/auth.py` | SDK usage shown first in docstring |

## Test plan
- [ ] With MCP configured, ask "how many accounts have 'jeff' in the name?" — verify agent uses MCP `read_query`, not a Python script
- [ ] Without MCP, ask the same — verify agent uses SDK, then suggests MCP setup
- [ ] Ask agent to create a publisher + solution — verify it uses SDK, not raw HTTP
- [ ] Ask agent to check user roles (N:N `$expand`) — verify it correctly uses Web API with justification

🤖 Generated with [Claude Code](https://claude.com/claude-code)