### PR TITLE
fix: add display name guidance to prevent schema names in UI

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "dataverse-skills",
   "metadata": {
     "description": "Official Dataverse plugin marketplace for agent-guided development",
-    "version": "1.1.0"
+    "version": "1.2.0"
   },
   "owner": {
     "name": "Microsoft",
@@ -13,7 +13,7 @@
       "name": "dataverse",
       "description": "Agent skills for building on, analyzing, and managing Microsoft Dataverse — with Dataverse MCP, PAC CLI, and Python SDK.",
       "source": "./.github/plugins/dataverse",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "homepage": "https://github.com/microsoft/Dataverse-skills"
     }
   ]

--- a/.github/plugins/dataverse/.claude-plugin/plugin.json
+++ b/.github/plugins/dataverse/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dataverse",
   "description": "Agent skills for building on, analyzing, and managing Microsoft Dataverse — with Dataverse MCP, PAC CLI, and Python SDK.",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": {
     "name": "Microsoft",
     "url": "https://www.microsoft.com"

--- a/.github/plugins/dataverse/.github/plugin/plugin.json
+++ b/.github/plugins/dataverse/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dataverse",
   "description": "Agent skills for building on, analyzing, and managing Microsoft Dataverse — with Dataverse MCP, PAC CLI, and Python SDK.",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": {
     "name": "Microsoft",
     "url": "https://www.microsoft.com"

--- a/.github/plugins/dataverse/skills/dv-metadata/SKILL.md
+++ b/.github/plugins/dataverse/skills/dv-metadata/SKILL.md
@@ -75,6 +75,26 @@ The only time you write files directly is when editing something that already ex
 
 ---
 
+## Naming Conventions: Display Names vs Schema Names
+
+**Schema names** are permanent internal identifiers. **Display names** are the human-readable labels users see in the UI. They must always be different.
+
+| What the user says | Schema name | Display name | Plural display name |
+|---|---|---|---|
+| "Checklist Template" | `prefix_ChecklistTemplate` | Checklist Template | Checklist Templates |
+| "Health Inspection Detail" | `prefix_HealthInspectionDetail` | Health Inspection Detail | Health Inspection Details |
+| "Code Enforcement Case" | `prefix_CodeEnforcementCase` | Code Enforcement Case | Code Enforcement Cases |
+
+**Rules:**
+- Schema names use **PascalCase** after the publisher prefix: `prefix_ChecklistTemplate`, never `prefix_checklisttemplate`
+- Display names use **natural language with spaces**: "Checklist Template", never `prefix_ChecklistTemplate`
+- **Never use a schema name as a display name.** Seeing `gov_checklisttemplate` in the UI means the display name was not set correctly.
+- The same rule applies to columns: schema `prefix_SpecialtyArea` → display "Specialty Area"
+
+**SDK limitation:** `client.tables.create()` sets the display name equal to the schema name. You MUST PATCH the display name after SDK table creation (see the table creation section below).
+
+---
+
 ## Creating a Table
 
 **If creating multiple tables for a data import**, also see these sections later in this skill:
@@ -86,14 +106,14 @@ The only time you write files directly is when editing something that already ex
 
 **SDK approach (use this by default):**
 
