### PR TITLE
add: version consistency eval and PR-level bump check

### DIFF
--- a/.github/evals/static_checks.py
+++ b/.github/evals/static_checks.py
@@ -45,9 +45,16 @@ CAT-5  Cross-Skill Completeness
        EVAL-COMPLETE-03  dv-overview Available Skills table lists every skill directory
        EVAL-COMPLETE-04  No skill references the removed 'dv-python-sdk' skill
        EVAL-COMPLETE-05  README.md skill count matches actual number of skill directories
+
+CAT-6  Manifest Version Consistency
+       Checks that the plugin version matches across all marketplace and plugin
+       manifest files, preventing drift when version bumps miss a file.
+       EVAL-VERSION-01  All four version fields match (3 files, 4 fields total)
+       EVAL-VERSION-02  Version format is valid semver (x.y.z)
 """
 
 import argparse
+import json
 import re
 import sys
 from pathlib import Path
@@ -316,6 +323,94 @@ def check_readme_skill_count(skills_dir, all_skill_names):
 
 
 # ---------------------------------------------------------------------------
+# CAT-6  Manifest Version Consistency
+# ---------------------------------------------------------------------------
+
+SEMVER_PATTERN = re.compile(r"^\d+\.\d+\.\d+$")
+
+
+def check_version_consistency(repo_root):
+    """
+    EVAL-VERSION-01: All four version fields match across manifest files.
+    EVAL-VERSION-02: Version format is valid semver (x.y.z).
+
+    The four version fields live in three files:
+      1. .github/plugin/marketplace.json -- metadata.version
+      2. .github/plugin/marketplace.json -- plugins[0].version
+      3. .github/plugins/dataverse/.claude-plugin/plugin.json -- version
+      4. .github/plugins/dataverse/.github/plugin/plugin.json -- version
+    """
+    failures = []
+
+    manifests = [
+        (
+            ".github/plugin/marketplace.json",
+            lambda d: d.get("metadata", {}).get("version"),
+            "metadata.version",
+        ),
+        (
+            ".github/plugin/marketplace.json",
+            lambda d: (d.get("plugins") or [{}])[0].get("version"),
+            "plugins[0].version",
+        ),
+        (
+            ".github/plugins/dataverse/.claude-plugin/plugin.json",
+            lambda d: d.get("version"),
+            "version",
+        ),
+        (
+            ".github/plugins/dataverse/.github/plugin/plugin.json",
+            lambda d: d.get("version"),
+            "version",
+        ),
+    ]
+
+    found = []
+    for rel_path, extractor, field in manifests:
+        full_path = repo_root / rel_path
+        if not full_path.exists():
+            failures.append(
+                f"EVAL-VERSION-01 [{rel_path}] manifest file not found"
+            )
+            continue
+        try:
+            data = json.loads(full_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as e:
+            failures.append(
+                f"EVAL-VERSION-01 [{rel_path}] invalid JSON: {e}"
+            )
+            continue
+
+        version = extractor(data)
+        if version is None:
+            failures.append(
+                f"EVAL-VERSION-01 [{rel_path}] missing '{field}' field"
+            )
+            continue
+
+        found.append((rel_path, field, version))
+
+        # EVAL-VERSION-02: semver format check
+        if not SEMVER_PATTERN.match(version):
+            failures.append(
+                f"EVAL-VERSION-02 [{rel_path}] '{field}' = '{version}' "
+                f"does not match semver format x.y.z"
+            )
+
+    # EVAL-VERSION-01: all collected versions must match
+    unique_versions = {v for _, _, v in found}
+    if len(unique_versions) > 1:
+        detail = ", ".join(
+            f"{rp}:{f}={v}" for rp, f, v in found
+        )
+        failures.append(
+            f"EVAL-VERSION-01 version mismatch across manifests -- {detail}"
+        )
+
+    return failures
+
+
+# ---------------------------------------------------------------------------
 # Runner
 # ---------------------------------------------------------------------------
 
@@ -358,6 +453,10 @@ def main():
     all_failures.extend(check_overview_index(overview_path, all_skill_names))
     all_failures.extend(check_readme_skill_count(skills_dir, all_skill_names))
 
+    # Manifest version consistency — check across repo root
+    repo_root = skills_dir.parent.parent.parent.parent
+    all_failures.extend(check_version_consistency(repo_root))
+
     if all_failures:
         # Group output by category prefix for readability
         categories = {}
@@ -376,7 +475,7 @@ def main():
         print(
             f"PASSED -- {len(skill_files)} skill files, "
             f"{python_block_count} Python blocks, "
-            f"5 categories checked"
+            f"6 categories checked"
         )
 
 

--- a/.github/evals/version_bump_check.py
+++ b/.github/evals/version_bump_check.py
@@ -1,0 +1,207 @@
+"""
+Version bump check — compares the base branch to HEAD and verifies that the
+version bump in the PR matches what the structural changes require.
+
+Rules:
+  - A removed or renamed skill directory requires a MAJOR bump.
+  - A new skill directory requires a MINOR bump (or MAJOR).
+  - Modifications only (prose, code fixes) can be PATCH.
+
+Usage:
+    python .github/evals/version_bump_check.py [--base main]
+
+Exit codes:
+  0 = check passed (or nothing version-relevant changed)
+  1 = version bump violates required level
+  2 = script error (missing git, not in repo, etc.)
+"""
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+SKILLS_REL = ".github/plugins/dataverse/skills"
+VERSION_FILE_REL = ".github/plugins/dataverse/.claude-plugin/plugin.json"
+
+BUMP_RANK = {"none": 0, "patch": 1, "minor": 2, "major": 3}
+
+
+def run_git(args):
+    """Run a git command, return stdout (stripped). Raise on non-zero exit."""
+    result = subprocess.run(
+        ["git"] + args,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"git {' '.join(args)} failed ({result.returncode}): {result.stderr.strip()}"
+        )
+    return result.stdout.strip()
+
+
+def parse_semver(v):
+    m = re.match(r"^(\d+)\.(\d+)\.(\d+)$", v.strip())
+    if not m:
+        raise ValueError(f"not valid semver: {v!r}")
+    return tuple(int(p) for p in m.groups())
+
+
+def classify_bump(old, new):
+    """Return 'major', 'minor', 'patch', or 'none' given two semver tuples."""
+    if new == old:
+        return "none"
+    if new[0] != old[0]:
+        return "major"
+    if new[1] != old[1]:
+        return "minor"
+    return "patch"
+
+
+def get_version_at(ref, path):
+    """Read the plugin.json version at the given git ref. None if file missing."""
+    try:
+        content = run_git(["show", f"{ref}:{path}"])
+    except RuntimeError:
+        return None
+    try:
+        return json.loads(content).get("version")
+    except json.JSONDecodeError:
+        return None
+
+
+def get_head_version(repo_root):
+    path = repo_root / VERSION_FILE_REL
+    if not path.exists():
+        return None
+    return json.loads(path.read_text(encoding="utf-8")).get("version")
+
+
+def list_skills_at(ref, skills_rel):
+    """List skill directory names at the given git ref."""
+    try:
+        out = run_git(["ls-tree", "-d", "--name-only", f"{ref}:{skills_rel}"])
+    except RuntimeError:
+        return set()
+    return {line.strip() for line in out.splitlines() if line.strip()}
+
+
+def list_head_skills(repo_root):
+    skills_dir = repo_root / SKILLS_REL
+    if not skills_dir.exists():
+        return set()
+    return {p.name for p in skills_dir.iterdir() if p.is_dir()}
+
+
+def required_bump(added, removed):
+    if removed:
+        return "major"
+    if added:
+        return "minor"
+    return "patch"
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Verify plugin version bump matches structural changes")
+    parser.add_argument("--base", default="main", help="base branch to compare against (default: main)")
+    args = parser.parse_args()
+
+    try:
+        repo_root = Path(run_git(["rev-parse", "--show-toplevel"]))
+    except RuntimeError as e:
+        print(f"ERROR: not in a git repository: {e}", file=sys.stderr)
+        sys.exit(2)
+
+    # Fetch base branch if not already available locally (no-op if already fetched)
+    try:
+        run_git(["rev-parse", "--verify", args.base])
+    except RuntimeError:
+        try:
+            run_git(["fetch", "origin", args.base])
+        except RuntimeError as e:
+            print(f"ERROR: cannot access base branch '{args.base}': {e}", file=sys.stderr)
+            sys.exit(2)
+
+    base_ref = args.base
+    base_version = get_version_at(base_ref, VERSION_FILE_REL)
+    head_version = get_head_version(repo_root)
+
+    if base_version is None:
+        print(f"ERROR: could not read version from {base_ref}:{VERSION_FILE_REL}", file=sys.stderr)
+        sys.exit(2)
+    if head_version is None:
+        print(f"ERROR: could not read version from HEAD:{VERSION_FILE_REL}", file=sys.stderr)
+        sys.exit(2)
+
+    try:
+        old = parse_semver(base_version)
+        new = parse_semver(head_version)
+    except ValueError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        sys.exit(2)
+
+    declared = classify_bump(old, new)
+
+    base_skills = list_skills_at(base_ref, SKILLS_REL)
+    head_skills = list_head_skills(repo_root)
+    added = head_skills - base_skills
+    removed = base_skills - head_skills
+
+    required = required_bump(added, removed)
+
+    # If nothing structural changed and declared is 'none', that's fine (PR may
+    # not need a bump at all — e.g., doc-only changes outside skills/).
+    if required == "patch" and declared == "none":
+        print("PASSED -- no version bump needed (no structural skill changes)")
+        sys.exit(0)
+
+    if BUMP_RANK[declared] < BUMP_RANK[required]:
+        print(
+            f"FAILED -- version bump insufficient\n"
+            f"  base ({base_ref}):  {base_version}\n"
+            f"  head (current):  {head_version}\n"
+            f"  declared bump:   {declared}\n"
+            f"  required bump:   {required}\n"
+        )
+        if added:
+            print(f"  added skills:    {sorted(added)}")
+        if removed:
+            print(f"  removed skills:  {sorted(removed)}")
+        print(
+            f"\nBump the version to at least {required.upper()} level "
+            f"(see CLAUDE.md 'Semver rules' section)."
+        )
+        sys.exit(1)
+
+    msg = (
+        f"PASSED -- {base_version} -> {head_version} "
+        f"({declared} bump, {required} required)"
+    )
+    if added:
+        msg += f"\n  added skills: {sorted(added)}"
+    if removed:
+        msg += f"\n  removed skills: {sorted(removed)}"
+    print(msg)
+
+    # Warn on over-bumping (declared > required) when no structural changes were
+    # detected. Legitimate cases exist (auth pattern change, renamed sections,
+    # new capabilities inside a skill), but a mismatch is worth a reviewer's eye.
+    if BUMP_RANK[declared] > BUMP_RANK[required] and not added and not removed:
+        print(
+            f"\nWARN -- declared {declared.upper()} bump but no structural skill "
+            f"changes detected.\n"
+            f"       Verify this is intentional (e.g., auth pattern change, "
+            f"renamed required section,\n"
+            f"       or other breaking change not reflected in skill directory "
+            f"structure)."
+        )
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/pr-metadata.yml
+++ b/.github/workflows/pr-metadata.yml
@@ -1,0 +1,60 @@
+name: PR Metadata Check
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+jobs:
+  check:
+    name: Validate PR title and body
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Check PR title and body
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const errors = [];
+
+            // 1. No branch-name leak in title (e.g., "Users/alice/my-feature")
+            if (/^[Uu]sers?\//.test(pr.title) || /^[a-z]+\/[a-z0-9._-]+\//.test(pr.title)) {
+              errors.push(
+                `Title appears to contain a branch path: "${pr.title}". ` +
+                `Use a human-readable title instead.`
+              );
+            }
+
+            // 2. Conventional commit prefix (matches CLAUDE.md convention)
+            const validPrefixes = /^(feat|fix|add|refactor|docs|chore|test|perf|build|ci):/i;
+            if (!validPrefixes.test(pr.title)) {
+              errors.push(
+                `Title must start with one of: feat:, fix:, add:, refactor:, docs:, chore:, test:, perf:, build:, ci:`
+              );
+            }
+
+            // 3. Non-empty body with meaningful content
+            const body = (pr.body || '').trim();
+            if (body.length < 50) {
+              errors.push(
+                `PR description must be at least 50 characters. ` +
+                `Explain the why and what of the change.`
+              );
+            }
+
+            // 4. Summary section encouraged
+            if (body.length >= 50 && !/##\s*Summary/i.test(body)) {
+              core.warning(
+                'PR description does not include a "## Summary" section. ' +
+                'Consider adding one for clearer context.'
+              );
+            }
+
+            if (errors.length) {
+              core.setFailed(
+                'PR metadata issues:\n' + errors.map(e => '  - ' + e).join('\n')
+              );
+            } else {
+              core.info('PR metadata check passed.');
+            }

--- a/.github/workflows/skill-evals.yml
+++ b/.github/workflows/skill-evals.yml
@@ -4,8 +4,9 @@ on:
   pull_request:
     branches: [main]
     paths:
-      - '.github/plugins/dataverse/skills/**'
+      - '.github/plugins/dataverse/**'
       - '.github/evals/**'
+      - '.github/plugin/marketplace.json'
 
 jobs:
   static-checks:
@@ -13,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # needed for version_bump_check.py to compare against main
 
       - uses: actions/setup-python@v5
         with:
@@ -20,3 +23,6 @@ jobs:
 
       - name: Run static eval suite
         run: python .github/evals/static_checks.py
+
+      - name: Run version bump check
+        run: python .github/evals/version_bump_check.py --base origin/main

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,11 +84,44 @@ Then describe a task that exercises the changed skill in plain English. The agen
 
 ## Version Bumping
 
-When a PR changes skill files (`.github/plugins/dataverse/skills/**`), bump the plugin version before merging. Version must be updated in all four files:
+When a PR changes skill files (`.github/plugins/dataverse/skills/**`), bump the plugin version before merging. Version must be updated in all four fields (across three files):
 
 1. `.github/plugin/marketplace.json` — top-level `metadata.version`
 2. `.github/plugin/marketplace.json` — plugin entry `version`
 3. `.github/plugins/dataverse/.claude-plugin/plugin.json` — `version`
 4. `.github/plugins/dataverse/.github/plugin/plugin.json` — `version`
 
-All four must match. Use semver: patch for fixes, minor for new patterns or skill changes, major for breaking changes (skill renames, removed sections).
+All four must match. The static eval (`python .github/evals/static_checks.py`) verifies version consistency and will fail if any of the four fields drift.
+
+Run the PR-level bump check to verify the bump level matches the structural changes in your branch:
+
+```bash
+python .github/evals/version_bump_check.py
+```
+
+It compares your branch to `main` and flags common mistakes — e.g., adding a new skill without a MINOR bump, or removing a skill without a MAJOR bump.
+
+### Semver rules (x.y.z)
+
+**MAJOR (x)** — Breaking changes that require user action:
+- Renaming or removing a skill
+- Removing or renaming a required section in a skill (e.g., `## Skill boundaries`)
+- Changing the auth pattern (e.g., switching from `get_credential` to a new import)
+- Changing MCP server configuration structure
+- Removing supported tools (SDK, PAC CLI, Web API) from routing
+
+**MINOR (y)** — Backward-compatible additions:
+- Adding a new skill
+- Adding a new section to an existing skill
+- New capabilities (new MCP tool guidance, new SDK patterns, new Web API examples)
+- New keywords or metadata fields
+- Expanding skill boundaries to cover new scenarios
+
+**PATCH (z)** — Backward-compatible fixes:
+- Bug fixes in code examples
+- Typo and grammar corrections
+- Clarifying prose without changing behavior
+- Updating links or references
+- Minor refactors that don't change skill routing
+
+**Note:** No need to update the `version` field in the [awesome-copilot marketplace](https://github.com/github/awesome-copilot/blob/main/plugins/external.json). The entry there tracks the default branch of this repo, so version updates propagate automatically. The `version` field in awesome-copilot is cosmetic-only.


### PR DESCRIPTION
## Summary

Adds evals and CI checks to prevent version drift, semver violations, and PR metadata issues.

### 1. Static version consistency check (`static_checks.py`)

New CAT-6 Manifest Version Consistency category:
- `EVAL-VERSION-01` — All four version fields match across the three manifest files
- `EVAL-VERSION-02` — Version format is valid semver (`x.y.z`)

### 2. PR-level bump check (new `version_bump_check.py`)

Compares the PR branch to `main` and verifies the bump level matches structural changes:
- **Fails** when a new skill is added without a MINOR bump
- **Fails** when a skill is removed without a MAJOR bump
- **Warns** on over-bumping without structural changes (legitimate cases exist — auth pattern changes, renamed required sections — so over-bumping is a warning, not a failure)

### 3. PR metadata check (new `pr-metadata.yml`)

Runs on every PR regardless of files changed. Validates:
- Title does not leak a branch path (e.g., `Users/alice/my-feature`)
- Title starts with a conventional commit prefix (`feat:`, `fix:`, `add:`, etc.)
- Body is at least 50 characters
- Warns when body does not include a `## Summary` section

### 4. CI wiring (`skill-evals.yml`)

- Extended `paths` filter to also trigger on manifest file changes
- Added `version_bump_check.py` step
- `fetch-depth: 0` so the bump check can compare against `main`

### 5. CLAUDE.md updates

- Added concrete semver rules (MAJOR/MINOR/PATCH) with Dataverse-specific examples
- Referenced the two new evals
- Clarified that the awesome-copilot marketplace version does NOT need bumping (cosmetic only; installs track the default branch)

## Test plan

- [x] `python .github/evals/static_checks.py` — passes (6 categories, 70 Python blocks)
- [x] `python .github/evals/version_bump_check.py` — passes (no structural changes)
- [x] Manually tested drift detection: modifying one version file fails EVAL-VERSION-01
- [x] Manually tested bump check: adding a skill without a minor bump fails; removing a skill without a major bump fails; over-bumping triggers WARN but exits 0
- [ ] CI run on this PR validates both workflows execute cleanly