### PR TITLE
docs: prefer winget for PAC CLI install + inline PATH setup for Git Bash

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "dataverse-skills",
   "metadata": {
     "description": "Official Dataverse plugin marketplace for agent-guided development",
-    "version": "1.2.0"
+    "version": "1.2.1"
   },
   "owner": {
     "name": "Microsoft",
@@ -13,7 +13,7 @@
       "name": "dataverse",
       "description": "Agent skills for building on, analyzing, and managing Microsoft Dataverse — with Dataverse MCP, PAC CLI, and Python SDK.",
       "source": "./.github/plugins/dataverse",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "homepage": "https://github.com/microsoft/Dataverse-skills"
     }
   ]

--- a/.github/plugins/dataverse/.claude-plugin/plugin.json
+++ b/.github/plugins/dataverse/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dataverse",
   "description": "Agent skills for building on, analyzing, and managing Microsoft Dataverse — with Dataverse MCP, PAC CLI, and Python SDK.",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "author": {
     "name": "Microsoft",
     "url": "https://www.microsoft.com"

--- a/.github/plugins/dataverse/.github/plugin/plugin.json
+++ b/.github/plugins/dataverse/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dataverse",
   "description": "Agent skills for building on, analyzing, and managing Microsoft Dataverse — with Dataverse MCP, PAC CLI, and Python SDK.",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "author": {
     "name": "Microsoft",
     "url": "https://www.microsoft.com"

--- a/.github/plugins/dataverse/skills/dv-connect/references/tools-setup.md
+++ b/.github/plugins/dataverse/skills/dv-connect/references/tools-setup.md
@@ -15,20 +15,41 @@ Check all in parallel. Install any that are missing.
 | Dataverse CLI | `npm list -g @microsoft/dataverse` (shows `@microsoft/dataverse@<version>` if installed; `(empty)` if not) | `npm install -g @microsoft/dataverse@latest` (always upgrades to latest — mirrors `pip install --upgrade` for the Python SDK) |
 | Git | `git --version` | `winget install Git.Git` |
 
-After any `winget` install, the new tool may not be in PATH until the shell is restarted. If a tool is not found immediately after install, ask the user to close and reopen the terminal (if running in Claude Code, remind them to resume the session correctly: "Remember to **use `claude --continue` to resume the session** without losing context"), then proceed.
+After any `winget` install, the new tool may not be in PATH until the shell is restarted. For PAC CLI specifically, don't rely on shell restart — discover the install location and add it to PATH inline (see PAC CLI section below). For other tools, if not found immediately after install, ask the user to close and reopen the terminal (if running in Claude Code, remind them: "Remember to **use `claude --continue` to resume the session** without losing context"), then proceed.
+
+### PAC CLI install — winget is the primary path
+
+**Use `winget install Microsoft.PowerAppsCLI`.** Do NOT use `dotnet tool install --global Microsoft.PowerApps.CLI.Tool` as the primary install method — it has a known packaging bug (missing `DotnetToolSettings.xml`) that fails on recent .NET SDK versions with the error "The settings file in the tool's NuGet package is invalid." Reserve `dotnet tool install` as a last-resort fallback only when winget is unavailable.
+
+After `winget install Microsoft.PowerAppsCLI` completes, PAC CLI is typically installed at:
+
+```
+C:\Users\<user>\AppData\Local\Microsoft\PowerAppsCLI\Microsoft.PowerApps.CLI.<version>\tools\
+```
+
+Don't require a shell restart. Instead, add the install directory to PATH inline in the current session and persist it to `~/.bashrc`:
+
+```bash
+# 1. Find the install directory (the versioned subfolder)
+PAC_DIR=$(ls -d /c/Users/$USER/AppData/Local/Microsoft/PowerAppsCLI/Microsoft.PowerApps.CLI.*/tools 2>/dev/null | tail -1)
+
+# 2. Add to current session
+export PATH="$PAC_DIR:$PATH"
+
+# 3. Persist to ~/.bashrc (skip if already present)
+touch ~/.bashrc
+grep -q "PowerAppsCLI" ~/.bashrc || echo "export PATH=\"$PAC_DIR:\$PATH\"" >> ~/.bashrc
+
+# 4. Verify
+pac
+```
 
 ### PAC CLI on Windows Git Bash
 
-PAC CLI is a `.cmd` wrapper. In Git Bash (used by Claude Code), `pac` alone may fail or hang. Use the PowerShell wrapper:
+PAC CLI is a `.cmd` wrapper. In Git Bash (used by Claude Code), `pac` alone may fail or hang. If after the PATH setup above `pac` still fails, use the PowerShell wrapper:
 
 ```bash
 powershell -Command "& 'C:\Users\$USER\AppData\Local\Microsoft\PowerAppsCLI\pac.cmd' help"
-```
-
-Or, if installed via `dotnet tool install --global`:
-
-```bash
-powershell -Command "& pac help"
 ```
 
 To avoid repeating this, add an alias to `~/.bashrc`:
@@ -38,7 +59,7 @@ echo 'alias pac="powershell -Command \"& pac.cmd\""' >> ~/.bashrc
 source ~/.bashrc
 ```
 
-If `pac` works directly in your shell, skip the PowerShell wrapper — it's only needed when Git Bash can't execute `.cmd` files.
+If `pac` works directly in your shell (after PATH setup above), skip the PowerShell wrapper — it's only needed when Git Bash can't execute `.cmd` files.
 
 ### Python SDK
 
@@ -49,7 +70,7 @@ pip install --upgrade azure-identity requests PowerPlatform-Dataverse-Client pan
 
 ### If winget is unavailable
 
-- PAC CLI: `dotnet tool install --global Microsoft.PowerApps.CLI.Tool`
+- PAC CLI: download the latest NuGet package from https://www.nuget.org/packages/Microsoft.PowerApps.CLI and extract to a local directory, or (last resort) `dotnet tool install --global Microsoft.PowerApps.CLI.Tool` (known to fail with "settings file invalid" — retry with a specific version if the latest is broken)
 - GitHub CLI: download from https://cli.github.com
 - Azure CLI: download from https://aka.ms/installazurecliwindows
 

--- a/.github/plugins/dataverse/skills/dv-connect/references/tools-setup.md
+++ b/.github/plugins/dataverse/skills/dv-connect/references/tools-setup.md
@@ -17,9 +17,11 @@ Check all in parallel. Install any that are missing.
 
 After any `winget` install, the new tool may not be in PATH until the shell is restarted. For PAC CLI specifically, don't rely on shell restart — discover the install location and add it to PATH inline (see PAC CLI section below). For other tools, if not found immediately after install, ask the user to close and reopen the terminal (if running in Claude Code, remind them: "Remember to **use `claude --continue` to resume the session** without losing context"), then proceed.
 
-### PAC CLI install — winget is the primary path
+### PAC CLI install — winget primary (Windows + Git Bash)
 
-**Use `winget install Microsoft.PowerAppsCLI`.** Do NOT use `dotnet tool install --global Microsoft.PowerApps.CLI.Tool` as the primary install method — it has a known packaging bug (missing `DotnetToolSettings.xml`) that fails on recent .NET SDK versions with the error "The settings file in the tool's NuGet package is invalid." Reserve `dotnet tool install` as a last-resort fallback only when winget is unavailable.
+> **Scope:** the steps below assume Windows with Git Bash (the typical Claude Code environment). For macOS/Linux, see the [official PAC CLI install docs](https://learn.microsoft.com/en-us/power-platform/developer/cli/introduction#install-power-platform-cli).
+
+**Prefer `winget install Microsoft.PowerAppsCLI`** as the install method on Windows. `dotnet tool install --global Microsoft.PowerApps.CLI.Tool` has had recurring packaging issues on some .NET SDK versions — if it fails with "The settings file in the tool's NuGet package is invalid" (missing `DotnetToolSettings.xml`), fall back to winget or download the NuGet package directly. The bug is transient per package release, so don't treat `dotnet tool install` as permanently broken; just don't make it the first choice when winget is available.
 
 After `winget install Microsoft.PowerAppsCLI` completes, PAC CLI is typically installed at:
 
@@ -27,7 +29,7 @@ After `winget install Microsoft.PowerAppsCLI` completes, PAC CLI is typically in
 C:\Users\<user>\AppData\Local\Microsoft\PowerAppsCLI\Microsoft.PowerApps.CLI.<version>\tools\
 ```
 
-Don't require a shell restart. Instead, add the install directory to PATH inline in the current session and persist it to `~/.bashrc`:
+Don't require a shell restart — add the install directory to PATH inline and persist it to `~/.bashrc`. The snippet below assumes a per-user winget install in Git Bash; adapt paths if you installed machine-wide (usually under `C:\Program Files\Microsoft\PowerAppsCLI\`) or are using a different shell:
 
 ```bash
 # 1. Find the install directory (the versioned subfolder)
@@ -70,7 +72,7 @@ pip install --upgrade azure-identity requests PowerPlatform-Dataverse-Client pan
 
 ### If winget is unavailable
 
-- PAC CLI: download the latest NuGet package from https://www.nuget.org/packages/Microsoft.PowerApps.CLI and extract to a local directory, or (last resort) `dotnet tool install --global Microsoft.PowerApps.CLI.Tool` (known to fail with "settings file invalid" — retry with a specific version if the latest is broken)
+- PAC CLI: download the latest NuGet package from https://www.nuget.org/packages/Microsoft.PowerApps.CLI and extract to a local directory, or try `dotnet tool install --global Microsoft.PowerApps.CLI.Tool` (known to fail with "settings file invalid" on some .NET SDK + package version combinations — if that error appears, retry with an explicit `--version` or fall back to the NuGet download above)
 - GitHub CLI: download from https://cli.github.com
 - Azure CLI: download from https://aka.ms/installazurecliwindows
 


### PR DESCRIPTION
## Summary

Two `tools-setup.md` updates driven by real-world testing of the connect flow on Windows with Git Bash. The agent defaulted to `dotnet tool install --global Microsoft.PowerApps.CLI.Tool`, hit the known "DotnetToolSettings.xml not found" packaging bug, fell back to `winget`, and then had to manually discover the install path before PAC CLI was usable.

## Changes

### 1. Prefer winget for PAC CLI install on Windows

Updated the PAC CLI install section to explicitly prefer `winget install Microsoft.PowerAppsCLI` as the primary method on Windows. `dotnet tool install` is not forbidden — its packaging bug is transient per package release, so the doc describes it honestly ("recurring issues on some .NET SDK + package version combinations") and shows the fallback path (NuGet download) without making `dotnet tool install` permanently off-limits.

### 2. Inline PATH setup for Git Bash (scoped)

After `winget install`, PAC CLI's versioned install directory is typically not on PATH in Git Bash, and a shell restart doesn't fix it. Added a four-step snippet that:

- Discovers the versioned install dir (`C:\Users\<user>\AppData\Local\Microsoft\PowerAppsCLI\Microsoft.PowerApps.CLI.<version>\tools\`)
- Exports it to the current session's PATH
- Persists to `~/.bashrc` (skip-if-already-present)
- Verifies with `pac`

Scope is explicit: the snippet is for Windows + Git Bash. Added a note at the top of the PAC CLI section linking to the [official PAC CLI install docs](https://learn.microsoft.com/en-us/power-platform/developer/cli/introduction#install-power-platform-cli) for macOS/Linux users, and noting the machine-wide install path (`C:\Program Files\...`) for users who did not do a per-user winget install.

## Version bump

1.2.0 → 1.2.1 (PATCH — doc/flow clarification, no skill routing change)

## Test plan

- [x] `python .github/evals/static_checks.py` — passes
- [x] `python .github/evals/version_bump_check.py` — passes
- [ ] Manually verify on a fresh Windows + Git Bash machine: `winget install Microsoft.PowerAppsCLI` + the inline PATH snippet makes `pac` available in the current session without a restart
- [ ] Manually verify the `~/.bashrc` edit is idempotent (doesn't duplicate on repeat runs)