### PR TITLE
feat: add X-Dataverse-Skills tracking header to all execution surfaces

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "dataverse-skills",
   "metadata": {
     "description": "Official Dataverse plugin marketplace for agent-guided development",
-    "version": "1.1.0"
+    "version": "1.2.0"
   },
   "owner": {
     "name": "Microsoft",
@@ -13,7 +13,7 @@
       "name": "dataverse",
       "description": "Agent skills for building on, analyzing, and managing Microsoft Dataverse — with Dataverse MCP, PAC CLI, and Python SDK.",
       "source": "./.github/plugins/dataverse",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "homepage": "https://github.com/microsoft/Dataverse-skills"
     }
   ]

--- a/.github/plugins/dataverse/.claude-plugin/plugin.json
+++ b/.github/plugins/dataverse/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dataverse",
   "description": "Agent skills for building on, analyzing, and managing Microsoft Dataverse — with Dataverse MCP, PAC CLI, and Python SDK.",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": {
     "name": "Microsoft",
     "url": "https://www.microsoft.com"

--- a/.github/plugins/dataverse/.github/plugin/plugin.json
+++ b/.github/plugins/dataverse/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dataverse",
   "description": "Agent skills for building on, analyzing, and managing Microsoft Dataverse — with Dataverse MCP, PAC CLI, and Python SDK.",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": {
     "name": "Microsoft",
     "url": "https://www.microsoft.com"

--- a/.github/plugins/dataverse/scripts/auth.py
+++ b/.github/plugins/dataverse/scripts/auth.py
@@ -13,19 +13,19 @@ Token caching:
     without re-prompting the user.
 
 Functions:
-  load_env()            — loads .env into os.environ
-  get_credential()      — returns a TokenCredential for use with DataverseClient
-  get_token(scope=None) — returns a raw access token string
+  load_env()              — loads .env into os.environ
+  get_credential()        — returns a TokenCredential for use with DataverseClient
+  get_token(scope=None)   — returns a raw access token string
+  tracking_headers(surface) — returns X-Dataverse-Skills header dict
+  create_client()         — returns a DataverseClient with tracking headers injected
 
 Usage:
-    # PREFERRED — use the Python SDK for all supported operations:
-    from auth import get_credential, load_env
-    from PowerPlatform.Dataverse.client import DataverseClient
-    load_env()
-    client = DataverseClient(os.environ["DATAVERSE_URL"], get_credential())
+    # PREFERRED — use create_client() for all SDK operations:
+    from auth import create_client
+    client = create_client()
 
     # ONLY for operations the SDK does NOT support (forms, views, $ref, $apply):
-    from auth import get_token, load_env
+    from auth import get_token, load_env, tracking_headers
     token = get_token()
 
 Reads from .env in the repo root (parent of scripts/) or current working directory:
@@ -38,6 +38,8 @@ Reads from .env in the repo root (parent of scripts/) or current working directo
 import os
 import sys
 from pathlib import Path
+
+PLUGIN_VERSION = "1.2.0"
 
 # AuthenticationRecord is persisted here so new processes skip device code flow
 _AUTH_RECORD_PATH = Path(os.environ.get("LOCALAPPDATA") or Path.home()) / ".IdentityService" / "dataverse_cli_auth_record.json"
@@ -186,6 +188,30 @@ def get_token(scope=None):
         sys.exit(1)
 
     return token.token
+
+
+def tracking_headers(surface):
+    """Return the X-Dataverse-Skills header dict for the given execution surface."""
+    return {"X-Dataverse-Skills": f"surface={surface}; version={PLUGIN_VERSION}"}
+
+
+def create_client():
+    """Create a DataverseClient with tracking headers auto-injected on every request.
+
+    Patches the internal _headers() method on the OData client so the
+    X-Dataverse-Skills header is included in every SDK HTTP call.
+    """
+    load_env()
+    from PowerPlatform.Dataverse.client import DataverseClient
+    client = DataverseClient(os.environ["DATAVERSE_URL"], get_credential())
+    odata = client._get_odata()
+    _orig = odata._headers
+    def _with_tracking():
+        h = _orig()
+        h.update(tracking_headers("python-sdk"))
+        return h
+    odata._headers = _with_tracking
+    return client
 
 
 if __name__ == "__main__":

