### PR TITLE
fix: address review nits from PR #32

### DIFF
--- a/.github/evals/static_checks.py
+++ b/.github/evals/static_checks.py
@@ -61,7 +61,7 @@ NO_DO_NOT_USE_EXEMPT = {"dv-overview", "dv-connect"}
 
 def extract_fenced_blocks(text, lang="python"):
     """Return list of (index, content) for fenced blocks of the given language."""
-    pattern = rf"```{re.escape(lang)}\n(.*?)```" if lang else r"```\w*\n(.*?)```"
+    pattern = rf"```{re.escape(lang)}[^\n]*\n(.*?)```" if lang else r"```\w*[^\n]*\n(.*?)```"
     return list(enumerate(re.findall(pattern, text, re.DOTALL), start=1))
 
 

--- a/.github/plugins/dataverse/skills/dv-connect/SKILL.md
+++ b/.github/plugins/dataverse/skills/dv-connect/SKILL.md
@@ -42,7 +42,7 @@ After Python is confirmed:
 pip install --upgrade azure-identity requests PowerPlatform-Dataverse-Client pandas
 ```
 
-**Skip condition:** All tools present and Python SDK installed.
+**Skip condition:** All tools present, Python SDK installed, and `pandas` importable (`python -c "import pandas"`).
 
 ---
 

--- a/.github/plugins/dataverse/skills/dv-query/SKILL.md
+++ b/.github/plugins/dataverse/skills/dv-query/SKILL.md
@@ -207,7 +207,7 @@ req = urllib.request.Request(url, headers={
     "Authorization": f"Bearer {token}",
     "OData-MaxVersion": "4.0", "OData-Version": "4.0", "Accept": "application/json",
 })
-with urllib.request.urlopen(req, timeout=30) as resp:
+with urllib.request.urlopen(req, timeout=120) as resp:
     data = json.loads(resp.read())
     for ticket in data["value"]:
         articles = [a["new_title"] for a in ticket.get("new_ticket_kbarticle", [])]
@@ -245,7 +245,7 @@ def apply_query(entity_set, apply_expr):
         "Authorization": f"Bearer {token}",
         "OData-MaxVersion": "4.0", "OData-Version": "4.0", "Accept": "application/json",
     })
-    with urllib.request.urlopen(req, timeout=30) as resp:
+    with urllib.request.urlopen(req, timeout=120) as resp:
         return json.loads(resp.read()).get("value", [])
 
 # Example 1: Count and sum by status

--- a/.github/plugins/dataverse/skills/dv-query/SKILL.md
+++ b/.github/plugins/dataverse/skills/dv-query/SKILL.md
@@ -207,7 +207,7 @@ req = urllib.request.Request(url, headers={
     "Authorization": f"Bearer {token}",
     "OData-MaxVersion": "4.0", "OData-Version": "4.0", "Accept": "application/json",
 })
-with urllib.request.urlopen(req, timeout=120) as resp:
+with urllib.request.urlopen(req, timeout=150) as resp:
     data = json.loads(resp.read())
     for ticket in data["value"]:
         articles = [a["new_title"] for a in ticket.get("new_ticket_kbarticle", [])]
@@ -245,7 +245,7 @@ def apply_query(entity_set, apply_expr):
         "Authorization": f"Bearer {token}",
         "OData-MaxVersion": "4.0", "OData-Version": "4.0", "Accept": "application/json",
     })
-    with urllib.request.urlopen(req, timeout=120) as resp:
+    with urllib.request.urlopen(req, timeout=150) as resp:
         return json.loads(resp.read()).get("value", [])
 
 # Example 1: Count and sum by status

--- a/.github/plugins/dataverse/skills/dv-query/SKILL.md
+++ b/.github/plugins/dataverse/skills/dv-query/SKILL.md
@@ -207,7 +207,7 @@ req = urllib.request.Request(url, headers={
     "Authorization": f"Bearer {token}",
     "OData-MaxVersion": "4.0", "OData-Version": "4.0", "Accept": "application/json",
 })
-with urllib.request.urlopen(req) as resp:
+with urllib.request.urlopen(req, timeout=30) as resp:
     data = json.loads(resp.read())
     for ticket in data["value"]:
         articles = [a["new_title"] for a in ticket.get("new_ticket_kbarticle", [])]
@@ -245,7 +245,7 @@ def apply_query(entity_set, apply_expr):
         "Authorization": f"Bearer {token}",
         "OData-MaxVersion": "4.0", "OData-Version": "4.0", "Accept": "application/json",
     })
-    with urllib.request.urlopen(req) as resp:
+    with urllib.request.urlopen(req, timeout=30) as resp:
         return json.loads(resp.read()).get("value", [])
 
 # Example 1: Count and sum by status


### PR DESCRIPTION
Fixes review comments from [#32](https://github.com/microsoft/Dataverse-skills/pull/32):

1. **dv-connect skip condition** — Updated to mention pandas importability check, since `client.dataframe.get()` (used by dv-query and dv-data) requires pandas.
2. **dv-query urlopen timeout** — Added `timeout=150` to both `urllib.request.urlopen()` calls (N:N `$expand` example and `$apply` helper). Uses 150s to give a comfortable margin above the Dataverse server-side 120s limit for network latency — 30s was too aggressive for `$apply` aggregation over large tables (can take 30-60s).
3. **static_checks.py regex** — Updated fenced block regex to handle potential info-string attributes on code fences.

All static evals pass: `python .github/evals/static_checks.py` → PASSED (6 files, 70 blocks, 5 categories).
