### PR TITLE
feat: add Node.js and Dataverse CLI to dv-connect toolchain check

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "dataverse-skills",
   "metadata": {
     "description": "Official Dataverse plugin marketplace for agent-guided development",
-    "version": "1.1.0"
+    "version": "1.2.0"
   },
   "owner": {
     "name": "Microsoft",
@@ -13,7 +13,7 @@
       "name": "dataverse",
       "description": "Agent skills for building on, analyzing, and managing Microsoft Dataverse — with Dataverse MCP, PAC CLI, and Python SDK.",
       "source": "./.github/plugins/dataverse",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "homepage": "https://github.com/microsoft/Dataverse-skills"
     }
   ]

--- a/.github/plugins/dataverse/.claude-plugin/plugin.json
+++ b/.github/plugins/dataverse/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dataverse",
   "description": "Agent skills for building on, analyzing, and managing Microsoft Dataverse — with Dataverse MCP, PAC CLI, and Python SDK.",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": {
     "name": "Microsoft",
     "url": "https://www.microsoft.com"

--- a/.github/plugins/dataverse/.github/plugin/plugin.json
+++ b/.github/plugins/dataverse/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dataverse",
   "description": "Agent skills for building on, analyzing, and managing Microsoft Dataverse — with Dataverse MCP, PAC CLI, and Python SDK.",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": {
     "name": "Microsoft",
     "url": "https://www.microsoft.com"

--- a/.github/plugins/dataverse/skills/dv-connect/SKILL.md
+++ b/.github/plugins/dataverse/skills/dv-connect/SKILL.md
@@ -29,17 +29,24 @@ Check each tool independently — **do not use fail-fast parallel execution.** I
 |---|---|
 | Python 3 | `python --version` |
 | Git | `git --version` |
+| Node.js | `node --version` |
 | PAC CLI | `pac` (prints version banner; note: `pac --version` is not a valid command and returns a non-zero exit code) (see [tools-setup.md](references/tools-setup.md) for Windows path discovery if not in PATH) |
+| Dataverse CLI | `npx @microsoft/dataverse --version` |
 | .NET SDK | `dotnet --version` |
 | Azure CLI | `az --version` |
 
-.NET SDK is needed for PAC CLI but NOT for the MCP proxy (the npm package bundles its own runtime). Azure CLI is used as a fallback for environment discovery when PAC CLI isn't available (see [mcp-configuration.md](references/mcp-configuration.md) Step 3b). GitHub CLI is not needed for connecting — it's used later for ALM/CI/CD scenarios (see `dv-solution`).
+.NET SDK is needed for PAC CLI but NOT for the Dataverse CLI (the npm package bundles its own runtime). Node.js powers the Dataverse CLI npm package (`@microsoft/dataverse`), which is used as the MCP proxy and for scripted data plane actions. Azure CLI is used as a fallback for environment discovery when PAC CLI isn't available (see [mcp-configuration.md](references/mcp-configuration.md) Step 3b). GitHub CLI is not needed for connecting — it's used later for ALM/CI/CD scenarios (see `dv-solution`).
 
 If any tool is missing, install it (see [tools-setup.md](references/tools-setup.md)), then verify. If `winget` installs a tool but it's not in PATH, ask the user to restart the terminal.
 
 After Python is confirmed:
 ```
 pip install --upgrade azure-identity requests PowerPlatform-Dataverse-Client pandas
+```
+
+After Node.js is confirmed, the Dataverse CLI is fetched on first use via `npx -y @microsoft/dataverse@latest`. To pre-warm the cache or pin a specific version globally:
+```
+npm install -g @microsoft/dataverse
 ```
 
 **Skip condition:** All tools present, Python SDK installed, and `pandas` importable (`python -c "import pandas"`).

--- a/.github/plugins/dataverse/skills/dv-connect/SKILL.md
+++ b/.github/plugins/dataverse/skills/dv-connect/SKILL.md
@@ -44,9 +44,9 @@ After Python is confirmed:
 pip install --upgrade azure-identity requests PowerPlatform-Dataverse-Client pandas
 ```
 
-After Node.js is confirmed, the Dataverse CLI is fetched on first use via `npx -y @microsoft/dataverse@latest`. To pre-warm the cache or pin a specific version globally:
+After Node.js is confirmed, install or upgrade the Dataverse CLI to the latest version. This mirrors the `pip install --upgrade` pattern used for the Python SDK — running it on each connect ensures the CLI stays current:
 ```