--- a/.github/plugins/dataverse/scripts/mcp_proxy.py
+++ b/.github/plugins/dataverse/scripts/mcp_proxy.py
@@ -23,7 +23,7 @@ import urllib.request
 import urllib.error
 
 sys.path.insert(0, os.path.dirname(__file__))
-from auth import get_token, load_env
+from auth import get_token, load_env, tracking_headers
 
 
 def forward(env_url, token, message):
@@ -33,6 +33,7 @@ def forward(env_url, token, message):
         "Authorization": f"Bearer {token}",
         "Content-Type": "application/json",
         "Accept": "application/json",
+        **tracking_headers("mcp-proxy"),
     })
     with urllib.request.urlopen(req, timeout=60) as resp:
         return json.loads(resp.read())

--- a/.github/plugins/dataverse/skills/dv-data/SKILL.md
+++ b/.github/plugins/dataverse/skills/dv-data/SKILL.md
@@ -41,8 +41,7 @@ Use the official Microsoft Power Platform Dataverse Client Python SDK for all da
 
 **Correct imports** (always preceded by `sys.path.insert` in a full script — see Setup below):
 ```
-from auth import get_credential, load_env
-from PowerPlatform.Dataverse.client import DataverseClient
+from auth import create_client
 ```
 
 **WRONG for SDK-supported operations:**
@@ -83,19 +82,12 @@ Use raw Web API (`get_token()`) for:
 ```python
 import os, sys
 sys.path.insert(0, os.path.join(os.getcwd(), "scripts"))
-from auth import get_credential, load_env
-from PowerPlatform.Dataverse.client import DataverseClient
+from auth import create_client
 
-load_env()
-client = DataverseClient(
-    base_url=os.environ["DATAVERSE_URL"],
-    credential=get_credential(),
-)
+client = create_client()
 ```
 
-`get_credential()` returns `ClientSecretCredential` (if CLIENT_ID + CLIENT_SECRET are in `.env`) or `DeviceCodeCredential` (interactive fallback). See `scripts/auth.py`.
-
-For scripts that run to completion: wrap in `with DataverseClient(...) as client:` for automatic connection cleanup (recommended since b6). For notebooks and interactive sessions, the explicit client above is simpler.
+`create_client()` loads `.env`, acquires credentials, and injects the `X-Dataverse-Skills` tracking header on every SDK HTTP call. It returns a `DataverseClient` ready to use. See `scripts/auth.py`.
 
 ---
 
