### PR TITLE
fix: reduce onboarding friction in connect flow

### DIFF
--- a/.github/plugins/dataverse/skills/dv-connect/SKILL.md
+++ b/.github/plugins/dataverse/skills/dv-connect/SKILL.md
@@ -23,13 +23,13 @@ One-step connection to Dataverse. Handles tool installation, authentication, env
 
 ## Step 1: Ensure tools are installed
 
-Check all tools in parallel. Install any that are missing. See [tools-setup.md](references/tools-setup.md) for installation commands and platform-specific notes.
+Check each tool independently — **do not use fail-fast parallel execution.** If one tool check fails, continue checking the others so you can report all missing tools at once. See [tools-setup.md](references/tools-setup.md) for installation commands and platform-specific notes.
 
 | Tool | Check |
 |---|---|
-| PAC CLI | `pac --version` |
 | Python 3 | `python --version` |
 | Git | `git --version` |
+| PAC CLI | `pac` (prints version banner; note: `pac --version` is not a valid command and returns a non-zero exit code) (see [tools-setup.md](references/tools-setup.md) for Windows path discovery if not in PATH) |
 | .NET SDK | `dotnet --version` |
 | Azure CLI | `az --version` |
 
@@ -62,13 +62,15 @@ pac org who
 **If PAC CLI is not authenticated:**
 - Ask: "Do you want to connect to an existing environment or create a new one?"
 
-**To select an existing environment:**
-```
-pac auth select --name <profile-name>
-```
-Or create a new profile:
+**Before selecting, check for tenant/region mismatch.** If the target environment URL uses a different region (e.g., `crm10.dynamics.com` = APAC) than the currently authenticated account's environments, the current auth profile likely belongs to a different tenant. In that case, create a new auth profile for the correct tenant rather than trying `pac org select` (which will fail with "no organization found"):
+
 ```
 pac auth create --name <profile-name> --environment <url>
+```
+
+**To select from existing profiles:**
+```
+pac auth select --name <profile-name>
 ```
 
 **To create a new environment** (requires admin permissions):
@@ -104,10 +106,15 @@ Present authentication options:
 
 Write `.env` directly — do not instruct the user to create it:
 
+Detect the current tool (Claude or Copilot) from context and set `MCP_CLIENT_ID` automatically:
+- Claude (CLI or VSCode extension): `0c412cc3-0dd6-449b-987f-05b053db9457`
+- GitHub Copilot: `aebc6443-996d-45c2-90f0-388ff96faa56`
+
 ```python
 with open(".env", "w") as f:
     f.write(f"DATAVERSE_URL={dataverse_url}\n")
     f.write(f"TENANT_ID={tenant_id}\n")
+    f.write(f"MCP_CLIENT_ID={mcp_client_id}\n")
     f.write(f"SOLUTION_NAME={solution_name}\n")
     f.write(f"PUBLISHER_PREFIX=\n")  # filled in when solution is created
     f.write(f"PAC_AUTH_PROFILE=nonprod\n")
@@ -193,9 +200,11 @@ If MCP is not configured, follow [mcp-configuration.md](references/mcp-configura
 **For Copilot:** Write the JSON config, then:
 > ✅ Dataverse MCP server configured. **Restart your editor** for changes to take effect.
 
-**For Claude:** Run the `claude mcp add` command, then:
-> Restart Claude Code to enable MCP.
+**For Claude:** Run the `claude mcp add` command, then warn the user about the auth popup that will appear on next launch:
+> ✅ Dataverse MCP server registered. Restart Claude Code to enable MCP tools.
 > Remember to **use `claude --continue` to resume the session** without losing context.
+>
+> **On restart, a browser window will open** asking you to sign in to your Dataverse environment. This is the MCP proxy authenticating on your behalf — sign in with the same account you used for PAC CLI (e.g., `{username}`). This only happens once; the token is cached for future sessions.
 
 ---
 

--- a/.github/plugins/dataverse/skills/dv-connect/references/mcp-configuration.md
+++ b/.github/plugins/dataverse/skills/dv-connect/references/mcp-configuration.md
@@ -270,6 +270,8 @@ This is the `SERVER_NAME`.
 
 Generate the CLI command. Do NOT edit any configuration files.
 
+**IMPORTANT: Always use `-t stdio` transport with the npx proxy.** Never use `--transport http` or `--transport sse` for Claude — the Dataverse MCP endpoint requires authentication that only the npx proxy handles. Using HTTP transport directly will fail with connection errors.
+
 **Generate a unique server name** from the `USER_URL`:
 1. Extract the subdomain (organization identifier) from the URL
    - Example: `https://orgbc9a965c.crm10.dynamics.com` → `orgbc9a965c`
@@ -383,10 +385,12 @@ Pause and give the user a chance to restart their editor before proceeding. Do n
 **If TOOL_TYPE is `claude`:**
 
 Run {CLAUDE_COMMAND} to install the Dataverse MCP server, then tell the user:
-> To enable the MCP server, restart Claude Code.
+> ✅ Dataverse MCP server registered. Restart Claude Code to enable MCP tools.
 > Remember to **use `claude --continue` to resume the session** without losing context.
 >