-npm install -g @microsoft/dataverse
+npm install -g @microsoft/dataverse@latest
 ```
 
 **Skip condition:** All tools present, Python SDK installed, and `pandas` importable (`python -c "import pandas"`).

--- a/.github/plugins/dataverse/skills/dv-connect/SKILL.md
+++ b/.github/plugins/dataverse/skills/dv-connect/SKILL.md
@@ -31,7 +31,7 @@ Check each tool independently — **do not use fail-fast parallel execution.** I
 | Git | `git --version` |
 | Node.js | `node --version` |
 | PAC CLI | `pac` (prints version banner; note: `pac --version` is not a valid command and returns a non-zero exit code) (see [tools-setup.md](references/tools-setup.md) for Windows path discovery if not in PATH) |
-| Dataverse CLI | `npx @microsoft/dataverse --version` |
+| Dataverse CLI | `npm list -g @microsoft/dataverse` (prints `@microsoft/dataverse@<version>` if installed globally; prints `(empty)` if not) |
 | .NET SDK | `dotnet --version` |
 | Azure CLI | `az --version` |
 

--- a/.github/plugins/dataverse/skills/dv-connect/references/tools-setup.md
+++ b/.github/plugins/dataverse/skills/dv-connect/references/tools-setup.md
@@ -12,7 +12,7 @@ Check all in parallel. Install any that are missing.
 | .NET SDK | `dotnet --version` | `winget install Microsoft.DotNet.SDK.9` |
 | Python 3 | `python --version` | `winget install Python.Python.3.12` |
 | Node.js | `node --version` | `winget install OpenJS.NodeJS.LTS` |
-| Dataverse CLI | `npx @microsoft/dataverse --version` | `npm install -g @microsoft/dataverse@latest` (always upgrades to latest — mirrors `pip install --upgrade` for the Python SDK) |
+| Dataverse CLI | `npm list -g @microsoft/dataverse` (shows `@microsoft/dataverse@<version>` if installed; `(empty)` if not) | `npm install -g @microsoft/dataverse@latest` (always upgrades to latest — mirrors `pip install --upgrade` for the Python SDK) |
 | Git | `git --version` | `winget install Git.Git` |
 
 After any `winget` install, the new tool may not be in PATH until the shell is restarted. If a tool is not found immediately after install, ask the user to close and reopen the terminal (if running in Claude Code, remind them to resume the session correctly: "Remember to **use `claude --continue` to resume the session** without losing context"), then proceed.

--- a/.github/plugins/dataverse/skills/dv-connect/references/tools-setup.md
+++ b/.github/plugins/dataverse/skills/dv-connect/references/tools-setup.md
@@ -11,6 +11,8 @@ Check all in parallel. Install any that are missing.
 | Azure CLI | `az --version` | `winget install Microsoft.AzureCLI` |
 | .NET SDK | `dotnet --version` | `winget install Microsoft.DotNet.SDK.9` |
 | Python 3 | `python --version` | `winget install Python.Python.3.12` |
+| Node.js | `node --version` | `winget install OpenJS.NodeJS.LTS` |
+| Dataverse CLI | `npx @microsoft/dataverse --version` | `npm install -g @microsoft/dataverse` (optional — `npx -y @microsoft/dataverse@latest` fetches on demand) |
 | Git | `git --version` | `winget install Git.Git` |
 
 After any `winget` install, the new tool may not be in PATH until the shell is restarted. If a tool is not found immediately after install, ask the user to close and reopen the terminal (if running in Claude Code, remind them to resume the session correctly: "Remember to **use `claude --continue` to resume the session** without losing context"), then proceed.

--- a/.github/plugins/dataverse/skills/dv-connect/references/tools-setup.md
+++ b/.github/plugins/dataverse/skills/dv-connect/references/tools-setup.md
@@ -12,7 +12,7 @@ Check all in parallel. Install any that are missing.
 | .NET SDK | `dotnet --version` | `winget install Microsoft.DotNet.SDK.9` |
 | Python 3 | `python --version` | `winget install Python.Python.3.12` |
 | Node.js | `node --version` | `winget install OpenJS.NodeJS.LTS` |
-| Dataverse CLI | `npx @microsoft/dataverse --version` | `npm install -g @microsoft/dataverse` (optional — `npx -y @microsoft/dataverse@latest` fetches on demand) |
+| Dataverse CLI | `npx @microsoft/dataverse --version` | `npm install -g @microsoft/dataverse@latest` (always upgrades to latest — mirrors `pip install --upgrade` for the Python SDK) |
 | Git | `git --version` | `winget install Git.Git` |
 
 After any `winget` install, the new tool may not be in PATH until the shell is restarted. If a tool is not found immediately after install, ask the user to close and reopen the terminal (if running in Claude Code, remind them to resume the session correctly: "Remember to **use `claude --continue` to resume the session** without losing context"), then proceed.


### PR DESCRIPTION
## Summary

Adds Node.js and Dataverse CLI (`@microsoft/dataverse`) to dv-connect's Step 1 prerequisite check, and ensures the CLI stays current across sessions by using `npm install -g @microsoft/dataverse@latest` — matching the Python SDK's `pip install --upgrade` pattern.

Previously the Dataverse CLI was an implicit on-demand dependency via `npx`, which caused unhelpful 'command not found' errors when Node.js was missing. A globally installed CLI also never upgraded once installed.

## Changes

- Add Node.js (`node --version`) and Dataverse CLI (`npx @microsoft/dataverse --version`) to the toolchain check table in dv-connect SKILL.md
- Add install commands to tools-setup.md:
  - `winget install OpenJS.NodeJS.LTS` for Node.js
  - `npm install -g @microsoft/dataverse@latest` for the CLI (always upgrades to latest — mirrors `pip install --upgrade` for the Python SDK)
- Update prose to clarify the Dataverse CLI's role (powers the MCP proxy + scripted data plane commands) and the upgrade-on-connect behavior
- Bump version 1.1.0 → 1.2.0 (MINOR — new toolchain capabilities, backward-compatible)

## Why

The Dataverse CLI is increasingly central to the plugin's architecture:
- Already used as the MCP proxy via `npx -y @microsoft/dataverse@latest mcp`
- Recent main commits added `data`, `skill`, `workspace`, and `erp` subcommands — making it a first-class scripted data plane tool
- Without explicit toolchain validation, users hit unclear failures when Node.js is missing
- Without `@latest` on the install, users who ran dv-connect once stayed on whatever CLI version was current at the time — drifting further from fixes and new features

## Test plan

- [x] `python .github/evals/static_checks.py` — passes
- [ ] Manually verify dv-connect catches missing Node.js and reports it cleanly
- [ ] Manually verify `npm install -g @microsoft/dataverse@latest` upgrades an existing install
- [ ] Manually verify `npx @microsoft/dataverse --version` works on a fresh machine