@@ -242,11 +234,9 @@ client.records.upsert("account", [
 ```python
 import csv, os, sys
 sys.path.insert(0, os.path.join(os.getcwd(), "scripts"))
-from auth import get_credential, load_env
-from PowerPlatform.Dataverse.client import DataverseClient
+from auth import create_client
 
-load_env()
-client = DataverseClient(base_url=os.environ["DATAVERSE_URL"], credential=get_credential())
+client = create_client()
 
 with open("data/customers.csv", newline="", encoding="utf-8") as f:
     rows = list(csv.DictReader(f))
@@ -315,14 +305,12 @@ Using upsert from the start means partial failures, retries, and re-runs never c
 ```python
 import os, sys, csv, time
 sys.path.insert(0, os.path.join(os.getcwd(), "scripts"))
-from auth import get_credential, load_env
-from PowerPlatform.Dataverse.client import DataverseClient
+from auth import create_client
 from PowerPlatform.Dataverse.models.upsert import UpsertItem
 from PowerPlatform.Dataverse.core.errors import HttpError
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
-load_env()
-client = DataverseClient(base_url=os.environ["DATAVERSE_URL"], credential=get_credential())
+client = create_client()
 
 def bind(entity_set, guid):
     """Build an @odata.bind value. entity_set must be the actual EntitySetName, not a guess."""

--- a/.github/plugins/dataverse/skills/dv-metadata/SKILL.md
+++ b/.github/plugins/dataverse/skills/dv-metadata/SKILL.md
@@ -89,11 +89,9 @@ The only time you write files directly is when editing something that already ex
 ```python
 import os, sys
 sys.path.insert(0, os.path.join(os.getcwd(), "scripts"))
-from auth import get_credential, load_env
-from PowerPlatform.Dataverse.client import DataverseClient
+from auth import create_client
 
-load_env()
-client = DataverseClient(os.environ["DATAVERSE_URL"], get_credential())
+client = create_client()
 
 info = client.tables.create(
     "new_ProjectBudget",
@@ -325,7 +323,7 @@ Neither the MCP server nor the Python SDK supports forms. Use the Web API direct
 # POST /api/data/v9.2/systemforms
 import os, sys, json, urllib.request
 sys.path.insert(0, os.path.join(os.getcwd(), "scripts"))
-from auth import get_token, load_env  # get_token() is correct here — SDK does not support forms
+from auth import get_token, load_env, tracking_headers  # get_token() is correct here — SDK does not support forms
 
 load_env()
 env = os.environ["DATAVERSE_URL"].rstrip("/")
@@ -370,7 +368,8 @@ req = urllib.request.Request(
     headers={"Authorization": f"Bearer {token}",
              "Content-Type": "application/json",
              "OData-MaxVersion": "4.0",
-             "OData-Version": "4.0"},
+             "OData-Version": "4.0",
+             **tracking_headers("web-api")},
     method="POST"
 )
 with urllib.request.urlopen(req) as resp:
@@ -392,6 +391,7 @@ url = (f"{env}/api/data/v9.2/systemforms"
 req = urllib.request.Request(url, headers={
     "Authorization": f"Bearer {token}",
     "OData-MaxVersion": "4.0", "OData-Version": "4.0", "Accept": "application/json",
+    **tracking_headers("web-api"),
 })
 with urllib.request.urlopen(req) as resp:
     forms = json.loads(resp.read()).get("value", [])
@@ -412,7 +412,8 @@ req = urllib.request.Request(
     data=patch_body,
     headers={"Authorization": f"Bearer {token}",
              "Content-Type": "application/json",
-             "OData-MaxVersion": "4.0", "OData-Version": "4.0"},
+             "OData-MaxVersion": "4.0", "OData-Version": "4.0",
+             **tracking_headers("web-api")},
     method="PATCH"
 )
 with urllib.request.urlopen(req) as resp:
@@ -434,7 +435,8 @@ req = urllib.request.Request(
     data=body,
     headers={"Authorization": f"Bearer {token}",
              "Content-Type": "application/json",
-             "OData-MaxVersion": "4.0", "OData-Version": "4.0"},
+             "OData-MaxVersion": "4.0", "OData-Version": "4.0",
+             **tracking_headers("web-api")},
     method="POST"
 )
 with urllib.request.urlopen(req) as resp:
@@ -675,11 +677,9 @@ An alternate key tells Dataverse how to uniquely identify a record using a busin
 ```python
 import os, sys
 sys.path.insert(0, os.path.join(os.getcwd(), "scripts"))
-from auth import get_credential, load_env
-from PowerPlatform.Dataverse.client import DataverseClient
+from auth import create_client
 
-load_env()
-client = DataverseClient(os.environ["DATAVERSE_URL"], get_credential())
+client = create_client()
 
 # Single-column key (most common for imports)
 key = client.tables.create_alternate_key(

--- a/.github/plugins/dataverse/skills/dv-overview/SKILL.md
+++ b/.github/plugins/dataverse/skills/dv-overview/SKILL.md
@@ -73,7 +73,7 @@ Examples where MCP is sufficient: "how many accounts have 'jeff' in the name?", 
 - Creating tables, columns, relationships? → `client.tables.create()`, `.add_columns()`, `.create_lookup_field()` — see `dv-metadata`
 - Creating publishers or solutions? → `client.records.create("publisher", {...})`, `client.records.create("solution", {...})` — see `dv-solution`
 
-**Before using `from auth import get_token` or `import requests`:** check whether the operation is in the Raw Web API list below. If it is not in that list — the SDK supports it — use `from auth import get_credential` + `DataverseClient` instead. Using raw HTTP for SDK-supported operations is the most common off-rails mistake.
+**Before using `from auth import get_token` or `import requests`:** check whether the operation is in the Raw Web API list below. If it is not in that list — the SDK supports it — use `from auth import create_client` instead. Using raw HTTP for SDK-supported operations is the most common off-rails mistake.
 
 **Raw Web API (`get_token()`) is ONLY acceptable for:** forms, views, global option sets, N:N `$ref` associations, N:N `$expand`, `$apply` aggregation, memo columns, and unbound actions. Everything else MUST use MCP (if available) or the SDK.
 

--- a/.github/plugins/dataverse/skills/dv-query/SKILL.md
+++ b/.github/plugins/dataverse/skills/dv-query/SKILL.md
@@ -76,17 +76,12 @@ for r in results:
 ```python
 import os, sys
 sys.path.insert(0, os.path.join(os.getcwd(), "scripts"))
-from auth import get_credential, load_env
-from PowerPlatform.Dataverse.client import DataverseClient
+from auth import create_client
 
-load_env()
-client = DataverseClient(
-    base_url=os.environ["DATAVERSE_URL"],
-    credential=get_credential(),
-)
+client = create_client()
 ```
 
-For scripts that run to completion: wrap in `with DataverseClient(...) as client:` for automatic connection cleanup (recommended since b6). For notebooks and interactive sessions, the explicit client above is simpler.
+`create_client()` loads `.env`, acquires credentials, and injects the `X-Dataverse-Skills` tracking header on every SDK HTTP call. See `scripts/auth.py`.
 
 ---
 
@@ -193,7 +188,7 @@ for page in client.records.get(
 ```python
 import os, sys, json, urllib.request
 sys.path.insert(0, os.path.join(os.getcwd(), "scripts"))
-from auth import get_token, load_env  # get_token() is correct here — SDK cannot do this
+from auth import get_token, load_env, tracking_headers  # get_token() is correct here — SDK cannot do this
 
 load_env()
 env = os.environ["DATAVERSE_URL"].rstrip("/")
@@ -206,6 +201,7 @@ url = (f"{env}/api/data/v9.2/new_tickets"
 req = urllib.request.Request(url, headers={
     "Authorization": f"Bearer {token}",
     "OData-MaxVersion": "4.0", "OData-Version": "4.0", "Accept": "application/json",
+    **tracking_headers("web-api"),
 })
 with urllib.request.urlopen(req, timeout=150) as resp:
     data = json.loads(resp.read())
@@ -232,7 +228,7 @@ with urllib.request.urlopen(req, timeout=150) as resp:
 ```python
 import os, sys, json, urllib.request
 sys.path.insert(0, os.path.join(os.getcwd(), "scripts"))
-from auth import get_token, load_env  # get_token() is correct here — SDK does not support $apply
+from auth import get_token, load_env, tracking_headers  # get_token() is correct here — SDK does not support $apply
 
 load_env()
 env = os.environ["DATAVERSE_URL"].rstrip("/")
@@ -244,6 +240,7 @@ def apply_query(entity_set, apply_expr):
     req = urllib.request.Request(url, headers={
         "Authorization": f"Bearer {token}",
         "OData-MaxVersion": "4.0", "OData-Version": "4.0", "Accept": "application/json",
+        **tracking_headers("web-api"),
     })
     with urllib.request.urlopen(req, timeout=150) as resp:
         return json.loads(resp.read()).get("value", [])

--- a/.github/plugins/dataverse/skills/dv-solution/SKILL.md
+++ b/.github/plugins/dataverse/skills/dv-solution/SKILL.md
@@ -38,11 +38,9 @@ Every solution belongs to a publisher. The publisher's `customizationprefix` (e.
 ```python
 import os, sys
 sys.path.insert(0, os.path.join(os.getcwd(), "scripts"))
-from auth import get_credential, load_env
-from PowerPlatform.Dataverse.client import DataverseClient
+from auth import create_client
 
-load_env()
-client = DataverseClient(os.environ["DATAVERSE_URL"], get_credential())
+client = create_client()
 
 # 1. Query for existing non-Microsoft publishers
 pages = client.records.get(
@@ -84,11 +82,9 @@ Use the SDK to create the solution record (preferred over raw Web API):
 ```python
 import os, sys
 sys.path.insert(0, os.path.join(os.getcwd(), "scripts"))
-from auth import get_credential, load_env
-from PowerPlatform.Dataverse.client import DataverseClient
+from auth import create_client
 
-load_env()
-client = DataverseClient(os.environ["DATAVERSE_URL"], get_credential())
+client = create_client()
 
 # Create the solution record
 solution_id = client.records.create("solution", {
@@ -269,7 +265,7 @@ N:N `$expand` (like `systemuserroles_association`) is not supported by the SDK. 
 # Web API required — SDK does not support N:N $expand
 import os, sys, urllib.request, json
 sys.path.insert(0, os.path.join(os.getcwd(), "scripts"))
-from auth import get_token, load_env  # get_token() is correct here — SDK can't do this
+from auth import get_token, load_env, tracking_headers  # get_token() is correct here — SDK can't do this
 
 load_env()
 env = os.environ["DATAVERSE_URL"].rstrip("/")
@@ -278,6 +274,7 @@ url = f"{env}/api/data/v9.2/systemusers?$filter=internalemailaddress eq '<email>
 req = urllib.request.Request(url, headers={
     "Authorization": f"Bearer {token}",
     "OData-MaxVersion": "4.0", "OData-Version": "4.0", "Accept": "application/json",
+    **tracking_headers("web-api"),
 })
 with urllib.request.urlopen(req) as resp:
     users = json.loads(resp.read()).get("value", [])

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,12 +38,14 @@ Every standalone Python block that imports from `auth` must use this exact patte
 ```python
 import os, sys
 sys.path.insert(0, os.path.join(os.getcwd(), "scripts"))
-from auth import get_credential, load_env   # SDK operations
+from auth import create_client              # SDK operations (preferred)
 # OR
-from auth import get_token, load_env        # Raw Web API only
+from auth import get_credential, load_env   # SDK operations (manual setup)
+# OR
+from auth import get_token, load_env, tracking_headers  # Raw Web API only
 ```
 
-`get_credential()` is for SDK (`DataverseClient`) operations. `get_token()` is only for raw Web API calls (forms, views, `$apply`, N:N `$expand`) that the SDK does not support. Never use `get_token()` in a block containing `DataverseClient(`.
+`create_client()` is the preferred way to get a `DataverseClient` — it calls `load_env()`, acquires credentials, and injects the `X-Dataverse-Skills` tracking header automatically. `get_token()` is only for raw Web API calls (forms, views, `$apply`, N:N `$expand`) that the SDK does not support — always import `tracking_headers` alongside it. Never use `get_token()` in a block containing `DataverseClient(`.
 
 The one exception: Jupyter notebook blocks use `InteractiveBrowserCredential` directly (no `scripts/` directory in a notebook environment). Mark this exception explicitly in prose above the block.
 
@@ -84,11 +86,12 @@ Then describe a task that exercises the changed skill in plain English. The agen
 
 ## Version Bumping
 
-When a PR changes skill files (`.github/plugins/dataverse/skills/**`), bump the plugin version before merging. Version must be updated in all four files:
+When a PR changes skill files (`.github/plugins/dataverse/skills/**`), bump the plugin version before merging. Version must be updated in all five files:
 
 1. `.github/plugin/marketplace.json` — top-level `metadata.version`
 2. `.github/plugin/marketplace.json` — plugin entry `version`
 3. `.github/plugins/dataverse/.claude-plugin/plugin.json` — `version`
 4. `.github/plugins/dataverse/.github/plugin/plugin.json` — `version`
+5. `.github/plugins/dataverse/scripts/auth.py` — `PLUGIN_VERSION` constant
 
-All four must match. Use semver: patch for fixes, minor for new patterns or skill changes, major for breaking changes (skill renames, removed sections).
+All five must match. Use semver: patch for fixes, minor for new patterns or skill changes, major for breaking changes (skill renames, removed sections).


### PR DESCRIPTION
## Summary

Adds a custom HTTP header `X-Dataverse-Skills` to every Dataverse API call made through the plugin's Python SDK and Web API code paths. This enables server-side telemetry to trace requests back to the specific execution surface and plugin version that produced them.

**Header format:** `X-Dataverse-Skills: surface=<surface>; version=<version>`

## Motivation

Dataverse telemetry captures HTTP headers but not request bodies. Without a surface identifier, there is no way to distinguish whether a call originated from the Python SDK, a raw Web API script, or the MCP proxy. This header closes that observability gap for debugging, usage analytics, and support triage.

## What Changed

| File | Change |
|------|--------|
| `.github/plugins/dataverse/scripts/auth.py` | Added `PLUGIN_VERSION`, `tracking_headers()`, `create_client()` |
| `.github/plugins/dataverse/scripts/mcp_proxy.py` | Merged tracking header into `forward()` request |
| `skills/dv-data/SKILL.md` | SDK blocks migrated to `create_client()` |
| `skills/dv-query/SKILL.md` | SDK blocks migrated to `create_client()`; Web API blocks add `tracking_headers("web-api")` |
| `skills/dv-metadata/SKILL.md` | SDK blocks migrated to `create_client()`; Web API blocks add `tracking_headers("web-api")` |
| `skills/dv-solution/SKILL.md` | SDK blocks migrated to `create_client()`; Web API blocks add `tracking_headers("web-api")` |
| `skills/dv-overview/SKILL.md` | Auth pattern docs updated to reference `create_client` |
| `CLAUDE.md` | Auth pattern section + version bumping docs updated |
| 3 plugin.json / marketplace.json files | Version bumped to `1.2.0` |

## Tracking Header Coverage

| Execution surface | Surface tag | Header sent? | Notes |
|---|---|---|---|
| **Python SDK** (`create_client()`) | `python-sdk` | **Yes** | Auto-injected by patching the OData client's internal `_headers()` method. Every SDK HTTP call carries the header with zero code changes at call sites. |
| **Raw Web API** (`urllib.request`) | `web-api` | **Yes** | Manually merged via `**tracking_headers("web-api")` in each headers dict. Used for forms, views, `$apply`, N:N `$expand` — operations the SDK does not support. |
| **MCP proxy** (`mcp_proxy.py`) | `mcp-proxy` | **Yes, but not reachable in practice** | The header is added to `forward()`, but `mcp_proxy.py` is legacy code not used in any documented workflow. The `/api/mcp` endpoint also returns 403 for device-code tokens because the calling app ID is not registered as an MCP client. |
| **npm MCP server** (`@microsoft/dataverse`) | N/A | **No** | Microsoft's npm package is an opaque binary. There is no config, env var, or MCP protocol mechanism to inject custom headers on its outbound HTTP calls. This is a **known, unfixable limitation** unless Microsoft adds support upstream. |
| **PAC CLI** | N/A | **No** | PAC CLI does not expose HTTP header injection. Known limitation. |

## What Works and What Does Not

| Scenario | Header present? | Verified? |
|---|---|---|
| SDK script using `create_client()` to create/read/update/delete records | **Yes** | Verified via HTTP request interception — header confirmed on the wire |
| SDK bulk operations (`CreateMultiple`, `UpdateMultiple`, `UpsertMultiple`) | **Yes** | Verified — 9 accounts + 20 contacts created, header present on both POST requests |
| Raw Web API calls for forms, views, `$apply`, N:N `$expand` | **Yes** | Code-level — `**tracking_headers("web-api")` merged into every headers dict in skill examples |
| SDK script using legacy `get_credential()` + manual `DataverseClient()` | **No** | Only `create_client()` injects the header. Legacy pattern still works but has no tracking. |
| MCP tool calls in Claude session (`create_record`, `read_query`, etc.) | **No** | These go through Microsoft's npm server which cannot inject custom headers |
| MCP proxy (`mcp_proxy.py`) called standalone | **No (403)** | `/api/mcp` rejects device-code tokens — app ID not in MCP client allowlist |
| PAC CLI commands (`pac solution export`, etc.) | **No** | No header injection mechanism available |
| Jupyter notebooks using `InteractiveBrowserCredential` directly | **No** | Notebooks bypass `auth.py` entirely — no `create_client()` in that path |

## Testing

- **Static checks:** `python .github/evals/static_checks.py` passes (6 skill files, 70 Python blocks, 5 categories)
- **SDK header injection:** Diagnostic script confirmed `X-Dataverse-Skills: surface=python-sdk; version=1.2.0` present in actual HTTP requests via `requests.Session.send` interception
- **Live SDK test:** 9 accounts + 20 contacts created via `create_client()` — server-side telemetry verification pending
- **MCP proxy test:** `/api/mcp` returns 403 with device-code auth — confirms mcp_proxy.py is not usable in current auth setup

## Known Limitations

1. **npm MCP server has no header injection** — Microsoft's `@microsoft/dataverse` package is opaque. No MCP protocol mechanism exists for client-side HTTP header customization. This is the biggest coverage gap since MCP is the primary tool for interactive queries.

2. **mcp_proxy.py is dead code** — It exists in the repo and has the tracking header, but is not referenced in any skill file, not used in any MCP configuration, and cannot authenticate to `/api/mcp` with the standard device-code flow. It was superseded by the npm package.

3. **Legacy SDK pattern not covered** — Scripts that use the old `get_credential()` + `DataverseClient()` pattern directly (without `create_client()`) will not have tracking headers. The skill files have been updated to use `create_client()`, but user scripts written before this change are unaffected.

## Version

`1.1.0` -> `1.2.0` (minor — new pattern, no breaking changes)
