### PR TITLE
Add safety and guardrails documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ The plugin is designed around a least-privilege model — it cannot exceed the p
 - **No data leaves your tenant** — all operations call the Dataverse Web API directly within your Microsoft tenant
 - **Multi-layer authorization** — requires developer auth, tenant admin consent, and per-environment allowlisting before any operation is possible
 - **Security role enforcement** — every API call is authorized server-side by Dataverse; the plugin cannot bypass or escalate permissions
-- **No telemetry** — the plugin does not phone home; no usage data is transmitted externally
+- **No plugin telemetry** — the plugin does not collect or transmit usage analytics; data flows only to Dataverse within your tenant and to the AI host (Claude or Copilot) as part of normal operation
 - **Token security** — credentials are stored in your OS native credential store or held in memory only; never passed to external services
 
 For the full safety model — including confirmation flows, logging, irreversible operation handling, and planned improvements — see [docs/safety-and-guardrails.md](docs/safety-and-guardrails.md).

--- a/README.md
+++ b/README.md
@@ -88,6 +88,18 @@ To install the local version directly without marketplace registration:
 copilot plugin install <path/to/repo>/.github/plugins/dataverse
 ```
 
+## Safety & Security
+
+The plugin is designed around a least-privilege model — it cannot exceed the permissions of the authenticated user. Key safeguards:
+
+- **No data leaves your tenant** — all operations call the Dataverse Web API directly within your Microsoft tenant
+- **Multi-layer authorization** — requires developer auth, tenant admin consent, and per-environment allowlisting before any operation is possible
+- **Security role enforcement** — every API call is authorized server-side by Dataverse; the plugin cannot bypass or escalate permissions
+- **No telemetry** — the plugin does not phone home; no usage data is transmitted externally
+- **Token security** — credentials are stored in your OS native credential store or held in memory only; never passed to external services
+
+For the full safety model — including confirmation flows, logging, irreversible operation handling, and planned improvements — see [docs/safety-and-guardrails.md](docs/safety-and-guardrails.md).
+
 ## Contributing
 
 We welcome contributions — new skills, improvements to existing ones, and bug fixes. See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.

--- a/README.md
+++ b/README.md
@@ -92,8 +92,7 @@ copilot plugin install <path/to/repo>/.github/plugins/dataverse
 
 The plugin is designed around a least-privilege model — it cannot exceed the permissions of the authenticated user. Key safeguards:
 
-- **No data leaves your tenant** — all operations call the Dataverse Web API directly within your Microsoft tenant
-- **Multi-layer authorization** — requires developer auth, tenant admin consent, and per-environment allowlisting before any operation is possible
+- **MCP authorization** — MCP access requires developer auth, tenant admin consent, and per-environment allowlisting; other plugin tools (SDK, PAC CLI) authenticate directly
 - **Security role enforcement** — every API call is authorized server-side by Dataverse; the plugin cannot bypass or escalate permissions
 - **No plugin telemetry** — the plugin does not collect or transmit usage analytics; data flows only to Dataverse within your tenant and to the AI host (Claude or Copilot) as part of normal operation
 - **Token security** — credentials are stored in your OS native credential store or held in memory only; never passed to external services

--- a/docs/safety-and-guardrails.md
+++ b/docs/safety-and-guardrails.md
@@ -1,0 +1,174 @@
+# Safety & Guardrails
+
+How the Dataverse plugin protects your data, respects your permissions, and keeps you in control.
+
+---
+
+## Supported Operations
+
+| Category | Operations | Notes |
+|---|---|---|
+| **Read / Query** | Query records, describe tables and columns, list tables, keyword search, explore schema metadata | Always available to any authenticated user with read privileges |
+| **Create** | Create records, tables, columns, relationships, forms, views | Requires appropriate Dataverse security role |
+| **Update** | Update records, modify schema, edit forms and views | Requires appropriate Dataverse security role |
+| **Import / Export** | CSV import with lookup resolution, solution export and import, bulk data operations | Bulk operations batched automatically via SDK |
+| **Delete** | Delete records, tables, columns, relationships | Requires appropriate Dataverse security role |
+
+## Authentication
+
+The plugin supports two authentication methods:
+
+### Interactive login (recommended for developers)
+
+- Uses Azure Identity **device code flow** — you sign in via your browser
+- Tokens are cached in your OS credential store (Windows Credential Manager, macOS Keychain, or Linux libsecret)
+- Silent token refresh on subsequent sessions — no repeated sign-in prompts
+- Tokens are scoped to the specific Dataverse environment
+
+### Service principal (recommended for CI/CD)
+
+- Uses client ID and client secret for non-interactive authentication
+- Tokens are held in memory only — not persisted to disk
+- Configured via environment variables
+
+### Multi-layer MCP authorization
+
+Access to Dataverse through the plugin requires three independent authorization layers:
+
+| Layer | Who approves | When | What it controls |
+|---|---|---|---|
+| **Developer auth** | Developer (you) | First use, then cached | Can this person access Dataverse? |
+| **Tenant admin consent** | Global Admin | One-time per tenant | Can MCP clients be used in this tenant? |
+| **Environment allowlist** | Environment Admin | One-time per environment | Can MCP clients be used in this specific environment? |
+
+Each layer can be independently revoked without affecting the others.
+
+## Least-Privilege & Security Role Enforcement
+
+The plugin **cannot exceed the permissions of the authenticated user**. Every API call respects the caller's Dataverse security roles:
+
+- **Read access** is determined by entity-level read privileges
+- **Write access** is determined by entity-level create, update, and delete privileges
+- **Field-level security** is applied automatically
+- **Ownership-based sharing** is respected
+- If the caller lacks permission, the operation fails with a clear error — the plugin does not attempt to bypass or escalate
+
+Role enforcement is handled server-side by Dataverse itself. The plugin is a passthrough — it adds guidance and guardrails, but authorization decisions are made by the platform.
+
+## Confirmation & Approval Steps
+
+Safety is enforced at two levels: **platform-level** controls that are always on, and **agent-level** guardrails defined in the plugin's skill instructions that guide Claude and Copilot behavior.
+
+### Platform-level (always enforced)
+
+- **Dataverse security roles** — every API call is authorized server-side by Dataverse (see [Least-Privilege](#least-privilege--security-role-enforcement) above).
+- **Multi-layer MCP authorization** — requires developer auth, tenant admin consent, and per-environment allowlisting before any operation is possible (see [Authentication](#authentication) above).
+
+### Agent-level (enforced via skill instructions)
+
+The plugin's skill definitions instruct AI agents (Claude, Copilot) to follow these mandatory confirmation steps. These are not hard-coded gates in the proxy — they are behavioral rules the agent follows from the skill instructions.
+
+#### 1. Environment confirmation
+
+Before the first operation that touches a specific environment, the agent:
+
+1. Shows the environment URL you are about to modify
+2. Asks for explicit confirmation: *"I'm about to make changes to `<environment URL>`. Is this the correct target environment?"*
+3. Runs `pac org who` to verify the active connection matches
+4. **Does not proceed until you explicitly confirm**
+
+Once confirmed for an environment in a session, re-confirmation is not required for subsequent operations against that same environment.
+
+#### 2. Solution confirmation (before schema changes)
+
+Before creating tables, columns, or forms, the agent asks which solution the components should belong to. Creating metadata outside a solution means components cannot be cleanly exported or deployed.
+
+#### 3. Publisher prefix confirmation
+
+Publisher prefixes are permanent on all components. The agent queries existing publishers in your environment and asks you to choose before proceeding.
+
+## Irreversible Operations
+
+Some operations require extra care because they are difficult or impossible to reverse:
+
+| Operation | Risk | Safeguard |
+|---|---|---|
+| Table deletion | Cascades to columns, forms, views, and plugins | Platform requires appropriate security role; no agent-level confirmation currently implemented |
+| Environment deletion | Permanent | Requires admin permissions via PAC CLI (platform-enforced) |
+| Solution import to production | Affects all users in the environment | Post-import validation queries provided by skill to verify components are live (skill-enforced) |
+| Bulk operations | Affects many records at once | SDK uses `CreateMultiple`/`UpdateMultiple` internally with automatic batching (code-enforced) |
+
+## Data Handling & Residency
+
+### Your data stays in your tenant
+
+- All operations call the Dataverse Web API directly within your Microsoft tenant
+- The MCP proxy is intentionally thin — no business logic executes outside the governed Dataverse perimeter
+- Tool execution, billing, and access control happen server-side within Dataverse
+- **No customer data is stored or transmitted outside your tenant**
+
+### Token security
+
+- Interactive login tokens: stored in your OS native credential store
+- Service principal tokens: held in memory only, never persisted
+- Tokens are scoped to your Dataverse environment and are not passed to external services
+
+### External dependencies
+
+All dependencies execute locally on your machine:
+
+| Dependency | Source | Execution |
+|---|---|---|
+| MCP Proxy (.NET) | Self-contained npm package | Local |
+| Python SDK | Open source (MIT) | Local |
+| Azure Identity | Microsoft first-party library | Local, uses OS credential store |
+| PAC CLI | Microsoft first-party tool | Local |
+
+## Logging & Auditability
+
+### Client-side logging (local to your machine)
+
+The MCP proxy and Python SDK produce logs that stay on your machine:
+
+- Tool execution calls and authentication flow events
+- HTTP request metadata (URLs, status codes)
+- Errors and validation failures
+- Log verbosity is configurable (Trace, Debug, Information, Warning, Error, Critical)
+- Optional file logging to your local temp directory via `--log-file`
+
+Client-side logs do **not** capture customer data records, credentials, or personal information.
+
+### Server-side logging (Dataverse platform)
+
+Every API call the plugin makes reaches Dataverse via HTTP. Once a request hits Dataverse, it is subject to your tenant's standard audit and telemetry policies — the same as any other Dataverse client (model-driven apps, Power Automate, direct API calls). The plugin does not add any additional server-side logging beyond what Dataverse records by default.
+
+For details on Dataverse auditing, see [Microsoft's auditing documentation](https://learn.microsoft.com/en-us/power-platform/admin/manage-dataverse-auditing).
+
+## Telemetry
+
+**The plugin does not phone home.** There is no active usage telemetry. No data about your usage, queries, or environment is transmitted to any external service beyond the Dataverse Web API calls to your own tenant.
+
+Usage metrics are gathered passively through public GitHub repository signals (clone counts, stars, forks) only.
+
+If telemetry is introduced in the future, it will be:
+
+- **Opt-in**, not opt-out
+- Free of PII (no email, username, tenant ID, or environment URL)
+- Not in the authentication code path
+- Documented in the README before activation
+
+## Planned Guardrail Improvements
+
+This document describes the safety model as it exists today. We are actively working on additional hardening, including:
+
+- **Environment classification** — declare environment type (dev/test/staging/prod) at connect time, with restricted operations on production environments by default
+- **Destructive operation confirmation** — explicit confirmation with impact summary before deletes and bulk modifications
+- **Pre-flight impact analysis** — query affected data before schema changes (e.g., "this column has 12,340 non-null values")
+- **Throttle resilience** — graceful handling of Dataverse `429 Retry-After` responses when service protection limits are reached
+- **Dry-run mode** — preview API calls without executing them
+
+If you have feedback on what guardrails matter most to you, [open an issue](https://github.com/microsoft/Dataverse-skills/issues).
+
+## Privacy
+
+This plugin operates under the [Microsoft Privacy Statement](https://go.microsoft.com/fwlink/?LinkId=521839). For security concerns, see [SECURITY.md](../SECURITY.md).

--- a/docs/safety-and-guardrails.md
+++ b/docs/safety-and-guardrails.md
@@ -64,9 +64,9 @@ Safety is enforced at two levels: **platform-level** controls that are always on
 - **Dataverse security roles** — every API call is authorized server-side by Dataverse (see [Least-Privilege](#least-privilege--security-role-enforcement) above).
 - **Multi-layer MCP authorization** — MCP access requires developer auth, tenant admin consent, and per-environment allowlisting (see [Authentication](#authentication) above). Other plugin tools (SDK, Web API, PAC CLI) authenticate directly and are not subject to these controls.
 
-### Agent-level (enforced via skill instructions)
+### Agent-level (guardrails in skill instructions)
 
-The plugin's skill definitions instruct AI agents (Claude, Copilot) to follow these mandatory confirmation steps. These are not hard-coded gates in the proxy — they are behavioral rules the agent follows from the skill instructions.
+The plugin's skill definitions instruct AI agents (Claude, Copilot) to follow these confirmation steps. These are not hard-coded gates in the proxy — they are behavioral rules the agent follows from the skill instructions.
 
 #### 1. Environment confirmation
 

--- a/docs/safety-and-guardrails.md
+++ b/docs/safety-and-guardrails.md
@@ -33,7 +33,7 @@ The plugin supports two authentication methods:
 
 ### Multi-layer MCP authorization
 
-Access to Dataverse through the plugin requires three independent authorization layers:
+Access to Dataverse through MCP specifically requires three independent authorization layers. Note: other tools used by the plugin (Python SDK, Web API, PAC CLI) authenticate directly and are not subject to these MCP-specific controls.
 
 | Layer | Who approves | When | What it controls |
 |---|---|---|---|
@@ -62,7 +62,7 @@ Safety is enforced at two levels: **platform-level** controls that are always on
 ### Platform-level (always enforced)
 
 - **Dataverse security roles** — every API call is authorized server-side by Dataverse (see [Least-Privilege](#least-privilege--security-role-enforcement) above).
-- **Multi-layer MCP authorization** — requires developer auth, tenant admin consent, and per-environment allowlisting before any operation is possible (see [Authentication](#authentication) above).
+- **Multi-layer MCP authorization** — MCP access requires developer auth, tenant admin consent, and per-environment allowlisting (see [Authentication](#authentication) above). Other plugin tools (SDK, Web API, PAC CLI) authenticate directly and are not subject to these controls.
 
 ### Agent-level (enforced via skill instructions)
 
@@ -100,29 +100,11 @@ Some operations require extra care because they are difficult or impossible to r
 
 ## Data Handling & Residency
 
-### Your data stays in your tenant
-
-- All operations call the Dataverse Web API directly within your Microsoft tenant
-- The MCP proxy is intentionally thin — no business logic executes outside the governed Dataverse perimeter
-- Tool execution, billing, and access control happen server-side within Dataverse
-- **No customer data is stored or transmitted outside your tenant**
-
 ### Token security
 
 - Interactive login tokens: stored in your OS native credential store
 - Service principal tokens: held in memory only, never persisted
 - Tokens are scoped to your Dataverse environment and are not passed to external services
-
-### External dependencies
-
-All dependencies execute locally on your machine:
-
-| Dependency | Source | Execution |
-|---|---|---|
-| MCP Proxy (.NET) | Self-contained npm package | Local |
-| Python SDK | Open source (MIT) | Local |
-| Azure Identity | Microsoft first-party library | Local, uses OS credential store |
-| PAC CLI | Microsoft first-party tool | Local |
 
 ## Logging & Auditability
 
@@ -157,15 +139,9 @@ If telemetry is introduced in the future, it will be:
 - Not in the authentication code path
 - Documented in the README before activation
 
-## Planned Guardrail Improvements
+## Areas Under Exploration
 
-This document describes the safety model as it exists today. We are actively working on additional hardening, including:
-
-- **Environment classification** — declare environment type (dev/test/staging/prod) at connect time, with restricted operations on production environments by default
-- **Destructive operation confirmation** — explicit confirmation with impact summary before deletes and bulk modifications
-- **Pre-flight impact analysis** — query affected data before schema changes (e.g., "this column has 12,340 non-null values")
-- **Throttle resilience** — graceful handling of Dataverse `429 Retry-After` responses when service protection limits are reached
-- **Dry-run mode** — preview API calls without executing them
+This document describes the safety model as it exists today. We are exploring ways to further harden the experience, such as environment-tier awareness and improved handling of Dataverse service protection limits. Because the plugin operates through AI agents that we do not fully control, some guardrails can only be influenced via skill instructions rather than enforced deterministically.
 
 If you have feedback on what guardrails matter most to you, [open an issue](https://github.com/microsoft/Dataverse-skills/issues).
 


### PR DESCRIPTION
Public-facing doc covering the plugin's safety model: supported operations, authentication, least-privilege enforcement, confirmation flows, data residency, logging, telemetry policy, irreversible operations, and planned improvements.

Clearly distinguishes platform-enforced controls (Dataverse security roles, MCP authorization layers) from agent-level guardrails (skill instructions).

Adds Safety & Security section to README with key trust signals and link to the full doc.