-> After restarting, you will be able to:
+> **On restart, a browser window will open** asking you to sign in to your Dataverse environment. This is the MCP proxy (`@microsoft/dataverse`) authenticating on your behalf. Sign in with the same account you used earlier. This only happens once — the token is cached for future sessions.
+>
+> After signing in, you will be able to:
 > - List all tables in your Dataverse environment
 > - Query records from any table
 > - Create, update, or delete records

--- a/.github/plugins/dataverse/skills/dv-connect/references/tools-setup.md
+++ b/.github/plugins/dataverse/skills/dv-connect/references/tools-setup.md
@@ -6,10 +6,10 @@ Check all in parallel. Install any that are missing.
 
 | Tool | Check | Install |
 |---|---|---|
-| PAC CLI | `pac --version` | `winget install Microsoft.PowerAppsCLI` |
+| PAC CLI | `pac` (prints version banner; `pac --version` is not valid and returns non-zero) | `winget install Microsoft.PowerAppsCLI` |
 | GitHub CLI | `gh --version` | `winget install GitHub.cli` |
 | Azure CLI | `az --version` | `winget install Microsoft.AzureCLI` |
-| .NET SDK | `dotnet --version` | `winget install Microsoft.DotNet.SDK.8` |
+| .NET SDK | `dotnet --version` | `winget install Microsoft.DotNet.SDK.9` |
 | Python 3 | `python --version` | `winget install Python.Python.3.12` |
 | Git | `git --version` | `winget install Git.Git` |
 
@@ -20,13 +20,13 @@ After any `winget` install, the new tool may not be in PATH until the shell is r
 PAC CLI is a `.cmd` wrapper. In Git Bash (used by Claude Code), `pac` alone may fail or hang. Use the PowerShell wrapper:
 
 ```bash
-powershell -Command "& 'C:\Users\$USER\AppData\Local\Microsoft\PowerAppsCLI\pac.cmd' --version"
+powershell -Command "& 'C:\Users\$USER\AppData\Local\Microsoft\PowerAppsCLI\pac.cmd' help"
 ```
 
 Or, if installed via `dotnet tool install --global`:
 
 ```bash
-powershell -Command "& pac --version"
+powershell -Command "& pac help"
 ```
 
 To avoid repeating this, add an alias to `~/.bashrc`:
@@ -145,16 +145,25 @@ Confirm the tenant ID in the output matches your dev tenant before proceeding.
 
 ## PAC CLI PATH setup
 
-Find the path (this may be slow, wait for it to finish):
+If `pac` is not in PATH, check these common Windows install locations in order (fastest first):
 
 ```bash
-find /c/Users/$USER/AppData/Local/Microsoft/PowerAppsCLI -name "pac.exe" 2>/dev/null
-find /c/Users/$USER/.dotnet/tools -name "pac" 2>/dev/null
+# 1. winget install location (most common)
+ls "/c/Users/$USER/AppData/Local/Microsoft/PowerAppsCLI/pac.exe" 2>/dev/null
+
+# 2. dotnet tool install location
+ls "/c/Users/$USER/.dotnet/tools/pac.exe" 2>/dev/null
+
+# 3. nuget global packages (if installed via Microsoft.PowerApps.CLI nuget package)
+ls /c/Users/$USER/.nuget/packages/microsoft.powerapps.cli/*/tools/pac.exe 2>/dev/null
 ```
 
-Add to `~/.bashrc` (for Git Bash / Claude Code):
+Do NOT use `find` or recursive search — it's slow and unnecessary when the install locations are known.
+
+Once found, add to `~/.bashrc` (for Git Bash / Claude Code):
 
 ```bash
-echo 'export PATH="$PATH:/c/Users/$USER/.dotnet/tools"' >> ~/.bashrc
+# Use the directory where pac.exe was found, e.g.:
+echo 'export PATH="$PATH:/c/Users/$USER/AppData/Local/Microsoft/PowerAppsCLI"' >> ~/.bashrc
 source ~/.bashrc
 ```


### PR DESCRIPTION
## Summary

Based on clean-machine testing of the plugin, fixes eight friction points in the connect/onboarding flow:

- **Independent prereq checks** — no longer fail-fast parallel; all missing tools reported at once
- **MCP_CLIENT_ID auto-populated in .env** — eliminates `enable-mcp-client.py` failure on first run
- **PAC CLI path discovery** — checks known Windows install paths (winget, dotnet tool, nuget) instead of slow recursive find
- **Never use HTTP transport for Claude** — explicit warning in Claude section only; Copilot HTTP transport unchanged
- **Tenant/region mismatch detection** — detects when environment URL region doesn't match current auth profile before wasting time on `pac org select`
- **Auth popup warning** — tells the user a browser sign-in will appear on restart and which account to use (previously fired with no explanation)
- **.NET SDK 8 to 9** — matches current release
- **PAC CLI check fix** — `pac --version` is not a valid command (non-zero exit); changed to `pac` which prints version banner cleanly

## Test plan
- [ ] On a clean Windows machine, run `/dataverse:connect` against a Dataverse environment and verify the agent follows the updated flow
- [ ] Verify Copilot MCP config still uses HTTP transport (not affected by stdio change)
- [ ] Verify `.env` includes `MCP_CLIENT_ID` after step 3 completes
- [ ] Verify PAC CLI is found without recursive search on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)