-```python
-import os, sys
-sys.path.insert(0, os.path.join(os.getcwd(), "scripts"))
-from auth import get_credential, load_env
-from PowerPlatform.Dataverse.client import DataverseClient
+The SDK creates the table but sets display name = schema name. Always follow up with a display name PATCH:
 
-load_env()
-client = DataverseClient(os.environ["DATAVERSE_URL"], get_credential())
+```python
+import os, sys, json, urllib.request
+sys.path.insert(0, os.path.join(os.getcwd(), "scripts"))
+from auth import create_client, get_token, load_env, tracking_headers  # SDK does not support display name patching
+
+client = create_client()
 
 info = client.tables.create(
     "new_ProjectBudget",
@@ -102,9 +122,67 @@ info = client.tables.create(
     primary_column="new_Name",
 )
 print(f"Created: {info['table_schema_name']}")
+
+# MANDATORY: Patch display names — SDK sets display_name = schema_name
+env = os.environ["DATAVERSE_URL"].rstrip("/")
+token = get_token()
+
+def label(text):
+    return {"@odata.type": "Microsoft.Dynamics.CRM.Label",
+            "LocalizedLabels": [{"@odata.type": "Microsoft.Dynamics.CRM.LocalizedLabel",
+                                  "Label": text, "LanguageCode": 1033}]}
+
+patch_body = json.dumps({
+    "DisplayName": label("Project Budget"),
+    "DisplayCollectionName": label("Project Budgets"),
+    "Description": label("Tracks project budget allocations"),
+}).encode()
+req = urllib.request.Request(
+    f"{env}/api/data/v9.2/EntityDefinitions(LogicalName='{info['table_logical_name']}')",
+    data=patch_body,
+    headers={"Authorization": f"Bearer {token}",
+             "Content-Type": "application/json",
+             "OData-MaxVersion": "4.0", "OData-Version": "4.0",
+             "MSCRM.MergeLabels": "true",
+             **tracking_headers("web-api")},
+    method="PUT"
+)
+with urllib.request.urlopen(req) as resp:
+    print(f"Display name set to 'Project Budget'")
+```
+
+When creating multiple tables, extract the PATCH into a helper to avoid repetition:
+
+```python
+# SDK does not support display name updates — raw Web API required
+def set_table_display_name(env, token, logical_name, display, plural, description=""):
+    """Patch table display name after SDK creation."""
+    def label(text):
+        return {"@odata.type": "Microsoft.Dynamics.CRM.Label",
+                "LocalizedLabels": [{"@odata.type": "Microsoft.Dynamics.CRM.LocalizedLabel",
+                                      "Label": text, "LanguageCode": 1033}]}
+    body = json.dumps({
+        "DisplayName": label(display),
+        "DisplayCollectionName": label(plural),
+        "Description": label(description),
+    }).encode()
+    req = urllib.request.Request(
+        f"{env}/api/data/v9.2/EntityDefinitions(LogicalName='{logical_name}')",
+        data=body,
+        headers={"Authorization": f"Bearer {token}",
+                 "Content-Type": "application/json",
+                 "OData-MaxVersion": "4.0", "OData-Version": "4.0",
+                 "MSCRM.MergeLabels": "true",
+                 **tracking_headers("web-api")},
+        method="PUT"
+    )
+    with urllib.request.urlopen(req) as resp:
+        print(f"  Display name: '{display}' set on {logical_name}")
 ```
 
 **Web API fallback (ONLY when you need OwnershipType, HasActivities, or other properties the SDK doesn't expose):**
+
+When using Web API directly, set `DisplayName` and `DisplayCollectionName` explicitly — never copy the schema name:
 
 ```python
 # Helper for Label boilerplate
@@ -115,16 +193,16 @@ def label(text):
 
 entity = {
     "@odata.type": "Microsoft.Dynamics.CRM.EntityMetadata",
-    "SchemaName": "new_ProjectBudget",
-    "DisplayName": label("Project Budget"),
-    "DisplayCollectionName": label("Project Budgets"),
-    "Description": label(""),
+    "SchemaName": "new_ProjectBudget",                      # PascalCase, prefixed
+    "DisplayName": label("Project Budget"),                  # Human-readable
+    "DisplayCollectionName": label("Project Budgets"),       # Plural human-readable
+    "Description": label("Tracks project budget allocations"),
     "OwnershipType": "UserOwned",
     "HasActivities": False, "HasNotes": False, "IsActivity": False,
     "PrimaryNameAttribute": "new_name",
     "Attributes": [{
         "@odata.type": "Microsoft.Dynamics.CRM.StringAttributeMetadata",
-        "SchemaName": "new_name",
+        "SchemaName": "new_Name",
         "DisplayName": label("Name"),
         "RequiredLevel": {"Value": "ApplicationRequired"},
         "MaxLength": 100, "IsPrimaryName": True,

--- a/.github/plugins/dataverse/skills/dv-overview/SKILL.md
+++ b/.github/plugins/dataverse/skills/dv-overview/SKILL.md
@@ -89,6 +89,13 @@ If an SDK method fails or a PAC CLI command doesn't exist, **consult the relevan
 
 **Publisher prefix:** Never hardcode a prefix (especially not `new`). Always query existing publishers in the environment and ask the user which to use. The prefix is permanent on every component created with it. See the solution skill's publisher discovery flow.
 
+**Display names vs schema names:** Schema names are permanent internal identifiers (`prefix_PascalCase`, e.g., `gov_ChecklistTemplate`). Display names are human-readable labels shown in the UI (e.g., "Checklist Template"). **Never use the schema name as the display name.** When a user asks to create a "Checklist Template" table, derive:
+- Schema name: `prefix_ChecklistTemplate` (PascalCase, no spaces)
+- Display name: `"Checklist Template"` (natural language with spaces)
+- Plural display name: `"Checklist Templates"`
+
+The SDK `tables.create()` sets display name = schema name automatically. You MUST PATCH the display name after SDK table creation — see `dv-metadata` for the pattern. Apply the same principle to columns: schema `prefix_SpecialtyArea` → display "Specialty Area".
+
 ### 3. Use Documented Auth Patterns
 
 Authentication is handled by `pac auth create` (for PAC CLI) and `scripts/auth.py` (for Python scripts and the SDK).


### PR DESCRIPTION
# fix: add display name guidance to prevent schema names in UI

## Problem

When an agent creates tables from a single prompt (e.g., "build a health inspection system"), every table ends up with its **schema name used as the display name** in the Dataverse UI:

| Display Name (actual) | Schema Name |
|---|---|
| gov_checklisttemplate | gov_checklisttemplate |
| gov_codeenforcementcase | gov_codeenforcementcase |
| gov_healthinspectiondetail | gov_healthinspectiondetail |

**Expected:** Display names should be human-readable — "Checklist Template", "Code Enforcement Case", "Health Inspection Detail".

This happens because of two compounding issues:

1. **No naming guidance in skills.** The skill files had no explicit rule telling agents that display names and schema names must be different. Agents defaulted to reusing the schema name for both.
2. **SDK limitation.** The Python SDK's `tables.create()` internally sets `display_name = table_schema_name` ([`_odata.py` line 1550](https://github.com/microsoft/PowerPlatform-DataverseClient-Python)). There is no `display_name` parameter to override this. Even if an agent intended to set a proper display name, the SDK gave no way to do so.

A retry where the user **explicitly asked for proper display names** still failed — the agent got it right for the first table, then reverted to schema names for the rest. This confirms the issue is in the skill guidance, not just agent laziness.

## Fix

Minimal, targeted changes to two skill files:

### `dv-overview/SKILL.md` — new naming rule under Hard Rules

Added a "Display names vs schema names" rule that establishes the convention at the routing layer (loaded before all other skills):

- Schema names: `prefix_PascalCase` (e.g., `gov_ChecklistTemplate`)
- Display names: natural language with spaces (e.g., "Checklist Template")
- Explicit: "Never use the schema name as the display name"
- Calls out the SDK limitation and points to dv-metadata for the PATCH pattern

### `dv-metadata/SKILL.md` — naming convention section + updated table creation example

1. **New "Naming Conventions" section** with a reference table showing correct schema/display/plural derivations for real-world table names
2. **Updated SDK table creation example** to include a mandatory display-name PATCH after `tables.create()`, since the SDK cannot set display names
3. **Added a `set_table_display_name()` helper** for multi-table creation scripts — avoids repetition when creating many tables
4. **Updated Web API example** with clearer comments distinguishing `SchemaName` from `DisplayName`

### Version bump

1.1.0 -> 1.2.0 (minor — new skill patterns) across all 4 tracked version files:
- `.github/plugin/marketplace.json` (both entries)
- `.github/plugins/dataverse/.claude-plugin/plugin.json`
- `.github/plugins/dataverse/.github/plugin/plugin.json`

## Testing

### Static checks

```
$ python .github/evals/static_checks.py
PASSED -- 6 skill files, 71 Python blocks, 5 categories checked
```

### Manual validation — Test 1: Health Inspection System (6 tables)

Tested with a fresh Claude Code session loaded with the updated plugin. Prompt used:

> "I need to build a solution for a city government health inspection system. Create the following tables: Checklist Template, Health Inspection Detail, Health Violation Code, Code Enforcement Case, Complaint, and Inspection. Use the publisher prefix "gov". Don't actually run anything — just show me the Python script you would use to create all 6 tables."

**Result: all 4 criteria passed.**

| Criteria | Before | After |
|---|---|---|
| Schema names use PascalCase | `gov_checklisttemplate` | `gov_ChecklistTemplate` |
| Display names are human-readable | `gov_checklisttemplate` | "Checklist Template" |
| Plural display names set | not set | "Checklist Templates" |
| Display-name PATCH after SDK creation | missing | Phase 2 patches all tables |

The generated script correctly:
- Defined all 6 tables with separate `schema`, `display`, and `plural` fields
- Used PascalCase for all schema names
- Included a Phase 2 that patches display names via Web API after SDK creation
- Adopted the `set_table_display_name()` helper pattern from the skill
- Followed phased creation with retry/idempotency patterns

### Manual validation — Test 2: Power Platform Demo Tracker (end-to-end)

Tested with a fresh Claude Code session using the exact prompts that originally triggered the bug:

> **Prompt 1:** "Create a simple Dataverse solution that I can use as a Power Platform Demo Tracker tool for all my demos. We can use the Account table from the Common Data Service. Then we need a Demo table, an Environment table, an Azure Resource Group table. The Demo table should have lookup fields to Account, Environment, and Azure Resource Group. It should also use a Timeline control. Use proper Display Names. Do not use the publisher prefix for Display Names. The publisher should be a new publisher called "MPP Demos Publisher" with a prefix of "demo". The Demo table should have a choice field with the options, Power Platform, Canvas Apps, Model-Driven Apps, Power Pages, Copilot Studio, and Other."

The agent generated a full `setup_demo_tracker.py` script. Key findings:

| Table | Schema Name | Display Name | Plural Display Name |
|---|---|---|---|
| Environment | `demo_Environment` | "Environment" | "Environments" |
| Azure Resource Group | `demo_AzureResourceGroup` | "Azure Resource Group" | "Azure Resource Groups" |
| Demo | `demo_Demo` | "Demo" | "Demos" |

**Before the fix**, Environment and Azure Resource Group would have shown `demo_environment` and `demo_azureresourcegroup` as display names in the UI. **After the fix**, the agent:

1. Created tables via SDK in Phase 1
2. Added an explicit **Phase 1b** that patches all display names via Web API using the `set_table_display_name()` helper
3. Created the Demo table via Web API (needed `HasActivities=True` for Timeline) with correct `DisplayName: label("Demo")` set inline
4. No publisher prefix leaked into any display name

The generated script also correctly handled lookups (`display_name="Account"`, `"Environment"`, `"Azure Resource Group"`), the choice column (6 options), the Timeline form with `HasActivities`, a main form, and a default view — all with proper display names throughout.

### Independent code review

Reviewed the full diff (`git diff main..HEAD`) against the original bug report. The fix addresses both root causes:
- **Missing guidance** → naming convention sections added to both `dv-overview` (routing layer) and `dv-metadata` (implementation layer)
- **SDK limitation** → mandatory PATCH pattern documented with working code examples and a reusable helper

## Files changed

| File | Change |
|---|---|
| `.github/plugins/dataverse/skills/dv-overview/SKILL.md` | +7 lines — naming convention rule |
| `.github/plugins/dataverse/skills/dv-metadata/SKILL.md` | +85/-7 lines — naming section, updated examples, PATCH pattern |
| `.github/plugin/marketplace.json` | version 1.1.0 -> 1.2.0 |
| `.github/plugins/dataverse/.claude-plugin/plugin.json` | version 1.1.0 -> 1.2.0 |
| `.github/plugins/dataverse/.github/plugin/plugin.json` | version 1.1.0 -> 1.2.0 |
