### PR TITLE
refactor: adopt Anthropic skill-authoring conventions; enforce token budget

### DIFF
--- a/.github/evals/static_checks.py
+++ b/.github/evals/static_checks.py
@@ -38,6 +38,9 @@ CAT-4  Skill Structure & Discoverability
        EVAL-STRUCT-02  Frontmatter 'name' matches the skill directory name
        EVAL-STRUCT-03  Description contains a 'Use when' routing hint
        EVAL-STRUCT-04  Description is <= 1024 chars (Anthropic spec hard limit)
+       EVAL-STRUCT-05  Frontmatter parses as valid YAML (catches unquoted colons,
+                       malformed mappings, and other syntax errors that break the
+                       skill manifest on GitHub and at plugin-load time)
 
 CAT-5  Cross-Skill Completeness
        Checks that skills reference each other correctly and that the
@@ -85,6 +88,12 @@ try:
     _ENCODER = tiktoken.get_encoding("cl100k_base")
 except ImportError:
     _ENCODER = None
+
+try:
+    import yaml
+    _YAML = yaml
+except ImportError:
+    _YAML = None
 
 
 def count_tokens(text):
@@ -277,6 +286,22 @@ def check_structure(name, text):
             f"EVAL-STRUCT-04 [{name}] description is {len(desc)} chars, "
             f"exceeds Anthropic's {DESCRIPTION_CHAR_LIMIT}-char limit"
         )
+
+    # EVAL-STRUCT-05: frontmatter must parse as valid YAML.
+    # Without this, descriptions with unquoted colons (e.g., "data model: add a
+    # column") render fine to a regex-extractor but break GitHub's YAML parser
+    # and any agent that loads the skill via a real YAML library.
+    if _YAML is not None:
+        try:
+            _YAML.safe_load(frontmatter)
+        except _YAML.YAMLError as e:
+            mark = getattr(e, "problem_mark", None)
+            loc = f" (line {mark.line + 1} col {mark.column + 1})" if mark else ""
+            failures.append(
+                f"EVAL-STRUCT-05 [{name}] frontmatter is not valid YAML{loc}: "
+                f"{getattr(e, 'problem', str(e))} -- "
+                f"common cause: an unquoted colon in the description value"
+            )
 
     return failures
 

--- a/.github/evals/static_checks.py
+++ b/.github/evals/static_checks.py
@@ -31,11 +31,13 @@ CAT-3  PAC CLI Accuracy
 
 CAT-4  Skill Structure & Discoverability
        Checks that every skill has the structural elements agents need to
-       discover and route to it correctly.
+       discover and route to it correctly. Anchored to Anthropic's Skills
+       authoring guidance: description is a single descriptive sentence with
+       an inline 'Use when ...' clause, third-person, max 1024 chars.
        EVAL-STRUCT-01  Frontmatter has required 'name' and 'description' fields
        EVAL-STRUCT-02  Frontmatter 'name' matches the skill directory name
-       EVAL-STRUCT-03  Frontmatter 'description' contains 'Use when:' trigger
-       EVAL-STRUCT-04  Frontmatter 'description' contains 'Do not use when:' trigger
+       EVAL-STRUCT-03  Description contains a 'Use when' routing hint
+       EVAL-STRUCT-04  Description is <= 1024 chars (Anthropic spec hard limit)
 
 CAT-5  Cross-Skill Completeness
        Checks that skills reference each other correctly and that the
@@ -61,6 +63,15 @@ CAT-7  Manifest Version Consistency
        manifest files, preventing drift when version bumps miss a file.
        EVAL-VERSION-01  All four version fields match (3 files, 4 fields total)
        EVAL-VERSION-02  Version format is valid semver (x.y.z)
+
+CAT-8  Skill Token Budget (Anthropic Skills spec)
+       Anthropic's published skills loading model — Level 1 (frontmatter, always
+       loaded across every interaction) ~100 tokens; Level 2 (body, loaded on
+       trigger) <5k tokens; Level 3 (`references/`, loaded on demand) unlimited.
+       EVAL-BUDGET-01  Frontmatter <= 200 tokens (Level 1, with headroom)
+       EVAL-BUDGET-02  Body       <= 5,000 tokens (Level 2 cap)
+       EVAL-BUDGET-03  Skills with body > 4,000 tokens must have a `references/`
+                       subfolder (forces Level 3 split before Level 2 fills up)
 """
 
 import argparse
@@ -69,11 +80,30 @@ import re
 import sys
 from pathlib import Path
 
+try:
+    import tiktoken
+    _ENCODER = tiktoken.get_encoding("cl100k_base")
+except ImportError:
+    _ENCODER = None
+
+
+def count_tokens(text):
+    """Token count using the cl100k_base encoder (matches Claude's input units).
+    Falls back to a 4-chars-per-token approximation if tiktoken is unavailable."""
+    if _ENCODER is not None:
+        return len(_ENCODER.encode(text))
+    return max(1, len(text) // 4)
+
 # Skills that intentionally have no Skill Boundaries table.
 NO_BOUNDARIES_EXEMPT = {"dv-overview", "dv-connect"}
 
-# Skills that intentionally have no 'Do not use when:' trigger (orchestration skills).
-NO_DO_NOT_USE_EXEMPT = {"dv-overview", "dv-connect"}
+# Skills exempt from CAT-8.3 (the references/ split nudge): orchestration / index
+# skills are loaded as one routing surface and don't have a natural "long workflow"
+# to extract. Hard cap (CAT-8.2) still applies.
+NO_REFERENCES_NUDGE_EXEMPT = {"dv-overview"}
+
+# Anthropic's Skills spec hard limit on the description field (per docs.claude.com).
+DESCRIPTION_CHAR_LIMIT = 1024
 
 
 def extract_fenced_blocks(text, lang="python"):
@@ -231,19 +261,22 @@ def check_structure(name, text):
                 f"does not match directory name '{name}'"
             )
 
-    # EVAL-STRUCT-03: 'Use when:' trigger present in description
-    if "Use when:" not in frontmatter:
+    # EVAL-STRUCT-03: 'Use when' routing hint present in description
+    desc_match = re.search(r"^description\s*:\s*(.+?)(?=^\w|\Z)", frontmatter, re.MULTILINE | re.DOTALL)
+    desc = desc_match.group(1).strip() if desc_match else ""
+    if "Use when" not in desc:
         failures.append(
-            f"EVAL-STRUCT-03 [{name}] frontmatter description missing 'Use when:' routing trigger"
+            f"EVAL-STRUCT-03 [{name}] description missing 'Use when' routing hint "
+            f"(per Anthropic's skill-authoring guidance, the description should "
+            f"include both what the skill does and when to use it)"
         )
 
-    # EVAL-STRUCT-04: 'Do not use when:' trigger present in description
-    if name not in NO_DO_NOT_USE_EXEMPT:
-        if "Do not use when:" not in frontmatter:
-            failures.append(
-                f"EVAL-STRUCT-04 [{name}] frontmatter description missing "
-                f"'Do not use when:' routing trigger"
-            )
+    # EVAL-STRUCT-04: description <= 1024 chars (Anthropic spec hard limit)
+    if len(desc) > DESCRIPTION_CHAR_LIMIT:
+        failures.append(
+            f"EVAL-STRUCT-04 [{name}] description is {len(desc)} chars, "
+            f"exceeds Anthropic's {DESCRIPTION_CHAR_LIMIT}-char limit"
+        )
 
     return failures
 
@@ -503,6 +536,59 @@ def check_version_consistency(repo_root):
 
 
 # ---------------------------------------------------------------------------
+# CAT-8  Skill Token Budget (Anthropic Skills spec)
+# ---------------------------------------------------------------------------
+
+FRONTMATTER_TOKEN_CAP = 200
+BODY_TOKEN_CAP = 5000
+BODY_TOKEN_REFERENCES_TRIGGER = 4000
+
+
+def check_token_budget(name, text, skill_dir):
+    """
+    EVAL-BUDGET-01: frontmatter <= FRONTMATTER_TOKEN_CAP tokens (Level 1)
+    EVAL-BUDGET-02: body <= BODY_TOKEN_CAP tokens (Level 2 — Anthropic spec)
+    EVAL-BUDGET-03: when body > BODY_TOKEN_REFERENCES_TRIGGER tokens, a
+                    `references/` subfolder must exist (forces Level 3 split)
+
+    Anchor: Anthropic's Skills loading model — Level 1 ~100 tok / Level 2 <5k tok / Level 3 unlimited.
+    """
+    failures = []
+    m = re.match(r"^---\n(.*?)\n---\n(.*)$", text, re.DOTALL)
+    if not m:
+        return failures  # CAT-4 already flags missing frontmatter
+    frontmatter, body = m.group(1), m.group(2)
+
+    fm_tokens = count_tokens(frontmatter)
+    if fm_tokens > FRONTMATTER_TOKEN_CAP:
+        failures.append(
+            f"EVAL-BUDGET-01 [{name}] frontmatter is {fm_tokens} tokens, "
+            f"exceeds cap of {FRONTMATTER_TOKEN_CAP} (Anthropic Level 1 — frontmatter "
+            f"is loaded into context for every interaction across all skills). "
+            f"Trim trigger phrases and over-long enumerations."
+        )
+
+    body_tokens = count_tokens(body)
+    if body_tokens > BODY_TOKEN_CAP:
+        failures.append(
+            f"EVAL-BUDGET-02 [{name}] body is {body_tokens} tokens, "
+            f"exceeds cap of {BODY_TOKEN_CAP} (Anthropic Level 2). "
+            f"Split long content into `references/<topic>.md` files."
+        )
+
+    if body_tokens > BODY_TOKEN_REFERENCES_TRIGGER and name not in NO_REFERENCES_NUDGE_EXEMPT:
+        if not (skill_dir / "references").is_dir():
+            failures.append(
+                f"EVAL-BUDGET-03 [{name}] body is {body_tokens} tokens "
+                f"(> {BODY_TOKEN_REFERENCES_TRIGGER} tokens) but no `references/` "
+                f"subfolder exists. Create `{skill_dir.name}/references/` and "
+                f"move long content there before the body hits the {BODY_TOKEN_CAP}-token cap."
+            )
+
+    return failures
+
+
+# ---------------------------------------------------------------------------
 # Runner
 # ---------------------------------------------------------------------------
 
@@ -540,6 +626,7 @@ def main():
         all_failures.extend(check_structure(name, text))
         all_failures.extend(check_completeness(name, text, all_skill_names))
         all_failures.extend(check_allowlist(name, text))
+        all_failures.extend(check_token_budget(name, text, f.parent))
 
     # Cross-skill checks — need all files loaded
     overview_path = skills_dir / "dv-overview" / "SKILL.md"
@@ -568,7 +655,7 @@ def main():
         print(
             f"PASSED -- {len(skill_files)} skill files, "
             f"{python_block_count} Python blocks, "
-            f"6 categories checked"
+            f"8 categories checked"
         )
 
 

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "dataverse-skills",
   "metadata": {
     "description": "Official Dataverse plugin marketplace for agent-guided development",
-    "version": "1.4.0"
+    "version": "1.5.0"
   },
   "owner": {
     "name": "Microsoft",
@@ -13,7 +13,7 @@
       "name": "dataverse",
       "description": "Agent skills for building on, analyzing, and managing Microsoft Dataverse — with Dataverse MCP, PAC CLI, and Python SDK.",
       "source": "./.github/plugins/dataverse",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "homepage": "https://github.com/microsoft/Dataverse-skills"
     }
   ]

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "dataverse-skills",
   "metadata": {
     "description": "Official Dataverse plugin marketplace for agent-guided development",
-    "version": "1.5.0"
+    "version": "1.4.2"
   },
   "owner": {
     "name": "Microsoft",
@@ -13,7 +13,7 @@
       "name": "dataverse",
       "description": "Agent skills for building on, analyzing, and managing Microsoft Dataverse — with Dataverse MCP, PAC CLI, and Python SDK.",
       "source": "./.github/plugins/dataverse",
-      "version": "1.5.0",
+      "version": "1.4.2",
       "homepage": "https://github.com/microsoft/Dataverse-skills"
     }
   ]

--- a/.github/plugins/dataverse/.claude-plugin/plugin.json
+++ b/.github/plugins/dataverse/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dataverse",
   "description": "Agent skills for building on, analyzing, and managing Microsoft Dataverse — with Dataverse MCP, PAC CLI, and Python SDK.",
-  "version": "1.5.0",
+  "version": "1.4.2",
   "author": {
     "name": "Microsoft",
     "url": "https://www.microsoft.com"

--- a/.github/plugins/dataverse/.claude-plugin/plugin.json
+++ b/.github/plugins/dataverse/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dataverse",
   "description": "Agent skills for building on, analyzing, and managing Microsoft Dataverse — with Dataverse MCP, PAC CLI, and Python SDK.",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "author": {
     "name": "Microsoft",
     "url": "https://www.microsoft.com"

--- a/.github/plugins/dataverse/.github/plugin/plugin.json
+++ b/.github/plugins/dataverse/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dataverse",
   "description": "Agent skills for building on, analyzing, and managing Microsoft Dataverse — with Dataverse MCP, PAC CLI, and Python SDK.",
-  "version": "1.5.0",
+  "version": "1.4.2",
   "author": {
     "name": "Microsoft",
     "url": "https://www.microsoft.com"

--- a/.github/plugins/dataverse/.github/plugin/plugin.json
+++ b/.github/plugins/dataverse/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dataverse",
   "description": "Agent skills for building on, analyzing, and managing Microsoft Dataverse — with Dataverse MCP, PAC CLI, and Python SDK.",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "author": {
     "name": "Microsoft",
     "url": "https://www.microsoft.com"

--- a/.github/plugins/dataverse/skills/dv-admin/SKILL.md
+++ b/.github/plugins/dataverse/skills/dv-admin/SKILL.md
@@ -1,31 +1,16 @@
 ---
 name: dv-admin
-description: >
-  Environment-level Dataverse administration: bulk delete, data retention/archival,
-  organization settings, OrgDB settings, recycle bin, and settings-definition overrides.
-  Covers 37 allowlisted PPAC toggles — audit, plugin trace, typeahead/quick find, canvas/flow solutions,
-  audit retention, MCP, search, Fabric, Work IQ, M365 Copilot, TDS endpoint, attachment security,
-  ownership across BUs, address records, delete users, Excel AI import, block unmanaged, app/plan security roles.
-  Use when: "bulk delete", "clean up old records", "schedule deletion", "pause/cancel/resume bulk delete", "pac data",
-  "retention", "archive", "data lifecycle", "audit retention", "audit log retention",
-  "org settings", "organization settings", "environment settings", "list-settings", "update-settings",
-  "enable audit", "audit status", "read auditing", "user access audit", "plugin trace",
-  "typeahead", "lookup delay", "quick find", "single table search", "leading wildcard",
-  "canvas apps in solutions", "cloud flows in solutions", "email validation",
-  "recycle bin", "cleanup interval", "recyclebinconfig",
-  "orgdb settings", "search settings", "mcp settings", "mcp advanced",
-  "fabric settings", "link to fabric", "fabric virtual tables",
-  "work iq", "dataverse intelligence", "m365 copilot data",
-  "tds endpoint", "attachment security", "record ownership", "ownership across business units",
-  "address records", "block unmanaged customizations", "delete disabled users", "excel import ai",
-  "app level security roles", "plan level security roles".
-  Do not use when: deleting individual records (use dv-data), deleting tables (use dv-metadata),
-  exporting/importing data files (use dv-solution), querying records (use dv-query),
-  assigning roles or self-elevating (use dv-security), creating sample data (use dv-data),
-  tenant governance like DLP or environment lifecycle (use pac admin --help).
+description: Performs environment-level Dataverse administration — bulk delete, retention/archival, organization settings, OrgDB settings, recycle bin, and settings-definition overrides (37 allowlisted PPAC toggles). Use when bulk-deleting records, scheduling retention or archival, modifying org or OrgDB settings, configuring audit, or toggling the recycle bin.
 ---
 
 # Skill: Environment Admin — Bulk Delete, Retention, Org Settings, OrgDB, Recycle Bin
+
+> ## ⚠️ Critical safety rules — read first
+>
+> 1. **Bulk delete is irreversible and bypasses the recycle bin.** `pac data bulk-delete schedule` without `--fetchxml` deletes every record in the table. Refuse to run until the user explicitly says ALL (or ALL RECORDS) **and** the entity logical name — e.g., `"yes, delete ALL records in contact"`. Bare `"yes"` rejected. Empty-filter FetchXML does NOT bypass this gate. See [Bulk Delete Commands](#bulk-delete-commands) for the full rule and disambiguation flow.
+> 2. **Settings allowlist is hard.** Only the 37 PPAC toggles in [Allowed settings](#allowed-settings--hard-allowlist) may be read or updated. Any other setting **must be refused**: *"That setting is out of scope for dv-admin. Use the Power Platform admin center."*
+> 3. **Recycle bin disable is PATCH, never DELETE.** `PATCH statecode=1, statuscode=2, isreadyforrecyclebin=false`. DELETE enqueues async opt-out and orphans per-entity configs — see [`references/recycle-bin.md`](references/recycle-bin.md).
+> 4. **System tables warning.** Unfiltered bulk delete on `systemuser`, `businessunit`, `organization`, or `role` breaks the environment. Warn additionally before running.
 
 **Four mechanisms — pick based on where the setting lives:**
 
@@ -40,21 +25,11 @@ Do NOT write Python scripts for operations PAC CLI can handle. Do NOT mix mechan
 
 ## Skill boundaries
 
-| Need | Use instead |
-|---|---|
-| Delete or update individual records | **dv-data** |
-| Create or delete tables, columns, relationships | **dv-metadata** |
-| Query or read records | **dv-query** |
-| Export or import solutions / data files | **dv-solution** |
-| Assign security roles or self-elevate | **dv-security** |
-| Create sample or seed data | **dv-data** |
-| Tenant governance (DLP, env lifecycle) | `pac admin --help` |
+Use **dv-data** for record CRUD and sample data, **dv-metadata** for tables / columns / relationships, **dv-query** for reading records, **dv-solution** for solution export/import, **dv-security** for roles and self-elevate, `pac admin --help` for tenant governance (DLP, env lifecycle).
 
 ## Allowed settings — hard allowlist
 
-This skill is only permitted to **read or update** the 37 PPAC toggles listed below (mapped to 35 unique backend keys — `SearchAndCopilotIndexMode` covers two toggles, `auditretentionperiodv2` covers two). Any request to change any other setting (session timeout, autosave, upload size, abort timeout, archival, shadow lake, activities features, synapse, or any org column / OrgDB key / `organizationsettings` override not in this table) **must be refused** with: *"That setting is out of scope for dv-admin. Use the Power Platform admin center."*
-
-Reading other settings is also out of scope — do not generate `pac org list-settings` without `--filter`, and do not dump the whole `orgdborgsettings` XML when the user's question is about a specific non-allowlisted setting.
+The 37 PPAC toggles below are the only ones this skill may read or update (35 unique backend keys — `SearchAndCopilotIndexMode` and `auditretentionperiodv2` each cover two toggles). Examples that are **out of scope and must be refused** per the safety rule above: `sessiontimeoutinmins`, `isautosaveenabled`, `maxuploadfilesize`, `inaborttimeoutinmins`, `IsArchivalEnabled`, `IsShadowLakeEnabled`, `EnableActivitiesFeatures`. Do not run `pac org list-settings` without `--filter`, and do not dump the whole `orgdborgsettings` XML for a non-allowlisted setting.
 
 ### Organization entity columns — use PAC CLI (14)
 
@@ -79,166 +54,76 @@ Use `pac org list-settings --filter <column>` to read, `pac org update-settings 
 
 ### OrgDB XML keys — use Python SDK on `orgdborgsettings` blob (17)
 
-Read/modify/PATCH the XML blob on `organizations({id})`. PascalCase is significant — `IsMCPEnabled`, not `IsMcpEnabled`.
+PascalCase is significant (`IsMCPEnabled`, not `IsMcpEnabled`). Full key list with PPAC labels and types lives in [`references/orgdb-settings.md`](references/orgdb-settings.md). Notable keys: `IsMCPEnabled`, `IsMCPPreviewEnabled`, `SearchAndCopilotIndexMode`, `IsLinkToFabricEnabled`, `IsFabricVirtualTableEnabled`, `ShowDataInM365Copilot`, `EnableWorkIQ`, `IsLockdownOfUnmanagedCustomizationEnabled`, `EnableSecurityOnAttachment`, `EnableTDSEndpoint`, `AllowAccessToTDSEndpoint`, `EnableOwnershipAcrossBusinessUnits`, `CreateOnlyNonEmptyAddressRecordsForEligibleEntities`, `EnableDeleteAddressRecords`, `BlockDeleteManagedAttributeMap`, `EnableSystemUserDelete`, `IsExcelToExistingTableWithAssistedMappingEnabled`.
 
-| # | PPAC label | XML key | Type |
-|---|---|---|---|
-| 15 | Allow MCP clients to interact with Dataverse MCP server | `IsMCPEnabled` | bool |
-| 16 | Advanced Settings (non-Copilot Studio MCP clients) | `IsMCPPreviewEnabled` | bool |
-| 17 | Dataverse search / Search for records in Microsoft 365 apps | `SearchAndCopilotIndexMode` | int 0–3 (see truth table below — one key, two UI toggles) |
-| 18 | Link Dataverse tables with Microsoft Fabric workspace | `IsLinkToFabricEnabled` | bool |
-| 19 | Define Dataverse virtual tables using Fabric OneLake data | `IsFabricVirtualTableEnabled` | bool |
-| 20 | Allow data availability in Microsoft 365 Copilot | `ShowDataInM365Copilot` | bool |
-| 21 | Turn on Dataverse intelligence (Work IQ) for agents | `EnableWorkIQ` | bool |
-| 22 | Block unmanaged customizations in environment | `IsLockdownOfUnmanagedCustomizationEnabled` | bool |
-| 23 | Enable security on Attachment entity | `EnableSecurityOnAttachment` | bool |
-| 24 | Enable TDS endpoint | `EnableTDSEndpoint` | bool |
-| 25 | Enable user level access control for TDS endpoint | `AllowAccessToTDSEndpoint` | bool |
-| 26 | Record ownership across business units | `EnableOwnershipAcrossBusinessUnits` | bool |
-| 27 | Disable empty address record creation | `CreateOnlyNonEmptyAddressRecordsForEligibleEntities` | bool |
-| 28 | Enable deletion of address records | `EnableDeleteAddressRecords` | bool |
-| 29 | Block deletion of OOB attribute maps | `BlockDeleteManagedAttributeMap` | bool |
-| 30 | Enable delete disabled users | `EnableSystemUserDelete` | bool |
-| 31 | Import Excel to existing table with AI-assisted mapping | `IsExcelToExistingTableWithAssistedMappingEnabled` | bool |
+**`SearchAndCopilotIndexMode`** is one int (0–3) that encodes two UI toggles — Dataverse search × M365 Copilot search:
 
-**`SearchAndCopilotIndexMode` truth table** (one int encodes two UI toggles):
-
-| Value | "Dataverse search" | "Search for records in M365 apps" (Copilot) |
+| Value | Dataverse search | M365 Copilot search |
 |---|---|---|
 | `0` | Off | On |
 | `1` | On | On |
 | `2` | Off | Off |
 | `3` | On | Off |
 
-### recyclebinconfigs entity — use Python SDK (2, **org-level only**)
+### recyclebinconfigs entity — use Python SDK (2, org-level only)
 
-These two toggles operate on the **organization-level** `recyclebinconfigs` row (filtered by the organization entity's MetadataId). Per-table recycle bin enable/disable is **out of scope** — PPAC only exposes the org-level on/off + cleanup days. Refuse requests like "enable recycle bin for `contact` only".
-
-| # | PPAC label | Field | Notes |
-|---|---|---|---|
-| 32 | Keep deleted Dataverse records (on/off) | `statecode` + `statuscode` + `isreadyforrecyclebin` | Org-level row only. See "Recycle Bin Configuration" section — always send `isreadyforrecyclebin: true` on enable |
-| 33 | Keep deleted records (days) | `cleanupintervalindays` | Org-level row only. int days; `-1` = never auto-purge; max 30 (when UI shows "30 days" with retention, stored as `-1`) |
+Two toggles operate on the org-level `recyclebinconfigs` row (filtered by the organization entity's MetadataId): on/off (`statecode` + `statuscode` + `isreadyforrecyclebin`) and cleanup days (`cleanupintervalindays`). Per-table toggles are **out of scope** — refuse requests like "enable recycle bin for `contact` only". Full lifecycle in [`references/recycle-bin.md`](references/recycle-bin.md).
 
 ### settingdefinition + organizationsettings — use Python SDK (2)
 
-These live in a join: `settingdefinition` holds the definition (default value, datatype), `organizationsettings` holds the org-level override. No override row means the defaultvalue applies.
+Two allowlisted toggles, both bool stored as string: `PowerAppsAppLevelSecurityRolesEnabled` (canvas apps), `PlanShareSecurityRolesEnabled` (plan designer). Read default from `settingdefinition`, CREATE/PATCH `organizationsettings` for the override. Full Python in [`references/settings-overrides.md`](references/settings-overrides.md).
 
-| # | PPAC label | `settingdefinition.uniquename` | Type |
-|---|---|---|---|
-| 34 | Enable app level security roles for canvas apps | `PowerAppsAppLevelSecurityRolesEnabled` | bool (string `"true"`/`"false"`) |
-| 35 | Enable plan level security roles for plan designer | `PlanShareSecurityRolesEnabled` | bool (string `"true"`/`"false"`) |
+## Preview Before Running
 
-Bulk delete, retention/archival jobs, and role assignment are covered elsewhere in this skill and remain in scope — this allowlist is about **environment/org/orgdb settings** only.
+- **Destructive / stateful** (bulk delete schedule/cancel/pause/resume, settings updates, recycle bin toggle, role assignment, self-elevate, retention set) — preview in prose: what's changing, new value, target environment(s). Use placeholders (`<ENV_URL>`) for unknowns and ask for missing values in the same turn. Skip the raw CLI block.
+- **Read-only** (list-settings, show job, read OrgDB / recycle bin status) — one-sentence prose preview is enough.
 
-## Preview Before Running — Scope by Operation Type
-
-Two rules, different strictness:
-
-- **Destructive / stateful operations** (bulk delete schedule/cancel/pause/resume, org-settings update, OrgDB-settings update, recycle bin toggle or interval change, role assignment, self-elevate, retention set/enable-entity) — preview the action in plain prose: what's changing, new value, and which environment(s), using placeholders (`<ENV_URL>`, `<USER_EMAIL>`) for anything unknown. Ask for confirmation and missing values in the same turn. Skip the raw command block; the user shouldn't need to read CLI syntax to approve a change.
-- **Read-only operations** (list-settings, list jobs, show job, read recycle bin status, read OrgDB settings) — a one-sentence prose preview is enough.
-
-**Key principle:** the user should be able to evaluate what's about to happen from your first response. A bare *"which environment?"* fails that test; a one-line prose preview passes it.
+The user must be able to evaluate the action from your first response. A bare *"which environment?"* fails; a one-line prose preview passes.
 
 ### Examples
 
-<example operation="pause bulk delete job (destructive — all info given)">
-<user>Pause the bulk delete job with ID 12345678-1234-1234-1234-123456789012</user>
-<bad>The command requires approval. Please confirm to pause the job.</bad>
-<good>I'll pause bulk delete job `12345678-1234-1234-1234-123456789012` on the active environment. Confirm to proceed.</good>
-</example>
+**Pause bulk delete (destructive, ID supplied):**
+- ❌ "The command requires approval. Please confirm to pause the job."
+- ✅ "I'll pause bulk delete job `<job-id>` on the active environment. Confirm to proceed."
 
-<example operation="read recycle bin status (read-only — prose is enough)">
-<user>What's the current recycle bin status?</user>
-<bad>Please provide your environment URL so I can check.</bad>
-<bad>Runs `pac org fetch` against `recyclebinconfig` — PAC CLI does NOT manage recycle bin. Always use the Web API via Python.</bad>
-<good>Recycle bin lives in the `recyclebinconfigs` entity — PAC CLI can't read it. I'll run the "Read Recycle Bin Status" snippet in the Recycle Bin Configuration section below (read-only, no confirmation needed). Provide your environment URL.</good>
-</example>
+**Audit status across N environments (read-only, multi-call):**
+- ❌ Sequential `pac org fetch` per env, or starting with Python/SDK because it "feels like a query."
+- ✅ "I'll run `pac org list-settings --filter audit` in parallel across all N environments (one `&`-batch, single `wait`)."
 
-<example operation="audit status across N environments (read-only but multi-call — teach the pattern)">
-<user>Tell me audit status of these 5 environments</user>
-<bad>Runs `pac env select` then `pac org fetch --entity organization --attributes isauditenabled` once per environment, sequentially, across N separate bash calls.</bad>
-<bad>Starts with Python / `urllib` / the SDK because "audit status" sounds like a multi-attribute query. Then falls back to `pac org fetch` when that fails, then PowerShell. All forbidden.</bad>
-<bad>Uses a `for env_id in ...` bash loop (sequential) instead of `&`-backgrounded parallel calls.</bad>
-<good>I'll run `pac org list-settings --filter audit` in parallel across all 5 environments (one `&`-batch, single `wait`), then render each env's audit block as a merged table. `--filter audit` returns every audit-related setting in one call (`isauditenabled`, `auditretentionperiodv2`, `isuseraccessauditenabled`, etc.) so we don't need multiple passes. `pac org list-settings` is the only command for reading org settings — never `pac org fetch`, `pac env select`, Python, PowerShell, or Web API.</good>
-</example>
+## How to Read or Update Org Settings
 
-<example operation="disable MCP (destructive OrgDB write — prose + snippet reference)">
-<user>Disable MCP for my environment</user>
-<bad>Please provide your environment URL so I can disable MCP.</bad>
-<good>MCP is the `IsMCPEnabled` key in the `orgdborgsettings` XML blob — PAC CLI can't modify it. I'll run the "Update or add an OrgDB setting" snippet in the OrgDB Settings section with `SETTING_NAME="IsMCPEnabled"`, `SETTING_VALUE="false"`. Provide your environment URL and confirm to proceed.</good>
-</example>
+**Org settings always go through `pac org list-settings` / `pac org update-settings`** — never raw Web API, FetchXML, PowerShell, or Python for org columns. Use `--filter <substring>` for category reads in one call. Multi-environment work runs in parallel via `&` + `wait` in ONE bash call.
 
-## CRITICAL: How to Read or Update Org Settings (Single or Multi-Environment)
-
-**Org settings = always `pac org list-settings` / `pac org update-settings`. No exceptions.** Single setting or a whole category, single env or many — this pair of commands covers all of it. If you are about to write Python, FetchXML, PowerShell, or any HTTP call to read or write an org column, STOP: you are off-rails.
-
-**Single setting on one environment:**
-
+**Single setting:**
 ```bash
-pac org list-settings --filter isauditenabled --environment https://org1.crm.dynamics.com
+pac org list-settings --filter isauditenabled --environment <url>
 ```
 
-**Category / multi-attribute read (e.g., "audit status", "all MCP settings") — substring filter in one call:**
-
+**Category read** (returns every match, e.g. all audit settings in one call):
 ```bash
-pac org list-settings --filter audit --environment https://org1.crm.dynamics.com
+pac org list-settings --filter audit --environment <url>
 ```
 
-`--filter` is a substring match on the setting name. `--filter audit` returns everything whose name contains "audit" (`isauditenabled`, `auditretentionperiodv2`, `isuseraccessauditenabled`, `isreadauditenabled`, etc.). Prefer this over running N separate `--filter <one>` calls when the user asks about a category.
-
-**Multiple environments — ALWAYS parallel in ONE bash call:**
-
+**Multi-environment — parallel in ONE bash call:**
 ```bash
-pac org list-settings --filter audit --environment https://org1.crm.dynamics.com &
-pac org list-settings --filter audit --environment https://org2.crm.dynamics.com &
-pac org list-settings --filter audit --environment https://org3.crm.dynamics.com &
+pac org list-settings --filter audit --environment <url1> &
+pac org list-settings --filter audit --environment <url2> &
+pac org list-settings --filter audit --environment <url3> &
 wait
 ```
 
-Then parse each environment's output and render a table. Same pattern for N environments: N backgrounded calls, one `wait`, one merged table.
-
-**NEVER do any of these for org settings — no exceptions, even when `list-settings` feels limiting:**
-- `pac env select` then `pac org fetch` — WRONG, use `pac org list-settings --environment <url>`
-- `pac org fetch` with FetchXML to query the `organization` entity — WRONG, PAC CLI reads org settings via `list-settings` only
-- `pac org who` — shows connection info, NOT settings
-- `curl` / `urllib` / `requests` to the Web API — WRONG for org columns, use `pac org list-settings`
-- `pac auth token` + raw HTTP — WRONG, PAC CLI handles auth internally
-- PowerShell `Invoke-RestMethod` — WRONG, use PAC CLI directly
-- Python `DataverseClient` / `get_token()` / any Azure Identity call for org columns — WRONG, use PAC CLI
-- Separate bash calls per environment / a `for` loop with sequential calls — WRONG, use `&` and `wait` in ONE call
-
-**If `pac org list-settings` fails for a setting**, that setting is NOT an org column — it lives elsewhere (OrgDB XML blob, `recyclebinconfigs`, `settingdefinition`). See the mechanism routing table below. Do not fall back to Web API / PowerShell / FetchXML.
+If `pac org list-settings` fails for a setting, that setting is NOT an org column — check the mechanism routing in the four-mechanism table at the top, then use the appropriate Python pattern. Do NOT fall back to Web API, PowerShell, FetchXML, or `pac org fetch` for org columns.
 
 ---
 
 ## Prerequisites
 
-- PAC CLI **latest version (.NET Framework build)** — `pac data bulk-delete` and `pac data retention` commands are only in the .NET Framework build (not the `dotnet tool` cross-platform version). Check your version:
-  ```bash
-  pac help   # look for "Version: x.x.x (.NET Framework ...)"
-  ```
-  If it shows `.NET 10` or `.NET 8` instead of `.NET Framework`, the `pac data` commands will not be available. To update to the latest .NET Framework build:
-  ```bash
-  pac install latest   # downloads latest NuGet package
-  pac use latest       # switches to the latest installed version
-  ```
-- Authenticated (`pac auth create`)
-- A Dataverse environment with System Administrator privilege
-- Active auth profile: `pac auth list`
-
----
+- PAC CLI **latest .NET Framework build** — `pac data bulk-delete` and `pac data retention` are only in the .NET Framework build, not the `dotnet tool` cross-platform version. Check with `pac help` (look for "Version: x.x.x (.NET Framework ...)"); if it shows `.NET 10` or `.NET 8`, run `pac install latest && pac use latest` to switch.
+- Authenticated (`pac auth create`), active profile (`pac auth list`), and System Administrator privilege on the target environment.
 
 ## Multi-Environment Operations — Always Parallel
 
-The pattern above applies to ALL multi-environment operations, not just org settings. For updates:
-
-```bash
-# UPDATE settings on multiple environments — ONE bash call, all parallel
-pac org update-settings --name isauditenabled --value true --environment https://org1.crm.dynamics.com &
-pac org update-settings --name isauditenabled --value true --environment https://org2.crm.dynamics.com &
-pac org update-settings --name isauditenabled --value true --environment https://org3.crm.dynamics.com &
-wait
-```
+The same `&` + `wait` pattern from `list-settings` applies to every multi-env operation (`update-settings`, `bulk-delete`, etc.) — N backgrounded calls in ONE bash call, never sequential or `for` loops.
 
 ---
 
@@ -297,14 +182,14 @@ pac data bulk-delete schedule --entity email \
 
 ### Hard stop: no `--fetchxml` means ALL records
 
-A `pac data bulk-delete schedule` without `--fetchxml` targets every record in the table and is irreversible. Bulk delete does not go through the recycle bin. Apply this gate before running:
+`pac data bulk-delete schedule` without `--fetchxml` targets every record in the table and is irreversible (does not go through recycle bin). Required gate:
 
-1. **Refuse to run until the user explicitly acknowledges.** The acknowledgement must include both the word ALL (or ALL RECORDS) **and** the entity logical name. Example accepted: `"yes, delete ALL records in contact"`. Example rejected: a bare `"yes"` or `"proceed"`.
-2. **Disambiguate first.** If the user's ask is vague ("clean up old emails", "remove stale accounts"), ask clarifying questions (date cutoff? statecode filter? owner?) and draft a FetchXML before showing any `bulk-delete schedule` command.
-3. **Do not synthesize empty-filter FetchXML to bypass the gate.** An empty `<filter/>` or `<filter><condition ...><value/></condition></filter>` still targets every record — that counts as "no `--fetchxml`" for this rule.
-4. **Scope.** This gate applies to `pac data bulk-delete schedule` only. `cancel`, `pause`, `resume`, `show`, and `list` don't need it.
+1. **Refuse until the user explicitly acknowledges** with the word ALL (or ALL RECORDS) **and** the entity logical name — e.g., `"yes, delete ALL records in contact"`. Bare `"yes"` rejected.
+2. **Disambiguate vague asks** ("clean up old emails") — propose a FetchXML filter with date / statecode / owner conditions before showing any command.
+3. **Empty-filter FetchXML doesn't bypass the gate** — `<filter/>` or `<filter><condition><value/></condition></filter>` still targets every record.
+4. **Scope:** applies to `bulk-delete schedule` only. `cancel`, `pause`, `resume`, `show`, `list` don't need it.
 
-For system tables (`systemuser`, `businessunit`, `organization`, `role`), warn additionally that an unfiltered bulk delete will break the environment.
+For system tables (`systemuser`, `businessunit`, `organization`, `role`), additionally warn that unfiltered bulk delete breaks the environment.
 
 ### Manage Jobs
 
@@ -375,480 +260,51 @@ pac org update-settings --name isauditenabled --value true --environment https:/
 pac org update-settings --name plugintracelogsetting --value 2 --environment https://myorg.crm.dynamics.com
 ```
 
-#### Arguments
+**Args:** `--name <column>` (required), `--value <value>` (required; `true`/`false` for bool, int for option sets), `--environment <url>` (optional). Allowed columns are the 14 listed in [Allowed settings](#allowed-settings--hard-allowlist) — anything else is out of scope.
 
-| Argument | Alias | Required | Description |
-|----------|-------|----------|-------------|
-| `--name` | `-n` | Yes | Setting name (e.g., `isauditenabled`) |
-| `--value` | `-v` | Yes | New value (`true`/`false` for booleans, integer for option sets) |
-| `--environment` | `-env` | No | Target environment URL or ID |
-
-#### Allowed Settings (14 org columns)
-
-`pac org update-settings --name <column>` accepts any column on the `organization` entity, not just the legacy audit ones — verified against real orgs.
-
-| Setting Name | Type | Values | PPAC label |
-|-------------|------|--------|------------|
-| `isauditenabled` | bool | `true` / `false` | Start Auditing |
-| `isuseraccessauditenabled` | bool | `true` / `false` | Audit user access (Log access) |
-| `isreadauditenabled` | bool | `true` / `false` | Start Read Auditing (Read logs to Purview) |
-| `plugintracelogsetting` | option | `0` Off, `1` Exception, `2` All | Plugin trace log setting |
-| `tablescopeddvsearchinapps` | bool | `true` / `false` | Single table search option |
-| `allowleadingwildcardsinquickfind` | int | `0` = prevent slow filter (UI "Prevent" ON), `1` = allow | Prevent slow keyword filter for quick find terms |
-| `quickfindrecordlimitenabled` | bool | `true` / `false` | Quick Find record limits |
-| `usequickfindviewforgridsearch` | bool | `true` / `false` | Use quick find view for searching on grids/subgrids |
-| `enablecanvasappsinsolutionsbydefault` | bool | `true` / `false` | Canvas apps in Dataverse solutions by default |
-| `enableflowsinsolutionbydefault` | bool | `true` / `false` | Cloud flows in Dataverse solutions by default (note: `solution` singular, no `s`) |
-| `isemailaddressvalidationenabled` | bool | `true` / `false` | Enable email address validation (preview) |
-| `lookupcharactercountbeforeresolve` | int | `0`–MAX_INT (null = feature off) | Minimum number of characters to trigger typeahead search |
-| `lookupresolvedelayms` | int | milliseconds (default `250`) | Delay between character inputs that trigger a search |
-| `auditretentionperiodv2` | int | `-1` = Forever; presets `30`, `90`, `180`, `365`, `730`, `2555`; custom integer `30`–`365000` (PPAC validates this range; `< 30` or `> 365000` fails) | Audit log retention policy / Custom retention period (days) |
-
-Any other org column (`isautosaveenabled`, `maxuploadfilesize`, `sessiontimeoutenabled`, `sessiontimeoutinmins`, `inaborttimeoutenabled`, `inaborttimeoutinmins`, etc.) is **out of scope** — refuse and direct the user to the Power Platform admin center.
-
-### Batch Workflow
-
-```
-Step 1: pac admin list                         -> Get all environments
-Step 2: Filter by type or name                 -> Identify targets
-Step 3: For updates: confirm with user first
-Step 4: Run ALL commands in parallel (see Multi-Environment section above)
-Step 5: Report summary as a table
-```
+**Batch workflow:** `pac admin list` → filter targets → confirm → run all `update-settings` calls in parallel (`&` + `wait`) → render summary table.
 
 ---
 
 ## Advanced Settings (Python SDK — PAC CLI Cannot Handle These)
 
-Three patterns require Python SDK:
-
-| Setting type | Where it lives | How to update |
-|---|---|---|
-| Top-level org columns (14 allowlisted — audit, typeahead, quick find, canvas/flow solutions, email validation, audit retention, etc.) | Organization entity columns | **PAC CLI** — `pac org update-settings --name <column>` (accepts any org column) |
-| OrgDB settings (17 allowlisted — MCP, search, Fabric, Work IQ, TDS, attachment security, ownership, address records, block unmanaged, delete users, Excel AI) | XML inside `orgdborgsettings` column | **Python SDK** — fetch XML, parse, modify, PATCH back |
-| Recycle bin (**org-level only**) | `recyclebinconfigs` entity, row filtered by the organization entity's MetadataId | **Python SDK** — CREATE/PATCH `recyclebinconfigs(<id>)`. Per-table toggles are out of scope — PPAC only exposes the org-level on/off + cleanup days |
-| Settings-definition overrides (2 allowlisted — app/plan security roles) | `settingdefinition` + `organizationsettings` join | **Python SDK** — look up `settingdefinitionid` by `uniquename`, then CREATE/PATCH `organizationsettings` row |
-
----
+OrgDB, recycle bin, and settings-definition overrides each need raw Web API or the Python SDK — PAC CLI does not cover them. The four-mechanism routing table at the top of this skill ([§ Skill](#skill-environment-admin--bulk-delete-retention-org-settings-orgdb-recycle-bin)) maps each setting to its mechanism. Sub-sections below summarise the patterns and link to the references for full Python.
 
 ### OrgDB Settings (orgdborgsettings XML)
 
-Settings like search mode, MCP, copilot features, fabric, and retention live inside the `orgdborgsettings` XML blob. The XML uses **direct PascalCase elements** (NOT `<pair>` tags):
+OrgDB settings live as PascalCase XML elements inside the `orgdborgsettings` column of the `organizations` entity. PAC CLI cannot read or write these — use raw Web API.
 
-```xml
-<OrgSettings>
-  <IsMCPEnabled>true</IsMCPEnabled>
-  <SearchAndCopilotIndexMode>0</SearchAndCopilotIndexMode>
-  <IsLinkToFabricEnabled>true</IsLinkToFabricEnabled>
-  <IsFabricVirtualTableEnabled>false</IsFabricVirtualTableEnabled>
-</OrgSettings>
-```
+**Quick reference:** `GET /organizations?$select=organizationid,orgdborgsettings` → parse XML with `xml.etree.ElementTree` → modify or `SubElement` → `PATCH /organizations({id})` with the serialized XML.
 
-**Read all OrgDB settings:**
-
-```python
-import os, sys, json, urllib.request
-from xml.etree import ElementTree as ET
-sys.path.insert(0, os.path.join(os.getcwd(), "scripts"))
-from auth import get_token, load_env  # SDK does not support orgdborgsettings XML blob
-
-load_env()
-env_url = os.environ["DATAVERSE_URL"].rstrip("/")
-token = get_token()
-
-req = urllib.request.Request(
-    f"{env_url}/api/data/v9.2/organizations?$select=organizationid,orgdborgsettings",
-    headers={"Authorization": f"Bearer {token}", "Accept": "application/json"},
-)
-with urllib.request.urlopen(req) as resp:
-    org = json.loads(resp.read())["value"][0]
-
-root = ET.fromstring(org["orgdborgsettings"])
-for child in sorted(root, key=lambda c: c.tag):
-    print(f"  {child.tag} = {child.text}", flush=True)
-```
-
-**Update or add an OrgDB setting:**
-
-```python
-import os, sys, json, urllib.request, urllib.error
-from xml.etree import ElementTree as ET
-sys.path.insert(0, os.path.join(os.getcwd(), "scripts"))
-from auth import get_token, load_env  # SDK does not support orgdborgsettings XML blob
-
-load_env()
-env_url = os.environ["DATAVERSE_URL"].rstrip("/")
-token = get_token()
-
-SETTING_NAME = "SearchAndCopilotIndexMode"  # PascalCase, case-sensitive
-SETTING_VALUE = "0"                          # always a string in XML
-
-headers = {
-    "Authorization": f"Bearer {token}",
-    "Accept": "application/json",
-    "Content-Type": "application/json",
-    "OData-MaxVersion": "4.0",
-    "OData-Version": "4.0",
-}
-
-# Fetch current XML
-req = urllib.request.Request(
-    f"{env_url}/api/data/v9.2/organizations?$select=organizationid,orgdborgsettings",
-    headers=headers,
-)
-with urllib.request.urlopen(req) as resp:
-    org = json.loads(resp.read())["value"][0]
-    org_id = org["organizationid"]
-
-root = ET.fromstring(org.get("orgdborgsettings", "<OrgSettings></OrgSettings>"))
-
-# Update existing or add new
-existing = root.find(SETTING_NAME)
-if existing is not None:
-    print(f"Current {SETTING_NAME} = {existing.text}", flush=True)
-    existing.text = SETTING_VALUE
-else:
-    print(f"{SETTING_NAME} not set -- adding", flush=True)
-    ET.SubElement(root, SETTING_NAME).text = SETTING_VALUE
-
-# PATCH back
-req = urllib.request.Request(
-    f"{env_url}/api/data/v9.2/organizations({org_id})",
-    data=json.dumps({"orgdborgsettings": ET.tostring(root, encoding="unicode")}).encode("utf-8"),
-    headers=headers,
-    method="PATCH",
-)
-try:
-    with urllib.request.urlopen(req) as resp:
-        print(f"SUCCESS: {SETTING_NAME} = {SETTING_VALUE} (HTTP {resp.status})", flush=True)
-except urllib.error.HTTPError as e:
-    print(f"ERROR {e.code}: {e.read().decode()}", flush=True)
-```
-
-**Remove an OrgDB setting:**
-
-```python
-# After fetching and parsing the XML (same as above):
-existing = root.find(SETTING_NAME)
-if existing is not None:
-    root.remove(existing)
-    # PATCH back the XML without the element
-```
-
-**Allowed OrgDB settings (17 keys — PascalCase, case-sensitive):**
-
-| Setting | Type | Values | PPAC label |
-|---|---|---|---|
-| `IsMCPEnabled` | bool | `true` / `false` | Allow MCP clients to interact with Dataverse MCP server |
-| `IsMCPPreviewEnabled` | bool | `true` / `false` | Advanced Settings (enable non-Copilot Studio MCP clients) |
-| `SearchAndCopilotIndexMode` | int | `0` Search Off / Copilot On; `1` Both On; `2` Both Off; `3` Search On / Copilot Off | Dataverse search + Search for records in Microsoft 365 apps (one key, two UI toggles — see truth table above) |
-| `IsLinkToFabricEnabled` | bool | `true` / `false` | Link Dataverse tables with Microsoft Fabric workspace |
-| `IsFabricVirtualTableEnabled` | bool | `true` / `false` | Define Dataverse virtual tables using Fabric OneLake data |
-| `ShowDataInM365Copilot` | bool | `true` / `false` | Allow data availability in Microsoft 365 Copilot |
-| `EnableWorkIQ` | bool | `true` / `false` | Turn on Dataverse intelligence (Work IQ) for agents |
-| `IsLockdownOfUnmanagedCustomizationEnabled` | bool | `true` / `false` | Block unmanaged customizations in environment |
-| `EnableSecurityOnAttachment` | bool | `true` / `false` | Enable security on Attachment entity |
-| `EnableTDSEndpoint` | bool | `true` / `false` | Enable TDS endpoint |
-| `AllowAccessToTDSEndpoint` | bool | `true` / `false` | Enable user level access control for TDS endpoint (requires TDS endpoint enabled first) |
-| `EnableOwnershipAcrossBusinessUnits` | bool | `true` / `false` | Record ownership across business units |
-| `CreateOnlyNonEmptyAddressRecordsForEligibleEntities` | bool | `true` / `false` | Disable empty address record creation (affects Account, Contact, Lead) |
-| `EnableDeleteAddressRecords` | bool | `true` / `false` | Enable deletion of address records |
-| `BlockDeleteManagedAttributeMap` | bool | `true` / `false` | Block deletion of OOB attribute maps |
-| `EnableSystemUserDelete` | bool | `true` / `false` | Enable delete disabled users |
-| `IsExcelToExistingTableWithAssistedMappingEnabled` | bool | `true` / `false` | Import Excel to existing table with AI-assisted mapping |
-
-Every other OrgDB key (`IsRetentionEnabled`, `IsArchivalEnabled`, `IsDVCopilotForTextDataEnabled`, `IsShadowLakeEnabled`, `IsCommandingModifiedOnEnabled`, `CanCreateApplicationStubUser`, `AllowRoleAssignmentOnDisabledUsers`, `EnableActivitiesFeatures`, `TDSListenerInitialized`, `AzureSynapseLinkIncrementalUpdateTimeInterval`, etc.) is **out of scope** — refuse and direct the user to the Power Platform admin center. Do NOT dump the whole `orgdborgsettings` XML to "discover" other settings for the user.
-
----
+For the read / update / remove Python patterns and the 17-key allowlist, see [`references/orgdb-settings.md`](references/orgdb-settings.md). Keys are case-sensitive (`IsMCPEnabled`, not `IsMcpEnabled`).
 
 ### Recycle Bin Configuration
 
-Recycle bin settings live in the `recyclebinconfigs` entity, NOT in `orgdborgsettings` XML. PAC CLI cannot manage these.
+Recycle bin settings live in the `recyclebinconfigs` entity (NOT `orgdborgsettings`). PAC CLI cannot manage them — use raw Web API.
 
-**Well-known constant:** The organization entity metadata ID is `e1bd1119-6e9d-45a4-bc15-12051e65a0bd`. This is the `MetadataId` of the `organization` entity's *schema record* in `EntityDefinitions` (a product-level system constant baked into every Dataverse installation), not a tenant-level GUID — so it is identical across all environments and all tenants. Verified empirically across 5 environments. Do not re-query it per environment.
+**Quick reference:** filter `recyclebinconfigs` by `_extensionofrecordid_value eq <ORG_ENTITY_METADATA_ID>` (the org-level metadata ID is a system constant: `e1bd1119-6e9d-45a4-bc15-12051e65a0bd`).
 
-### Read Recycle Bin Status
+- **Enable:** PATCH `statecode=0, statuscode=1, isreadyforrecyclebin=true` (or POST a new config). `isreadyforrecyclebin: true` is required to force the synchronous opt-in path.
+- **Disable:** PATCH `statecode=1, statuscode=2, isreadyforrecyclebin=false`. **Do NOT DELETE** — it enqueues async opt-out and orphans per-entity configs.
+- **Drain in-flight `ProcessRecycleBin` async jobs** (`operationtype eq 50, statecode ne 3`) before any second toggle.
 
-```python
-import os, sys, json, urllib.request, urllib.parse
-sys.path.insert(0, os.path.join(os.getcwd(), "scripts"))
-from auth import get_token, load_env  # SDK does not support recyclebinconfigs entity
-
-load_env()
-env_url = os.environ["DATAVERSE_URL"].rstrip("/")
-token = get_token()
-
-ORGANIZATION_ENTITY_ID = "e1bd1119-6e9d-45a4-bc15-12051e65a0bd"
-
-headers = {
-    "Authorization": f"Bearer {token}",
-    "Accept": "application/json",
-    "Content-Type": "application/json",
-    "OData-MaxVersion": "4.0",
-    "OData-Version": "4.0",
-}
-
-# Fetch org-level config by extensionofrecordid (NOT by name)
-filter_q = urllib.parse.quote(f"_extensionofrecordid_value eq '{ORGANIZATION_ENTITY_ID}'")
-req = urllib.request.Request(
-    f"{env_url}/api/data/v9.2/recyclebinconfigs?$filter={filter_q}&$select=recyclebinconfigid,statecode,statuscode,cleanupintervalindays",
-    headers=headers,
-)
-with urllib.request.urlopen(req) as resp:
-    records = json.loads(resp.read()).get("value", [])
-
-if records:
-    config = records[0]
-    enabled = config["statecode"] == 0
-    cleanup = config["cleanupintervalindays"]
-    print(f"Recycle bin: {'enabled' if enabled else 'disabled'}", flush=True)
-    print(f"Cleanup interval: {cleanup} days ({'-1 means no auto-cleanup' if cleanup == -1 else ''})", flush=True)
-    print(f"Config ID: {config['recyclebinconfigid']}", flush=True)
-else:
-    print("Recycle bin: not configured (no org-level record)", flush=True)
-```
-
-### Critical: Always Send `isreadyforrecyclebin: true` on Enable
-
-**Every enable payload (POST or PATCH) must set `isreadyforrecyclebin: true`.**
-
-Without it, the platform defaults `isreadyforrecyclebin` to `false` (CREATE) or leaves it null (PATCH), which forces the platform into the **asynchronous** opt-in path — a `ProcessRecycleBin` background job is queued and your HTTP call returns success before any entity-level work happens. In that window, platform metadata operations (solution imports, attribute publish, async handlers) can race against the partial state and throw `EntityBinUpdateAction called for entity <x> which is not enabled for RecycleBin`. Sending `isreadyforrecyclebin: true` forces the synchronous, globally-locked opt-in path, which fans out to every entity inside one transaction.
-
-### Critical: Disable via PATCH, Not DELETE
-
-**Disable with `PATCH statecode=1, statuscode=2, isreadyforrecyclebin=false`. Do not DELETE the org config record.**
-
-DELETE enqueues an async opt-out (when `RecycleBinOptOutOrgAsynchronously` is on) while leaving the org row marked Inactive and child entity rows still flagged `IsReadyForRecycleBin=true, IsDisabled=false`. Any platform operation that runs between your DELETE and your next enable will see "org is enabled" from the config cache, proceed to `RecycleBinConfigService.Update(<entity-config>)` synchronously, and throw when the DB-backed `IsRecycleBinEnabledForEntity` check disagrees. A PATCH-based disable takes the synchronous `OptOutOrganization` path under the customization lock, cleanly cascading to every entity.
-
-### Wait for in-flight `ProcessRecycleBin` Jobs Between Toggles
-
-Every enable/disable queues a `ProcessRecycleBin` async operation (OperationType = `50`). Do NOT enable-then-disable-then-enable rapidly; the jobs share a dependency token and can interleave in ways that corrupt state. Before any second toggle, poll `AsyncOperation` until no `ProcessRecycleBin` row is `Queued` or `InProgress` for this org.
-
-### Enable Recycle Bin
-
-Two cases depending on whether a config record already exists. Both send `isreadyforrecyclebin: true`.
-
-```python
-# ... (same imports, headers, ORGANIZATION_ENTITY_ID, and fetch as above)
-# SDK does not support recyclebinconfigs entity
-
-CLEANUP_DAYS = 30  # default; -1 means records in recycle bin are never auto-purged
-
-# Pre-flight: wait for any in-flight ProcessRecycleBin async jobs to finish
-import time
-def wait_for_recyclebin_async_jobs(env_url, headers, timeout_s=120):
-    # OperationType 50 = ProcessRecycleBin; StateCode 0=Ready/1=Suspended/2=Locked are all "not done"
-    filter_q = urllib.parse.quote("operationtype eq 50 and statecode ne 3")
-    url = f"{env_url}/api/data/v9.2/asyncoperations?$filter={filter_q}&$select=asyncoperationid,statecode,statuscode,name"
-    deadline = time.time() + timeout_s
-    while time.time() < deadline:
-        req = urllib.request.Request(url, headers=headers)
-        with urllib.request.urlopen(req) as resp:
-            pending = json.loads(resp.read()).get("value", [])
-        if not pending:
-            return
-        print(f"  waiting on {len(pending)} ProcessRecycleBin job(s)...", flush=True)
-        time.sleep(5)
-    raise RuntimeError("Timed out waiting for pending ProcessRecycleBin async jobs")
-
-wait_for_recyclebin_async_jobs(env_url, headers)
-
-if not records:
-    # Case 1: No config exists -- CREATE a new one
-    # extensionofrecordid binds to the entities() metadata endpoint, NOT organizations()
-    payload = {
-        "extensionofrecordid@odata.bind": f"entities({ORGANIZATION_ENTITY_ID})",
-        "extensionofrecordid@OData.Community.Display.V1.FormattedValue": "OrganizationId",
-        "isreadyforrecyclebin": True,   # MUST be true -- forces sync opt-in under the global lock
-        "cleanupintervalindays": CLEANUP_DAYS,
-    }
-    req = urllib.request.Request(
-        f"{env_url}/api/data/v9.2/recyclebinconfigs",
-        data=json.dumps(payload).encode("utf-8"),
-        headers=headers,
-        method="POST",
-    )
-    with urllib.request.urlopen(req) as resp:
-        print(f"SUCCESS: recycle bin enabled with {CLEANUP_DAYS} day cleanup (HTTP {resp.status})", flush=True)
-else:
-    # Case 2: Config exists -- PATCH statecode/statuscode, cleanup interval, and isreadyforrecyclebin
-    config_id = records[0]["recyclebinconfigid"]
-    payload = {
-        "cleanupintervalindays": CLEANUP_DAYS,
-        "statecode": 0,
-        "statuscode": 1,
-        "isreadyforrecyclebin": True,   # MUST be true -- without this, UpdateInternal routes through updateAsync
-    }
-    req = urllib.request.Request(
-        f"{env_url}/api/data/v9.2/recyclebinconfigs({config_id})",
-        data=json.dumps(payload).encode("utf-8"),
-        headers=headers,
-        method="PATCH",
-    )
-    with urllib.request.urlopen(req) as resp:
-        print(f"SUCCESS: recycle bin enabled with {CLEANUP_DAYS} day cleanup (HTTP {resp.status})", flush=True)
-
-# Post-flight: drain the sync opt-in fan-out before returning control
-wait_for_recyclebin_async_jobs(env_url, headers)
-```
-
-### Disable Recycle Bin
-
-**Disable = PATCH `statecode=1, statuscode=2, isreadyforrecyclebin=false`.** This triggers the synchronous `OptOutOrganization` path which cascades cleanly to every entity config.
-
-```python
-# ... (same fetch as above to get config_id)
-# SDK does not support recyclebinconfigs entity
-
-wait_for_recyclebin_async_jobs(env_url, headers)   # drain first
-
-if records:
-    config_id = records[0]["recyclebinconfigid"]
-    payload = {
-        "statecode": 1,                 # Inactive
-        "statuscode": 2,                # Inactive
-        "isreadyforrecyclebin": False,  # required to take the isOptOut branch in UpdateInternal
-    }
-    req = urllib.request.Request(
-        f"{env_url}/api/data/v9.2/recyclebinconfigs({config_id})",
-        data=json.dumps(payload).encode("utf-8"),
-        headers=headers,
-        method="PATCH",
-    )
-    with urllib.request.urlopen(req) as resp:
-        print(f"SUCCESS: recycle bin disabled (HTTP {resp.status})", flush=True)
-else:
-    print("Recycle bin is already disabled (no config record)", flush=True)
-
-wait_for_recyclebin_async_jobs(env_url, headers)   # drain the opt-out fan-out
-```
-
-**Do NOT use DELETE to disable.** Legacy guidance (including older Admin Center behavior) suggested DELETE, but DELETE enqueues an async opt-out and can leave per-entity configs orphaned — any platform metadata operation that runs before cleanup finishes will throw `EntityBinUpdateAction called for entity <x> which is not enabled for RecycleBin` on an unrelated entity.
-
-### Key Fields on `recyclebinconfigs`
-
-| Field | Type | What it does |
-|---|---|---|
-| `statecode` | int | `0` = enabled (active), `1` = disabled (inactive) |
-| `statuscode` | int | `1` = enabled, `2` = disabled |
-| `cleanupintervalindays` | int | Auto-cleanup interval. `-1` = no auto-cleanup (default). `30` = purge after 30 days (max). Min: `1` |
-| `_extensionofrecordid_value` | guid | Entity metadata ID this config applies to. Org-level = `e1bd1119-6e9d-45a4-bc15-12051e65a0bd` |
-
-### Important Notes
-
-- **Fetch by `_extensionofrecordid_value`**, not by `name`. The `name` field is unreliable for filtering.
-- **Create uses `entities()` binding** -- `extensionofrecordid@odata.bind: entities({id})`, NOT `organizations()`.
-- **Enable payloads MUST include `isreadyforrecyclebin: true`.** Without it, CREATE defaults to false and PATCH sends null — both force the async opt-in path and expose the org to cache-vs-DB races during platform metadata operations.
-- **Disable = PATCH `statecode=1, statuscode=2, isreadyforrecyclebin=false`**, not DELETE. DELETE enqueues an async opt-out and can leave per-entity configs orphaned.
-- **Drain `ProcessRecycleBin` async jobs between toggles.** Query `asyncoperations` for `operationtype eq 50 and statecode ne 3` before and after each enable/disable.
-- **Cleanup days**: default is `-1` (no auto-cleanup). Max is `30`. When the UI shows "30 days", the API stores `-1` internally (the platform applies a 30-day default).
-- Solution-managed configs (e.g., `msdyn_recurringsalesaction`) cannot be enabled/disabled via API.
-- **Per-table recycle bin toggles are out of scope.** PPAC only exposes the org-level on/off + cleanup days — if a user asks to enable/disable recycle bin for a specific table (e.g., "turn on recycle bin for `contact` only"), refuse with: *"Per-table recycle bin is out of scope for dv-admin. Use the Power Platform admin center."* The `recyclebinconfigs` entity does hold per-entity rows, but this skill only reads/writes the org-level row (filtered by the organization entity's MetadataId).
-
----
+For the full Python lifecycle (read / enable / disable / async-drain helper), the cache-vs-DB race explanation, and the per-table out-of-scope rule, see [`references/recycle-bin.md`](references/recycle-bin.md).
 
 ### Settings-Definition Overrides (app/plan security roles)
 
-A small number of allowlisted toggles don't live on the `organization` entity or in `orgdborgsettings`. They're modeled as a join between two entities:
+Two allowlisted toggles (`PowerAppsAppLevelSecurityRolesEnabled`, `PlanShareSecurityRolesEnabled`) live in a join: `settingdefinition` (defaults) + `organizationsettings` (overrides). PAC CLI doesn't manage these.
 
-- **`settingdefinition`** — defines the setting (uniquename, datatype, defaultvalue, description). Read-only; one row per known setting; identical across environments in the same build.
-- **`organizationsettings`** — holds per-org overrides. If no row exists for a given `settingdefinitionid`, the `defaultvalue` from `settingdefinition` applies.
+**Quick reference:** look up the `settingdefinitionid` by `uniquename`, then either CREATE an `organizationsettings` row with `value` (string `"true"`/`"false"`) or PATCH the existing row. DELETE on the override row reverts to the default.
 
-Allowlisted uniquenames (both `datatype=2` bool, stored as string `"true"`/`"false"`):
-- `PowerAppsAppLevelSecurityRolesEnabled` — Enable app level security roles for canvas apps
-- `PlanShareSecurityRolesEnabled` — Enable plan level security roles for plan designer
+For the read + idempotent CREATE/PATCH Python and the gating notes, see [`references/settings-overrides.md`](references/settings-overrides.md).
 
-**Read current value:**
+## Operational confirmation rules
 
-```python
-import os, sys, json, urllib.request, urllib.parse
-sys.path.insert(0, os.path.join(os.getcwd(), "scripts"))
-from auth import get_token, load_env  # SDK does not support settingdefinition/organizationsettings entities
+The four rules in the safety callout at the top of this file cover the irreversible / destructive cases. The rules below cover the non-destructive but still impactful operations:
 
-load_env()
-env_url = os.environ["DATAVERSE_URL"].rstrip("/")
-headers = {
-    "Authorization": f"Bearer {get_token()}",
-    "Accept": "application/json",
-    "OData-MaxVersion": "4.0",
-    "OData-Version": "4.0",
-    "Content-Type": "application/json",
-}
-
-UNIQUENAME = "PowerAppsAppLevelSecurityRolesEnabled"   # or PlanShareSecurityRolesEnabled
-
-q = urllib.parse.quote(f"uniquename eq '{UNIQUENAME}'")
-req = urllib.request.Request(
-    f"{env_url}/api/data/v9.2/settingdefinitions?$filter={q}"
-    f"&$select=settingdefinitionid,uniquename,defaultvalue,datatype",
-    headers=headers,
-)
-with urllib.request.urlopen(req) as resp:
-    defn = json.loads(resp.read())["value"][0]
-
-sd_id = defn["settingdefinitionid"]
-default = defn["defaultvalue"]
-
-q2 = urllib.parse.quote(f"_settingdefinitionid_value eq '{sd_id}'")
-req = urllib.request.Request(
-    f"{env_url}/api/data/v9.2/organizationsettings?$filter={q2}&$select=organizationsettingid,value",
-    headers=headers,
-)
-with urllib.request.urlopen(req) as resp:
-    overrides = json.loads(resp.read())["value"]
-
-current = overrides[0]["value"] if overrides else default
-print(f"{UNIQUENAME} = {current} (default = {default}, override present: {bool(overrides)})", flush=True)
-```
-
-**Write (idempotent CREATE-or-PATCH):**
-
-```python
-# Continues from Read script above — reuses UNIQUENAME, sd_id, overrides, headers, env_url.
-# SDK does not support settingdefinition/organizationsettings entities.
-NEW_VALUE = "true"   # bool-as-string; "true"/"false" (lowercase)
-
-if overrides:
-    setting_id = overrides[0]["organizationsettingid"]
-    req = urllib.request.Request(
-        f"{env_url}/api/data/v9.2/organizationsettings({setting_id})",
-        data=json.dumps({"value": NEW_VALUE}).encode("utf-8"),
-        headers=headers,
-        method="PATCH",
-    )
-else:
-    # No override exists — CREATE a new one
-    payload = {
-        "settingdefinitionid@odata.bind": f"settingdefinitions({sd_id})",
-        "value": NEW_VALUE,
-    }
-    req = urllib.request.Request(
-        f"{env_url}/api/data/v9.2/organizationsettings",
-        data=json.dumps(payload).encode("utf-8"),
-        headers=headers,
-        method="POST",
-    )
-
-with urllib.request.urlopen(req) as resp:
-    print(f"SUCCESS: {UNIQUENAME} = {NEW_VALUE} (HTTP {resp.status})", flush=True)
-```
-
-**Notes:**
-- `datatype=2` means bool; other values exist for string/int but only bool toggles are in our allowlist today.
-- `value` is always a **string**, even for bool and int definitions — `"true"` not `True`.
-- The two allowlisted uniquenames are gated by ECS feature flags (`enablePowerAppsAppLevelSecurityRolesToggle`, `enablePlanShareSecurityRolesToggle`) in the PPAC UI, but the entities exist regardless — if the flag is off in an env, setting the override still takes effect.
-- `DELETE` on the override row reverts to the `settingdefinition.defaultvalue`.
-
----
-
-## Safety Rules
-
-- **Always confirm** before scheduling a bulk delete — this is destructive
-- If `--fetchxml` is omitted, warn that ALL records in the table will be deleted
-- For system tables (`systemuser`, `businessunit`, `organization`), warn that deleting may break the environment
-- **Always confirm** before changing org settings that affect all users
-- For multi-environment updates, show the list of environments and get confirmation first
-- For OrgDB settings, warn that incorrect values can break environment features
-- For recycle bin, warn that reducing cleanup interval will permanently delete records sooner
-- For recycle bin enable/disable: always set `isreadyforrecyclebin` explicitly (true on enable, false on disable), use PATCH for disable (not DELETE), and drain any in-flight `ProcessRecycleBin` async jobs before toggling. Omitting these can produce `EntityBinUpdateAction called for entity <x> which is not enabled for RecycleBin` on unrelated platform operations.
+- Confirm before changing org settings that affect all users.
+- For multi-environment updates, show the list of target environments and get confirmation first.
+- For OrgDB settings, warn that incorrect values can break environment features.
+- For recycle bin cleanup interval changes, warn that reducing the interval permanently deletes recycled records sooner.
+- For recycle bin enable/disable specifically: always set `isreadyforrecyclebin` explicitly (true on enable, false on disable), and drain any in-flight `ProcessRecycleBin` async jobs before any second toggle. Omitting these can produce `EntityBinUpdateAction called for entity <x> which is not enabled for RecycleBin` on unrelated platform operations.
 

--- a/.github/plugins/dataverse/skills/dv-admin/SKILL.md
+++ b/.github/plugins/dataverse/skills/dv-admin/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dv-admin
-description: Performs environment-level Dataverse administration — bulk delete, retention/archival, organization settings, OrgDB settings, recycle bin, and settings-definition overrides (37 allowlisted PPAC toggles). Use when bulk-deleting records, scheduling retention or archival, modifying org or OrgDB settings, configuring audit, or toggling the recycle bin.
+description: Environment-level Dataverse administration — bulk delete, retention/archival, organization settings, OrgDB settings, recycle bin, audit, and the 37 allowlisted PPAC toggles. Use when the user wants to clean up data at scale, configure audit, change environment settings, or manage retention policies.
 ---
 
 # Skill: Environment Admin — Bulk Delete, Retention, Org Settings, OrgDB, Recycle Bin

--- a/.github/plugins/dataverse/skills/dv-admin/references/orgdb-settings.md
+++ b/.github/plugins/dataverse/skills/dv-admin/references/orgdb-settings.md
@@ -1,0 +1,127 @@
+# OrgDB Settings (orgdborgsettings XML)
+
+Settings like search mode, MCP, copilot features, fabric, and retention live inside the `orgdborgsettings` XML blob. The XML uses **direct PascalCase elements** (NOT `<pair>` tags):
+
+```xml
+<OrgSettings>
+  <IsMCPEnabled>true</IsMCPEnabled>
+  <SearchAndCopilotIndexMode>0</SearchAndCopilotIndexMode>
+  <IsLinkToFabricEnabled>true</IsLinkToFabricEnabled>
+  <IsFabricVirtualTableEnabled>false</IsFabricVirtualTableEnabled>
+</OrgSettings>
+```
+
+**Read all OrgDB settings:**
+
+```python
+import os, sys, json, urllib.request
+from xml.etree import ElementTree as ET
+sys.path.insert(0, os.path.join(os.getcwd(), "scripts"))
+from auth import get_token, load_env  # SDK does not support orgdborgsettings XML blob
+
+load_env()
+env_url = os.environ["DATAVERSE_URL"].rstrip("/")
+token = get_token()
+
+req = urllib.request.Request(
+    f"{env_url}/api/data/v9.2/organizations?$select=organizationid,orgdborgsettings",
+    headers={"Authorization": f"Bearer {token}", "Accept": "application/json"},
+)
+with urllib.request.urlopen(req) as resp:
+    org = json.loads(resp.read())["value"][0]
+
+root = ET.fromstring(org["orgdborgsettings"])
+for child in sorted(root, key=lambda c: c.tag):
+    print(f"  {child.tag} = {child.text}", flush=True)
+```
+
+**Update or add an OrgDB setting:**
+
+```python
+import os, sys, json, urllib.request, urllib.error
+from xml.etree import ElementTree as ET
+sys.path.insert(0, os.path.join(os.getcwd(), "scripts"))
+from auth import get_token, load_env  # SDK does not support orgdborgsettings XML blob
+
+load_env()
+env_url = os.environ["DATAVERSE_URL"].rstrip("/")
+token = get_token()
+
+SETTING_NAME = "SearchAndCopilotIndexMode"  # PascalCase, case-sensitive
+SETTING_VALUE = "0"                          # always a string in XML
+
+headers = {
+    "Authorization": f"Bearer {token}",
+    "Accept": "application/json",
+    "Content-Type": "application/json",
+    "OData-MaxVersion": "4.0",
+    "OData-Version": "4.0",
+}
+
+# Fetch current XML
+req = urllib.request.Request(
+    f"{env_url}/api/data/v9.2/organizations?$select=organizationid,orgdborgsettings",
+    headers=headers,
+)
+with urllib.request.urlopen(req) as resp:
+    org = json.loads(resp.read())["value"][0]
+    org_id = org["organizationid"]
+
+root = ET.fromstring(org.get("orgdborgsettings", "<OrgSettings></OrgSettings>"))
+
+# Update existing or add new
+existing = root.find(SETTING_NAME)
+if existing is not None:
+    print(f"Current {SETTING_NAME} = {existing.text}", flush=True)
+    existing.text = SETTING_VALUE
+else:
+    print(f"{SETTING_NAME} not set -- adding", flush=True)
+    ET.SubElement(root, SETTING_NAME).text = SETTING_VALUE
+
+# PATCH back
+req = urllib.request.Request(
+    f"{env_url}/api/data/v9.2/organizations({org_id})",
+    data=json.dumps({"orgdborgsettings": ET.tostring(root, encoding="unicode")}).encode("utf-8"),
+    headers=headers,
+    method="PATCH",
+)
+try:
+    with urllib.request.urlopen(req) as resp:
+        print(f"SUCCESS: {SETTING_NAME} = {SETTING_VALUE} (HTTP {resp.status})", flush=True)
+except urllib.error.HTTPError as e:
+    print(f"ERROR {e.code}: {e.read().decode()}", flush=True)
+```
+
+**Remove an OrgDB setting:**
+
+```python
+# After fetching and parsing the XML (same as above):
+existing = root.find(SETTING_NAME)
+if existing is not None:
+    root.remove(existing)
+    # PATCH back the XML without the element
+```
+
+**Allowed OrgDB settings (17 keys — PascalCase, case-sensitive):**
+
+| Setting | Type | Values | PPAC label |
+|---|---|---|---|
+| `IsMCPEnabled` | bool | `true` / `false` | Allow MCP clients to interact with Dataverse MCP server |
+| `IsMCPPreviewEnabled` | bool | `true` / `false` | Advanced Settings (enable non-Copilot Studio MCP clients) |
+| `SearchAndCopilotIndexMode` | int | `0` Search Off / Copilot On; `1` Both On; `2` Both Off; `3` Search On / Copilot Off | Dataverse search + Search for records in Microsoft 365 apps (one key, two UI toggles — see truth table above) |
+| `IsLinkToFabricEnabled` | bool | `true` / `false` | Link Dataverse tables with Microsoft Fabric workspace |
+| `IsFabricVirtualTableEnabled` | bool | `true` / `false` | Define Dataverse virtual tables using Fabric OneLake data |
+| `ShowDataInM365Copilot` | bool | `true` / `false` | Allow data availability in Microsoft 365 Copilot |
+| `EnableWorkIQ` | bool | `true` / `false` | Turn on Dataverse intelligence (Work IQ) for agents |
+| `IsLockdownOfUnmanagedCustomizationEnabled` | bool | `true` / `false` | Block unmanaged customizations in environment |
+| `EnableSecurityOnAttachment` | bool | `true` / `false` | Enable security on Attachment entity |
+| `EnableTDSEndpoint` | bool | `true` / `false` | Enable TDS endpoint |
+| `AllowAccessToTDSEndpoint` | bool | `true` / `false` | Enable user level access control for TDS endpoint (requires TDS endpoint enabled first) |
+| `EnableOwnershipAcrossBusinessUnits` | bool | `true` / `false` | Record ownership across business units |
+| `CreateOnlyNonEmptyAddressRecordsForEligibleEntities` | bool | `true` / `false` | Disable empty address record creation (affects Account, Contact, Lead) |
+| `EnableDeleteAddressRecords` | bool | `true` / `false` | Enable deletion of address records |
+| `BlockDeleteManagedAttributeMap` | bool | `true` / `false` | Block deletion of OOB attribute maps |
+| `EnableSystemUserDelete` | bool | `true` / `false` | Enable delete disabled users |
+| `IsExcelToExistingTableWithAssistedMappingEnabled` | bool | `true` / `false` | Import Excel to existing table with AI-assisted mapping |
+
+Every other OrgDB key (`IsRetentionEnabled`, `IsArchivalEnabled`, `IsDVCopilotForTextDataEnabled`, `IsShadowLakeEnabled`, `IsCommandingModifiedOnEnabled`, `CanCreateApplicationStubUser`, `AllowRoleAssignmentOnDisabledUsers`, `EnableActivitiesFeatures`, `TDSListenerInitialized`, `AzureSynapseLinkIncrementalUpdateTimeInterval`, etc.) is **out of scope** — refuse and direct the user to the Power Platform admin center. Do NOT dump the whole `orgdborgsettings` XML to "discover" other settings for the user.

--- a/.github/plugins/dataverse/skills/dv-admin/references/recycle-bin.md
+++ b/.github/plugins/dataverse/skills/dv-admin/references/recycle-bin.md
@@ -1,0 +1,183 @@
+# Recycle Bin Configuration
+
+Recycle bin settings live in the `recyclebinconfigs` entity, NOT in `orgdborgsettings` XML. PAC CLI cannot manage these.
+
+**Well-known constant:** The organization entity metadata ID is `e1bd1119-6e9d-45a4-bc15-12051e65a0bd`. This is the `MetadataId` of the `organization` entity's *schema record* in `EntityDefinitions` (a product-level system constant baked into every Dataverse installation), not a tenant-level GUID — so it is identical across all environments and all tenants. Verified empirically across 5 environments. Do not re-query it per environment.
+
+### Read Recycle Bin Status
+
+```python
+import os, sys, json, urllib.request, urllib.parse
+sys.path.insert(0, os.path.join(os.getcwd(), "scripts"))
+from auth import get_token, load_env  # SDK does not support recyclebinconfigs entity
+
+load_env()
+env_url = os.environ["DATAVERSE_URL"].rstrip("/")
+token = get_token()
+
+ORGANIZATION_ENTITY_ID = "e1bd1119-6e9d-45a4-bc15-12051e65a0bd"
+
+headers = {
+    "Authorization": f"Bearer {token}",
+    "Accept": "application/json",
+    "Content-Type": "application/json",
+    "OData-MaxVersion": "4.0",
+    "OData-Version": "4.0",
+}
+
+# Fetch org-level config by extensionofrecordid (NOT by name)
+filter_q = urllib.parse.quote(f"_extensionofrecordid_value eq '{ORGANIZATION_ENTITY_ID}'")
+req = urllib.request.Request(
+    f"{env_url}/api/data/v9.2/recyclebinconfigs?$filter={filter_q}&$select=recyclebinconfigid,statecode,statuscode,cleanupintervalindays",
+    headers=headers,
+)
+with urllib.request.urlopen(req) as resp:
+    records = json.loads(resp.read()).get("value", [])
+
+if records:
+    config = records[0]
+    enabled = config["statecode"] == 0
+    cleanup = config["cleanupintervalindays"]
+    print(f"Recycle bin: {'enabled' if enabled else 'disabled'}", flush=True)
+    print(f"Cleanup interval: {cleanup} days ({'-1 means no auto-cleanup' if cleanup == -1 else ''})", flush=True)
+    print(f"Config ID: {config['recyclebinconfigid']}", flush=True)
+else:
+    print("Recycle bin: not configured (no org-level record)", flush=True)
+```
+
+### Critical: Always Send `isreadyforrecyclebin: true` on Enable
+
+**Every enable payload (POST or PATCH) must set `isreadyforrecyclebin: true`.**
+
+Without it, the platform defaults `isreadyforrecyclebin` to `false` (CREATE) or leaves it null (PATCH), which forces the platform into the **asynchronous** opt-in path — a `ProcessRecycleBin` background job is queued and your HTTP call returns success before any entity-level work happens. In that window, platform metadata operations (solution imports, attribute publish, async handlers) can race against the partial state and throw `EntityBinUpdateAction called for entity <x> which is not enabled for RecycleBin`. Sending `isreadyforrecyclebin: true` forces the synchronous, globally-locked opt-in path, which fans out to every entity inside one transaction.
+
+### Critical: Disable via PATCH, Not DELETE
+
+**Disable with `PATCH statecode=1, statuscode=2, isreadyforrecyclebin=false`. Do not DELETE the org config record.**
+
+DELETE enqueues an async opt-out (when `RecycleBinOptOutOrgAsynchronously` is on) while leaving the org row marked Inactive and child entity rows still flagged `IsReadyForRecycleBin=true, IsDisabled=false`. Any platform operation that runs between your DELETE and your next enable will see "org is enabled" from the config cache, proceed to `RecycleBinConfigService.Update(<entity-config>)` synchronously, and throw when the DB-backed `IsRecycleBinEnabledForEntity` check disagrees. A PATCH-based disable takes the synchronous `OptOutOrganization` path under the customization lock, cleanly cascading to every entity.
+
+### Wait for in-flight `ProcessRecycleBin` Jobs Between Toggles
+
+Every enable/disable queues a `ProcessRecycleBin` async operation (OperationType = `50`). Do NOT enable-then-disable-then-enable rapidly; the jobs share a dependency token and can interleave in ways that corrupt state. Before any second toggle, poll `AsyncOperation` until no `ProcessRecycleBin` row is `Queued` or `InProgress` for this org.
+
+### Enable Recycle Bin
+
+Two cases depending on whether a config record already exists. Both send `isreadyforrecyclebin: true`.
+
+```python
+# ... (same imports, headers, ORGANIZATION_ENTITY_ID, and fetch as above)
+# SDK does not support recyclebinconfigs entity
+
+CLEANUP_DAYS = 30  # default; -1 means records in recycle bin are never auto-purged
+
+# Pre-flight: wait for any in-flight ProcessRecycleBin async jobs to finish
+import time
+def wait_for_recyclebin_async_jobs(env_url, headers, timeout_s=120):
+    # OperationType 50 = ProcessRecycleBin; StateCode 0=Ready/1=Suspended/2=Locked are all "not done"
+    filter_q = urllib.parse.quote("operationtype eq 50 and statecode ne 3")
+    url = f"{env_url}/api/data/v9.2/asyncoperations?$filter={filter_q}&$select=asyncoperationid,statecode,statuscode,name"
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        req = urllib.request.Request(url, headers=headers)
+        with urllib.request.urlopen(req) as resp:
+            pending = json.loads(resp.read()).get("value", [])
+        if not pending:
+            return
+        print(f"  waiting on {len(pending)} ProcessRecycleBin job(s)...", flush=True)
+        time.sleep(5)
+    raise RuntimeError("Timed out waiting for pending ProcessRecycleBin async jobs")
+
+wait_for_recyclebin_async_jobs(env_url, headers)
+
+if not records:
+    # Case 1: No config exists -- CREATE a new one
+    # extensionofrecordid binds to the entities() metadata endpoint, NOT organizations()
+    payload = {
+        "extensionofrecordid@odata.bind": f"entities({ORGANIZATION_ENTITY_ID})",
+        "extensionofrecordid@OData.Community.Display.V1.FormattedValue": "OrganizationId",
+        "isreadyforrecyclebin": True,   # MUST be true -- forces sync opt-in under the global lock
+        "cleanupintervalindays": CLEANUP_DAYS,
+    }
+    req = urllib.request.Request(
+        f"{env_url}/api/data/v9.2/recyclebinconfigs",
+        data=json.dumps(payload).encode("utf-8"),
+        headers=headers,
+        method="POST",
+    )
+    with urllib.request.urlopen(req) as resp:
+        print(f"SUCCESS: recycle bin enabled with {CLEANUP_DAYS} day cleanup (HTTP {resp.status})", flush=True)
+else:
+    # Case 2: Config exists -- PATCH statecode/statuscode, cleanup interval, and isreadyforrecyclebin
+    config_id = records[0]["recyclebinconfigid"]
+    payload = {
+        "cleanupintervalindays": CLEANUP_DAYS,
+        "statecode": 0,
+        "statuscode": 1,
+        "isreadyforrecyclebin": True,   # MUST be true -- without this, UpdateInternal routes through updateAsync
+    }
+    req = urllib.request.Request(
+        f"{env_url}/api/data/v9.2/recyclebinconfigs({config_id})",
+        data=json.dumps(payload).encode("utf-8"),
+        headers=headers,
+        method="PATCH",
+    )
+    with urllib.request.urlopen(req) as resp:
+        print(f"SUCCESS: recycle bin enabled with {CLEANUP_DAYS} day cleanup (HTTP {resp.status})", flush=True)
+
+# Post-flight: drain the sync opt-in fan-out before returning control
+wait_for_recyclebin_async_jobs(env_url, headers)
+```
+
+### Disable Recycle Bin
+
+**Disable = PATCH `statecode=1, statuscode=2, isreadyforrecyclebin=false`.** This triggers the synchronous `OptOutOrganization` path which cascades cleanly to every entity config.
+
+```python
+# ... (same fetch as above to get config_id)
+# SDK does not support recyclebinconfigs entity
+
+wait_for_recyclebin_async_jobs(env_url, headers)   # drain first
+
+if records:
+    config_id = records[0]["recyclebinconfigid"]
+    payload = {
+        "statecode": 1,                 # Inactive
+        "statuscode": 2,                # Inactive
+        "isreadyforrecyclebin": False,  # required to take the isOptOut branch in UpdateInternal
+    }
+    req = urllib.request.Request(
+        f"{env_url}/api/data/v9.2/recyclebinconfigs({config_id})",
+        data=json.dumps(payload).encode("utf-8"),
+        headers=headers,
+        method="PATCH",
+    )
+    with urllib.request.urlopen(req) as resp:
+        print(f"SUCCESS: recycle bin disabled (HTTP {resp.status})", flush=True)
+else:
+    print("Recycle bin is already disabled (no config record)", flush=True)
+
+wait_for_recyclebin_async_jobs(env_url, headers)   # drain the opt-out fan-out
+```
+
+**Do NOT use DELETE to disable.** Legacy guidance (including older Admin Center behavior) suggested DELETE, but DELETE enqueues an async opt-out and can leave per-entity configs orphaned — any platform metadata operation that runs before cleanup finishes will throw `EntityBinUpdateAction called for entity <x> which is not enabled for RecycleBin` on an unrelated entity.
+
+### Key Fields on `recyclebinconfigs`
+
+| Field | Type | What it does |
+|---|---|---|
+| `statecode` | int | `0` = enabled (active), `1` = disabled (inactive) |
+| `statuscode` | int | `1` = enabled, `2` = disabled |
+| `cleanupintervalindays` | int | Auto-cleanup interval. `-1` = no auto-cleanup (default). `30` = purge after 30 days (max). Min: `1` |
+| `_extensionofrecordid_value` | guid | Entity metadata ID this config applies to. Org-level = `e1bd1119-6e9d-45a4-bc15-12051e65a0bd` |
+
+### Important Notes
+
+- **Fetch by `_extensionofrecordid_value`**, not by `name`. The `name` field is unreliable for filtering.
+- **Create uses `entities()` binding** -- `extensionofrecordid@odata.bind: entities({id})`, NOT `organizations()`.
+- **Enable payloads MUST include `isreadyforrecyclebin: true`.** Without it, CREATE defaults to false and PATCH sends null — both force the async opt-in path and expose the org to cache-vs-DB races during platform metadata operations.
+- **Disable = PATCH `statecode=1, statuscode=2, isreadyforrecyclebin=false`**, not DELETE. DELETE enqueues an async opt-out and can leave per-entity configs orphaned.
+- **Drain `ProcessRecycleBin` async jobs between toggles.** Query `asyncoperations` for `operationtype eq 50 and statecode ne 3` before and after each enable/disable.
+- **Cleanup days**: default is `-1` (no auto-cleanup). Max is `30`. When the UI shows "30 days", the API stores `-1` internally (the platform applies a 30-day default).
+- Solution-managed configs (e.g., `msdyn_recurringsalesaction`) cannot be enabled/disabled via API.
+- **Per-table recycle bin toggles are out of scope.** PPAC only exposes the org-level on/off + cleanup days — if a user asks to enable/disable recycle bin for a specific table (e.g., "turn on recycle bin for `contact` only"), refuse with: *"Per-table recycle bin is out of scope for dv-admin. Use the Power Platform admin center."* The `recyclebinconfigs` entity does hold per-entity rows, but this skill only reads/writes the org-level row (filtered by the organization entity's MetadataId).

--- a/.github/plugins/dataverse/skills/dv-admin/references/settings-overrides.md
+++ b/.github/plugins/dataverse/skills/dv-admin/references/settings-overrides.md
@@ -1,0 +1,91 @@
+# Settings-Definition Overrides (app/plan security roles)
+
+A small number of allowlisted toggles don't live on the `organization` entity or in `orgdborgsettings`. They're modeled as a join between two entities:
+
+- **`settingdefinition`** — defines the setting (uniquename, datatype, defaultvalue, description). Read-only; one row per known setting; identical across environments in the same build.
+- **`organizationsettings`** — holds per-org overrides. If no row exists for a given `settingdefinitionid`, the `defaultvalue` from `settingdefinition` applies.
+
+Allowlisted uniquenames (both `datatype=2` bool, stored as string `"true"`/`"false"`):
+- `PowerAppsAppLevelSecurityRolesEnabled` — Enable app level security roles for canvas apps
+- `PlanShareSecurityRolesEnabled` — Enable plan level security roles for plan designer
+
+**Read current value:**
+
+```python
+import os, sys, json, urllib.request, urllib.parse
+sys.path.insert(0, os.path.join(os.getcwd(), "scripts"))
+from auth import get_token, load_env  # SDK does not support settingdefinition/organizationsettings entities
+
+load_env()
+env_url = os.environ["DATAVERSE_URL"].rstrip("/")
+headers = {
+    "Authorization": f"Bearer {get_token()}",
+    "Accept": "application/json",
+    "OData-MaxVersion": "4.0",
+    "OData-Version": "4.0",
+    "Content-Type": "application/json",
+}
+
+UNIQUENAME = "PowerAppsAppLevelSecurityRolesEnabled"   # or PlanShareSecurityRolesEnabled
+
+q = urllib.parse.quote(f"uniquename eq '{UNIQUENAME}'")
+req = urllib.request.Request(
+    f"{env_url}/api/data/v9.2/settingdefinitions?$filter={q}"
+    f"&$select=settingdefinitionid,uniquename,defaultvalue,datatype",
+    headers=headers,
+)
+with urllib.request.urlopen(req) as resp:
+    defn = json.loads(resp.read())["value"][0]
+
+sd_id = defn["settingdefinitionid"]
+default = defn["defaultvalue"]
+
+q2 = urllib.parse.quote(f"_settingdefinitionid_value eq '{sd_id}'")
+req = urllib.request.Request(
+    f"{env_url}/api/data/v9.2/organizationsettings?$filter={q2}&$select=organizationsettingid,value",
+    headers=headers,
+)
+with urllib.request.urlopen(req) as resp:
+    overrides = json.loads(resp.read())["value"]
+
+current = overrides[0]["value"] if overrides else default
+print(f"{UNIQUENAME} = {current} (default = {default}, override present: {bool(overrides)})", flush=True)
+```
+
+**Write (idempotent CREATE-or-PATCH):**
+
+```python
+# Continues from Read script above — reuses UNIQUENAME, sd_id, overrides, headers, env_url.
+# SDK does not support settingdefinition/organizationsettings entities.
+NEW_VALUE = "true"   # bool-as-string; "true"/"false" (lowercase)
+
+if overrides:
+    setting_id = overrides[0]["organizationsettingid"]
+    req = urllib.request.Request(
+        f"{env_url}/api/data/v9.2/organizationsettings({setting_id})",
+        data=json.dumps({"value": NEW_VALUE}).encode("utf-8"),
+        headers=headers,
+        method="PATCH",
+    )
+else:
+    # No override exists — CREATE a new one
+    payload = {
+        "settingdefinitionid@odata.bind": f"settingdefinitions({sd_id})",
+        "value": NEW_VALUE,
+    }
+    req = urllib.request.Request(
+        f"{env_url}/api/data/v9.2/organizationsettings",
+        data=json.dumps(payload).encode("utf-8"),
+        headers=headers,
+        method="POST",
+    )
+
+with urllib.request.urlopen(req) as resp:
+    print(f"SUCCESS: {UNIQUENAME} = {NEW_VALUE} (HTTP {resp.status})", flush=True)
+```
+
+**Notes:**
+- `datatype=2` means bool; other values exist for string/int but only bool toggles are in our allowlist today.
+- `value` is always a **string**, even for bool and int definitions — `"true"` not `True`.
+- The two allowlisted uniquenames are gated by ECS feature flags (`enablePowerAppsAppLevelSecurityRolesToggle`, `enablePlanShareSecurityRolesToggle`) in the PPAC UI, but the entities exist regardless — if the flag is off in an env, setting the override still takes effect.
+- `DELETE` on the override row reverts to the `settingdefinition.defaultvalue`.

--- a/.github/plugins/dataverse/skills/dv-connect/SKILL.md
+++ b/.github/plugins/dataverse/skills/dv-connect/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dv-connect
-description: Connects to a Dataverse environment in one step — installs tools, authenticates, configures MCP, and verifies the connection. Use when setting up Dataverse on a new machine, configuring MCP, fixing a missing .env, starting a new project, or troubleshooting MCP connectivity.
+description: One-step setup for a Dataverse environment — installs tools, authenticates, registers the MCP server, and writes `.env`. Use when starting a new project, switching environments, fixing authentication, or troubleshooting an MCP connection that won't come up.
 ---
 
 # Skill: Connect

--- a/.github/plugins/dataverse/skills/dv-connect/SKILL.md
+++ b/.github/plugins/dataverse/skills/dv-connect/SKILL.md
@@ -1,14 +1,6 @@
 ---
 name: dv-connect
-description: >
-  Connect to a Dataverse environment in one step — installs tools, authenticates, configures MCP, and verifies the connection.
-  Use when: "connect to Dataverse", "configure MCP", "set up MCP server", "MCP not working",
-  ".env is missing", "setting up on a new machine", "starting a new project",
-  "initialize workspace", "new repo", "first time setup", "install tools",
-  "command not found", "missing tools", "new machine setup", "authenticate",
-  "MCP not connected", "create a new environment", "select environment",
-  "connect via MCP", "add Dataverse to Copilot", "add Dataverse to Claude",
-  "load demo data", "sample data".
+description: Connects to a Dataverse environment in one step — installs tools, authenticates, configures MCP, and verifies the connection. Use when setting up Dataverse on a new machine, configuring MCP, fixing a missing .env, starting a new project, or troubleshooting MCP connectivity.
 ---
 
 # Skill: Connect

--- a/.github/plugins/dataverse/skills/dv-data/SKILL.md
+++ b/.github/plugins/dataverse/skills/dv-data/SKILL.md
@@ -1,17 +1,6 @@
 ---
 name: dv-data
-description: >
-  Create, update, delete, bulk-import, and upsert Dataverse records using the official Python SDK.
-  Use when: "create records", "insert data", "bulk create", "bulk update", "bulk import",
-  "import CSV", "load data", "upsert", "upsert records", "write data", "upload file",
-  "add records", "CreateMultiple", "UpdateMultiple", "UpsertMultiple",
-  "multi-table import", "FK dependencies", "dependency order", "parallel import", "large dataset",
-  "create sample data", "seed data", "generate test records", "populate entity",
-  "add sample records", "create dummy data", "generate sample accounts",
-  "seed the account table", "create test data for".
-  Do not use when: querying or reading records (use dv-query),
-  creating tables, columns, or relationships (use dv-metadata),
-  exporting solutions (use dv-solution).
+description: Creates, updates, deletes, bulk-imports, and upserts Dataverse records via the Python SDK. Use when writing or modifying records, bulk-importing data, upserting with alternate keys, running multi-table imports with FK dependencies, or generating sample or seed data.
 ---
 
 # Skill: Data — Create, Update, Delete, and Bulk Import
@@ -29,17 +18,13 @@ Two rules, different strictness:
 
 ### Examples
 
-<example operation="generate N sample records (destructive — show the command)">
-<user>Generate 20 test contact records</user>
-<bad>Which environment should I target? Please provide the Dataverse URL.</bad>
-<good>I'll run the schema-query + bulk-create snippets from the Sample Data Generation section below with `TABLE="contact"`, `COUNT=20`. Uses `CreateMultiple`, `.example.com` emails, `555-01xx` phones against the active `pac auth list` environment. Confirm to proceed, or tell me to target a different environment.</good>
-</example>
+**Generate N sample records (destructive — preview the snippet, ask for env):**
+- ❌ "Which environment should I target? Please provide the Dataverse URL."
+- ✅ "I'll run the Sample Data Generation snippets with `TABLE=\"contact\"`, `COUNT=20`. Uses `CreateMultiple`, `.example.com` emails, `555-01xx` phones, against the active `pac auth list` environment. Confirm to proceed, or specify a different environment."
 
-<example operation="sample data on custom entity (schema unknown — prose is enough)">
-<user>Create dummy data for a custom entity called cr123_project</user>
-<bad>I need more info about the entity. What are the required fields?</bad>
-<good>Custom entity — I'll query EntityDefinitions for `cr123_project` first to discover required columns, then generate 5 records inline mapping each column to a generator by `AttributeType`, and call `client.records.create("cr123_project", records)`. Snippets in the Sample Data Generation section below. Confirm to proceed, or tell me a different count.</good>
-</example>
+**Sample data on a custom entity (schema unknown — prose is enough):**
+- ❌ "I need more info about the entity. What are the required fields?"
+- ✅ "Custom entity — I'll query `EntityDefinitions` for `cr123_project` to discover required columns, then generate 5 records inline mapping each column to a generator by `AttributeType` and call `client.records.create(\"cr123_project\", records)`. Confirm to proceed, or tell me a different count."
 
 Use the official Microsoft Power Platform Dataverse Client Python SDK for all data write operations.
 
@@ -258,7 +243,7 @@ client.records.upsert("account", [
 
 ## Bulk Import from CSV
 
-> **For imports that may be re-run** (most real-world cases), use `UpsertItem` with alternate keys instead of `create()` — see the Multi-Table Import section below. The `create()` pattern here is for one-shot loads only.
+> **For imports that may be re-run** (most real-world cases), use `UpsertItem` with alternate keys instead of `create()` — see [`references/multi-table-fk-import.md`](references/multi-table-fk-import.md). The `create()` pattern here is for one-shot loads only.
 
 | Volume | Tool | Why |
 |---|---|---|
@@ -325,219 +310,22 @@ Before bulk-creating in a system table (account, contact, opportunity):
 
 ## Multi-Table Import with FK Dependencies
 
-When importing data across multiple tables with foreign key relationships, follow this sequence:
+When importing data across multiple tables with foreign key relationships, the import must run in dependency order with `UpsertItem` + alternate keys (idempotent, safe for re-runs).
 
-1. **Create tables** with source ID columns (`prefix_Src*Id`) — see **dv-metadata**
-2. **Create alternate keys** on the source ID columns — see **dv-metadata** "Alternate Keys" section
-3. **Create lookup relationships** — see **dv-metadata**
-4. **Import data** in dependency order using `UpsertItem` with alternate keys (safe for re-runs)
+**Quick reference:**
+1. Create tables with source ID columns + alternate keys + lookup relationships (see **dv-metadata**).
+2. Import Level 0 (no FK deps) tables in parallel via `ThreadPoolExecutor`. Sequential chunks within each table (concurrent writes deadlock).
+3. Build source-ID → GUID maps by querying back (upsert doesn't return GUIDs).
+4. Repeat per dependency level — Level 1 needs Level 0's maps for `@odata.bind`.
 
-Using upsert from the start means partial failures, retries, and re-runs never create duplicates. The alternate key lets Dataverse match records by the source system's ID instead of GUIDs.
+For the full pattern — adaptive `bulk_upsert` helper, composite-key handling, post-import verification, and the first-time `bulk_create` variant — see [`references/multi-table-fk-import.md`](references/multi-table-fk-import.md).
 
-**Deciding which alternate key to create:**
-- **Database source (SQLite, SQL Server):** Read the schema to identify primary keys. The source PK maps directly to the Dataverse alternate key. Agent can decide without asking.
-- **Excel/CSV source:** Inspect the data for columns with all-unique values (`df[col].nunique() == len(df)`). Look for naming conventions (`*_ID`, `*_Code`). **Propose the candidate to the user and confirm** — "Column `Employee_ID` has 500 unique values across 500 rows. Use this as the key?" Do not create the key without confirmation, since uniqueness in current data doesn't guarantee it's the intended business key.
+Key invariants (apply even without reading the reference):
 
-```python
-import os, sys, csv, time
-sys.path.insert(0, os.path.join(os.getcwd(), "scripts"))
-from auth import get_credential, load_env
-from PowerPlatform.Dataverse.client import DataverseClient
-from PowerPlatform.Dataverse.models.upsert import UpsertItem
-from PowerPlatform.Dataverse.core.errors import HttpError
-from concurrent.futures import ThreadPoolExecutor, as_completed
-
-load_env()
-client = DataverseClient(base_url=os.environ["DATAVERSE_URL"], credential=get_credential())
-
-def bind(entity_set, guid):
-    """Build an @odata.bind value. entity_set must be the actual EntitySetName, not a guess."""
-    return f"/{entity_set}({guid})"
-
-# IMPORTANT: EntitySetName is NOT always logical_name + 's'.
-# Dataverse uses English pluralization: country -> countries, city -> cities,
-# winby -> winbies, extraruns -> extrarunses.
-# Always query the actual names before building @odata.bind values:
-#   GET /api/data/v9.2/EntityDefinitions?$select=LogicalName,EntitySetName
-
-def bulk_upsert(logical_name, items, chunk_size=1000, retries=3):
-    """Upsert items in adaptive chunks with retry. Starts at chunk_size, doubles on
-    success (up to max_size), halves on size/timeout failure. Caps at last successful
-    size to avoid oscillation. Safe for re-runs."""
-    import requests as req_lib  # for timeout exception types
-    current_size = chunk_size
-    max_size = 4000
-    i = 0
-    while i < len(items):
-        chunk = items[i:i + current_size]
-        for attempt in range(retries):
-            try:
-                client.records.upsert(logical_name, chunk)
-                print(f"  {logical_name}: {i + len(chunk)}/{len(items)} (chunk={current_size})", flush=True)
-                i += len(chunk)
-                current_size = min(current_size * 2, max_size)  # ramp up
-                break
-            except HttpError as e:
-                if e.status_code == 429 and attempt < retries - 1:
-                    time.sleep(5 * (attempt + 1))
-                    continue
-                if e.status_code in (413, 500) and current_size > 100:
-                    current_size = max(current_size // 2, 100)
-                    max_size = current_size
-                    print(f"  {logical_name}: chunk capped at {current_size}", flush=True)
-                    break  # retry same offset with smaller chunk
-                raise
-            except req_lib.exceptions.RequestException:
-                # Network timeout — SDK default is 120s for POST
-                if current_size > 100:
-                    current_size = max(current_size // 2, 100)
-                    max_size = current_size
-                    print(f"  {logical_name}: timeout, chunk capped at {current_size}", flush=True)
-                    break
-                raise
-        else:
-            i += len(chunk)  # skip chunk after all retries exhausted
-
-def build_map(logical_name, src_col, id_col):
-    """Query Dataverse to build source_id -> GUID map after upsert."""
-    result = {}
-    for page in client.records.get(logical_name, select=[src_col, id_col]):
-        for r in page:
-            src_val = r.get(src_col)
-            if src_val is not None:
-                result[src_val] = r[id_col]
-    return result
-
-def upsert_table(logical_name, items, chunk_size=1000):
-    """Upsert one table — used as target for ThreadPoolExecutor."""
-    bulk_upsert(logical_name, items, chunk_size)
-    return logical_name
-```
-
-**Import data in dependency levels — parallelize tables within each level:**
-
-Tables at the same dependency level are independent of each other and can be imported concurrently. Tables at different levels must be sequential (Level 1 needs Level 0's GUIDs for `@odata.bind`).
-
-```python
-# --- Level 0: All lookup tables concurrently (no FK dependencies) ---
-# Alternate keys must already exist. See dv-metadata "Alternate Keys".
-level0 = {
-    "prefix_country": [UpsertItem(
-        alternate_key={"prefix_srccountryid": r["id"]},
-        record={"prefix_name": r["name"]},  # key cols must NOT be in record body
-    ) for r in country_rows],
-    "prefix_team": [UpsertItem(...) for r in team_rows],
-    # ... all other Level 0 tables
-}
-
-# For composite-key tables (e.g., line items with multi-column PK):
-# ALL key columns go in alternate_key, NONE of them in record.
-line_items = [UpsertItem(
-    alternate_key={
-        "prefix_srcorderid": r["order_id"],
-        "prefix_srclineno": r["line_no"],
-    },
-    record={  # only non-key columns here
-        "prefix_name": f"Order-{r['order_id']}-Line-{r['line_no']}",
-        "prefix_quantity": r["qty"],
-        "prefix_unitprice": r["price"],
-    },
-) for r in order_line_rows]
-
-level0 = {
-    # ... lookup tables as above
-}
-
-with ThreadPoolExecutor(max_workers=len(level0)) as pool:
-    futures = {pool.submit(upsert_table, t, items): t for t, items in level0.items()}
-    for f in as_completed(futures):
-        table = futures[f]
-        try:
-            f.result()
-            print(f"  {table}: done", flush=True)
-        except Exception as e:
-            print(f"  {table}: FAILED — {e}", flush=True)
-            # Continue — don't kill other tables. Re-run later (upsert is idempotent).
-
-# Build lookup maps by querying back (upsert doesn't return GUIDs)
-country_map = build_map("prefix_country", "prefix_srccountryid", "prefix_countryid")
-team_map = build_map("prefix_team", "prefix_srcteamid", "prefix_teamid")
-
-# --- Level 1: Tables referencing Level 0, imported concurrently ---
-# Build items with @odata.bind using Level 0 maps, then import in parallel
-# ... repeat pattern for each level
-```
-
-**Key rules:**
-- **Parallelize across tables at the same level** — they share no data pages or indexes. Use `ThreadPoolExecutor` with one worker per table.
-- **Sequential between levels** — Level 1 needs Level 0's GUIDs for `@odata.bind`.
-- **Sequential chunks within each table** — concurrent writes to the same table cause SQL deadlocks (error 1205).
-- Use `UpsertItem` with the source system's PK as the alternate key — idempotent, safe for re-runs and partial failures.
-- **Do NOT put alternate key columns in the record body.** `UpsertMultiple` fails with "An unexpected error" if key columns appear in both. Single upsert tolerates it; bulk does not.
-- **Catch per-table failures in ThreadPoolExecutor** — wrap `f.result()` in try/except. One table failing must not kill the entire executor and prevent other tables from completing.
-- Build GUID maps by querying Dataverse after each level (upsert doesn't return GUIDs).
-- Start with `chunk_size=1000` and let the adaptive helper ramp up. Dataverse has no fixed record limit — the constraints are payload size and timeout. Narrow tables (few columns) can handle 2000-4000 per chunk.
-- `flush=True` on all print statements for real-time progress on Windows.
-- If a source row references a missing lookup ID, skip the row and log it.
-
-**Do NOT parallelize chunks within a single table.** Concurrent `UpsertMultiple`/`CreateMultiple` calls to the same table cause SQL Server deadlocks because concurrent inserts contend on shared data pages and index pages — even though the records are different.
-
-### Post-Import Verification
-
-After all levels are imported, verify record counts match the source. Count by iterating pages with a single-column select (memory-efficient — no need to load full DataFrames just for counts):
-
-```python
-def count_records(logical_name, id_col):
-    return sum(len(page) for page in client.records.get(logical_name, select=[id_col]))
-
-# Build expected counts from source data (e.g., len(rows) per table from earlier import phases)
-expected = {"prefix_department": 12, "prefix_employee": 500, "prefix_timesheet": 15000}
-for table, exp in expected.items():
-    actual = count_records(table, table + "id")  # e.g., prefix_department -> prefix_departmentid
-    status = "OK" if actual == exp else f"MISMATCH ({actual})"
-    print(f"  {table}: {status} (expected {exp})", flush=True)
-```
-
-For deeper verification (spot-check data values, not just counts), use `client.dataframe.get()` — see **dv-query**.
-
-### First-Time Import (when you are certain no re-runs are needed)
-
-If you control the environment and are certain the tables are empty, `client.records.create()` is faster than upsert (no existence check). But if the import fails partway through, re-running will create duplicates. Use this only for one-shot loads into fresh environments:
-
-```python
-def bulk_create(logical_name, records, chunk_size=1000):
-    """Import via create with adaptive chunking — faster but NOT safe for re-runs."""
-    import requests as req_lib
-    all_guids = []
-    current_size = chunk_size
-    max_size = 4000
-    i = 0
-    while i < len(records):
-        chunk = records[i:i + current_size]
-        try:
-            guids = client.records.create(logical_name, chunk)
-            all_guids.extend(guids)
-            print(f"  {logical_name}: {i + len(chunk)}/{len(records)} (chunk={current_size})", flush=True)
-            i += len(chunk)
-            current_size = min(current_size * 2, max_size)
-        except HttpError as e:
-            if e.status_code in (413, 500) and current_size > 100:
-                current_size = max(current_size // 2, 100)
-                max_size = current_size
-                print(f"  {logical_name}: chunk capped at {current_size}", flush=True)
-            else:
-                raise
-        except req_lib.exceptions.RequestException:
-            if current_size > 100:
-                current_size = max(current_size // 2, 100)
-                max_size = current_size
-                print(f"  {logical_name}: timeout, chunk capped at {current_size}", flush=True)
-            else:
-                raise
-    return all_guids
-```
-
----
+- **Parallelize across tables at the same level**, sequential between levels, sequential chunks within a table.
+- **Alternate key columns must NOT also appear in the record body** — `UpsertMultiple` fails.
+- **Catch per-table failures** in the executor — one table failing must not kill the others.
+- Start `chunk_size=1000`; the helper ramps up adaptively.
 
 ## Error Handling
 
@@ -568,137 +356,12 @@ except HttpError as e:
 
 ## Sample Data Generation
 
-Generate and insert realistic sample records into any Dataverse table. Useful for development, demos, and testing.
+Generate realistic sample records inline — schema-driven, table-agnostic, PII-safe defaults (`@example.com` emails, `555-01xx` phones).
 
-**Use the Python SDK** (`client.records.create()`) — not raw `urllib` or `requests`.
+**Quick reference:** confirm environment + count + table → query `EntityDefinitions(LogicalName='<table>')/Attributes?$filter=AttributeOf eq null` for required columns → dispatch by `AttributeType` (String / Memo / Integer / DateTime / Picklist / etc.) → `client.records.create()` (use `CreateMultiple` for count >= 10).
 
-### Agentic Flow
+For the schema-driven `fake()` template, the `EntityDefinitions` query, and the safety rules, see [`references/sample-data-generation.md`](references/sample-data-generation.md).
 
-#### Step 1: Confirm environment and count
-
-Before creating anything, confirm:
-- **Target environment** — run `pac auth list` to show the active environment
-- **Record count** — default is **5 records** unless the user specifies otherwise
-- **Table name** — get the logical name (e.g., `account`, `contact`, `cr123_customtable`)
-
-#### Step 2: Inspect the table schema
-
-Use the EntityDefinitions metadata API to discover required columns and their types. Two non-obvious bits:
-
-- **`$filter=AttributeOf eq null`** — without this, each lookup column returns a duplicated sub-attribute row (e.g. a `primarycontactid` Lookup plus a `_primarycontactid_value` pair), which makes the list twice as long and confuses downstream code.
-- **`UserLocalizedLabel` is null on unlocalized columns** — dereference safely before reading `.Label`, otherwise custom tables without display names crash the loop.
-
-```python
-import os, sys, json, urllib.request, urllib.parse
-sys.path.insert(0, os.path.join(os.getcwd(), "scripts"))
-from auth import get_token, load_env  # SDK does not support EntityDefinitions metadata
-
-load_env()
-env_url = os.environ["DATAVERSE_URL"].rstrip("/")
-TABLE = "account"   # or any other table logical name
-
-params = urllib.parse.urlencode({
-    "$select": "LogicalName,AttributeType,RequiredLevel,DisplayName",
-    "$filter": "AttributeOf eq null",
-})
-req = urllib.request.Request(
-    f"{env_url}/api/data/v9.2/EntityDefinitions(LogicalName='{TABLE}')/Attributes?{params}",
-    headers={"Authorization": f"Bearer {get_token()}", "Accept": "application/json"},
-)
-with urllib.request.urlopen(req) as resp:
-    attrs = json.loads(resp.read())["value"]
-
-for a in attrs:
-    dn = (a.get("DisplayName") or {}).get("UserLocalizedLabel")
-    label = dn["Label"] if dn else a["LogicalName"]
-    if a["RequiredLevel"]["Value"] == "ApplicationRequired":
-        print(f"REQUIRED  {a['LogicalName']:30s} {a['AttributeType']:15s} {label}", flush=True)
-```
-
-Filter or group the raw `attrs` list however the task needs — don't assume the printed shape above; inline code downstream should consume `attrs` directly.
-
-#### Step 3: Generate realistic data (by AttributeType)
-
-Use the schema from Step 2 to pick a generator per column. No separate script — the agent writes this inline per request so it matches the actual table.
-
-| AttributeType | Generate |
-|---|---|
-| `String` / `Memo` | Realistic text based on column name (e.g., `name` -> company names) |
-| `Integer` / `Decimal` / `Money` | Random values within `MinValue`/`MaxValue` |
-| `Boolean` | Alternate `true`/`false` |
-| `DateTime` | Recent dates in ISO 8601 format |
-| `Picklist` / `Status` | Integer option values (e.g., `industrycode: 1`) |
-| `Lookup` | **Skip by default** — only set if user provides valid record IDs |
-| `Uniqueidentifier` (non-PK) | Skip — let Dataverse auto-generate |
-
-#### Step 4: Create the records inline via the SDK — schema-driven
-
-This template is **table-agnostic by design**. It reads the `attrs` list from Step 2 and dispatches by `AttributeType` — no table-specific field names or hardcoded sample values baked in. Use it as a starting point; override/extend `fake()` when the table has domain-specific needs (e.g., look up real picklist option values, generate industry-appropriate company names for `account`, etc.).
-
-```python
-import os, sys, random, datetime
-sys.path.insert(0, os.path.join(os.getcwd(), "scripts"))
-from auth import get_credential, load_env
-from PowerPlatform.Dataverse.client import DataverseClient
-
-load_env()
-env_url = os.environ["DATAVERSE_URL"].rstrip("/")
-client = DataverseClient(base_url=env_url, credential=get_credential())
-
-TABLE = "account"   # any table logical name from Step 1
-COUNT = 5           # confirmed with user
-# `attrs` = the list returned by Step 2's EntityDefinitions query (re-run Step 2 if needed)
-
-SKIP_TYPES = {"Lookup", "Uniqueidentifier", "EntityName", "State", "Status", "Owner", "Customer"}
-
-def fake(attr, i):
-    """Context-based value by AttributeType + PII-safe heuristics on column name."""
-    name, t = attr["LogicalName"], attr["AttributeType"]
-    if t in ("String", "Memo"):
-        if "email" in name: return f"user{i}@example.com"
-        if any(s in name for s in ("phone", "telephone", "fax")): return f"555-01{i:02d}"
-        if "url" in name or "website" in name: return f"https://example.com/{name}/{i}"
-        return f"Sample {name} {i}"
-    if t in ("Integer", "BigInt"):          return random.randint(1, 1000)
-    if t in ("Decimal", "Double", "Money"): return round(random.uniform(1, 10_000), 2)
-    if t == "Boolean":                       return bool(i % 2)
-    if t == "DateTime":
-        d = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=i)
-        return d.isoformat(timespec="seconds").replace("+00:00", "Z")
-    if t in ("Picklist", "Status"):
-        return 1   # placeholder — for real picklists, look up valid OptionSet values first
-    return None    # skip Lookup, Uniqueidentifier, and anything unhandled
-
-required = [a for a in attrs
-            if a["RequiredLevel"]["Value"] == "ApplicationRequired"
-            and a["AttributeType"] not in SKIP_TYPES]
-
-records = []
-for i in range(COUNT):
-    rec = {}
-    for a in required:
-        v = fake(a, i)
-        if v is not None:
-            rec[a["LogicalName"]] = v
-    records.append(rec)
-
-# CreateMultiple for count >= 10, individual creates otherwise.
-if COUNT >= 10:
-    ids = client.records.create(TABLE, records)
-    print(f"Created {len(ids)} records via CreateMultiple", flush=True)
-else:
-    ids = [client.records.create(TABLE, r) for r in records]
-    print(f"Created {len(ids)} records individually", flush=True)
-
-print(f"View: {env_url}/main.aspx?pagetype=entitylist&etn={TABLE}", flush=True)
-```
-
-**Why schema-driven and not a hardcoded 5-account template:** a template that bakes in `account`-shaped columns (`name`, `telephone1`, `revenue`, `numberofemployees`) biases the agent toward copy-paste-then-hack whenever the user asks for `contact` or `cr123_project` records. The `fake()` function above dispatches per-attribute so the same snippet produces correct fields for any table. Override `fake()` when you need domain-specific values — e.g. real company names for `account.name`, valid status-reason integers for a custom picklist.
-
-### Safety Rules for Sample Data
-
-- **Always confirm** the target environment and record count
-- Use `.example.com` domains for emails — never real domains
-- Use `555-01xx` phone numbers — obviously fake
-- Skip lookup fields unless user explicitly asks
-- Skip system fields: `createdon`, `modifiedon`, `ownerid`, `statecode`, `statuscode`
+Key invariants:
+- Skip Lookup, Uniqueidentifier, State, Status, Owner, Customer fields unless the user explicitly provides values.
+- `UserLocalizedLabel` may be null — dereference safely.

--- a/.github/plugins/dataverse/skills/dv-data/SKILL.md
+++ b/.github/plugins/dataverse/skills/dv-data/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dv-data
-description: Creates, updates, deletes, bulk-imports, and upserts Dataverse records via the Python SDK. Use when writing or modifying records, bulk-importing data, upserting with alternate keys, running multi-table imports with FK dependencies, or generating sample or seed data.
+description: Record-level CRUD and bulk operations via the Python SDK — create, update, delete, upsert, CSV import, multi-table foreign-key loads, AI-generated sample data. Use when the user wants to write, modify, seed, or import data records into Dataverse tables.
 ---
 
 # Skill: Data — Create, Update, Delete, and Bulk Import

--- a/.github/plugins/dataverse/skills/dv-data/SKILL.md
+++ b/.github/plugins/dataverse/skills/dv-data/SKILL.md
@@ -7,25 +7,6 @@ description: Record-level CRUD and bulk operations via the Python SDK — create
 
 > **This skill uses Python exclusively.** Do not use Node.js, JavaScript, or any other language for Dataverse scripting. If you are about to run `npm install` or write a `.js` file, STOP — you are going off-rails. See the overview skill's Hard Rules.
 
-## Preview Before Running — Scope by Operation Type
-
-Two rules, different strictness:
-
-- **Destructive / stateful operations** (create, update, delete, bulk-import, upsert records) — preview the action in plain prose: which table, how many records, and which environment, using placeholders (`<ENV_URL>`) for anything unknown. Reference the documented snippet by name rather than pasting the full block inline. Ask for confirmation and missing values in the same turn.
-- **Read-only or scoped-reference operations** (schema inspection, looking up a record count, explaining what you'll run from a documented snippet) — a one-sentence prose preview is enough.
-
-**Key principle:** the user should be able to evaluate what's about to happen from your first response. A bare *"which environment?"* fails that test; a one-line prose preview passes it.
-
-### Examples
-
-**Generate N sample records (destructive — preview the snippet, ask for env):**
-- ❌ "Which environment should I target? Please provide the Dataverse URL."
-- ✅ "I'll run the Sample Data Generation snippets with `TABLE=\"contact\"`, `COUNT=20`. Uses `CreateMultiple`, `.example.com` emails, `555-01xx` phones, against the active `pac auth list` environment. Confirm to proceed, or specify a different environment."
-
-**Sample data on a custom entity (schema unknown — prose is enough):**
-- ❌ "I need more info about the entity. What are the required fields?"
-- ✅ "Custom entity — I'll query `EntityDefinitions` for `cr123_project` to discover required columns, then generate 5 records inline mapping each column to a generator by `AttributeType` and call `client.records.create(\"cr123_project\", records)`. Confirm to proceed, or tell me a different count."
-
 Use the official Microsoft Power Platform Dataverse Client Python SDK for all data write operations.
 
 **Official SDK:** https://github.com/microsoft/PowerPlatform-DataverseClient-Python
@@ -365,3 +346,13 @@ For the schema-driven `fake()` template, the `EntityDefinitions` query, and the 
 Key invariants:
 - Skip Lookup, Uniqueidentifier, State, Status, Owner, Customer fields unless the user explicitly provides values.
 - `UserLocalizedLabel` may be null — dereference safely.
+
+### Confirmation-flow examples
+
+**Generate N sample records (destructive — preview the snippet, ask for env):**
+- ❌ "Which environment should I target? Please provide the Dataverse URL."
+- ✅ "I'll run the Sample Data Generation snippets with `TABLE=\"contact\"`, `COUNT=20`. Uses `CreateMultiple`, `.example.com` emails, `555-01xx` phones, against the active `pac auth list` environment. Confirm to proceed, or specify a different environment."
+
+**Sample data on a custom entity (schema unknown — prose is enough):**
+- ❌ "I need more info about the entity. What are the required fields?"
+- ✅ "Custom entity — I'll query `EntityDefinitions` for `cr123_project` to discover required columns, then generate 5 records inline mapping each column to a generator by `AttributeType` and call `client.records.create(\"cr123_project\", records)`. Confirm to proceed, or tell me a different count."

--- a/.github/plugins/dataverse/skills/dv-data/references/multi-table-fk-import.md
+++ b/.github/plugins/dataverse/skills/dv-data/references/multi-table-fk-import.md
@@ -1,0 +1,213 @@
+# Multi-Table Import with FK Dependencies
+
+When importing data across multiple tables with foreign key relationships, follow this sequence:
+
+1. **Create tables** with source ID columns (`prefix_Src*Id`) — see **dv-metadata**
+2. **Create alternate keys** on the source ID columns — see **dv-metadata** "Alternate Keys" section
+3. **Create lookup relationships** — see **dv-metadata**
+4. **Import data** in dependency order using `UpsertItem` with alternate keys (safe for re-runs)
+
+Using upsert from the start means partial failures, retries, and re-runs never create duplicates. The alternate key lets Dataverse match records by the source system's ID instead of GUIDs.
+
+**Deciding which alternate key to create:**
+- **Database source (SQLite, SQL Server):** Read the schema to identify primary keys. The source PK maps directly to the Dataverse alternate key. Agent can decide without asking.
+- **Excel/CSV source:** Inspect the data for columns with all-unique values (`df[col].nunique() == len(df)`). Look for naming conventions (`*_ID`, `*_Code`). **Propose the candidate to the user and confirm** — "Column `Employee_ID` has 500 unique values across 500 rows. Use this as the key?" Do not create the key without confirmation, since uniqueness in current data doesn't guarantee it's the intended business key.
+
+```python
+import os, sys, csv, time
+sys.path.insert(0, os.path.join(os.getcwd(), "scripts"))
+from auth import get_credential, load_env
+from PowerPlatform.Dataverse.client import DataverseClient
+from PowerPlatform.Dataverse.models.upsert import UpsertItem
+from PowerPlatform.Dataverse.core.errors import HttpError
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+load_env()
+client = DataverseClient(base_url=os.environ["DATAVERSE_URL"], credential=get_credential())
+
+def bind(entity_set, guid):
+    """Build an @odata.bind value. entity_set must be the actual EntitySetName, not a guess."""
+    return f"/{entity_set}({guid})"
+
+# IMPORTANT: EntitySetName is NOT always logical_name + 's'.
+# Dataverse uses English pluralization: country -> countries, city -> cities,
+# winby -> winbies, extraruns -> extrarunses.
+# Always query the actual names before building @odata.bind values:
+#   GET /api/data/v9.2/EntityDefinitions?$select=LogicalName,EntitySetName
+
+def bulk_upsert(logical_name, items, chunk_size=1000, retries=3):
+    """Upsert items in adaptive chunks with retry. Starts at chunk_size, doubles on
+    success (up to max_size), halves on size/timeout failure. Caps at last successful
+    size to avoid oscillation. Safe for re-runs."""
+    import requests as req_lib  # for timeout exception types
+    current_size = chunk_size
+    max_size = 4000
+    i = 0
+    while i < len(items):
+        chunk = items[i:i + current_size]
+        for attempt in range(retries):
+            try:
+                client.records.upsert(logical_name, chunk)
+                print(f"  {logical_name}: {i + len(chunk)}/{len(items)} (chunk={current_size})", flush=True)
+                i += len(chunk)
+                current_size = min(current_size * 2, max_size)  # ramp up
+                break
+            except HttpError as e:
+                if e.status_code == 429 and attempt < retries - 1:
+                    time.sleep(5 * (attempt + 1))
+                    continue
+                if e.status_code in (413, 500) and current_size > 100:
+                    current_size = max(current_size // 2, 100)
+                    max_size = current_size
+                    print(f"  {logical_name}: chunk capped at {current_size}", flush=True)
+                    break  # retry same offset with smaller chunk
+                raise
+            except req_lib.exceptions.RequestException:
+                # Network timeout — SDK default is 120s for POST
+                if current_size > 100:
+                    current_size = max(current_size // 2, 100)
+                    max_size = current_size
+                    print(f"  {logical_name}: timeout, chunk capped at {current_size}", flush=True)
+                    break
+                raise
+        else:
+            i += len(chunk)  # skip chunk after all retries exhausted
+
+def build_map(logical_name, src_col, id_col):
+    """Query Dataverse to build source_id -> GUID map after upsert."""
+    result = {}
+    for page in client.records.get(logical_name, select=[src_col, id_col]):
+        for r in page:
+            src_val = r.get(src_col)
+            if src_val is not None:
+                result[src_val] = r[id_col]
+    return result
+
+def upsert_table(logical_name, items, chunk_size=1000):
+    """Upsert one table — used as target for ThreadPoolExecutor."""
+    bulk_upsert(logical_name, items, chunk_size)
+    return logical_name
+```
+
+**Import data in dependency levels — parallelize tables within each level:**
+
+Tables at the same dependency level are independent of each other and can be imported concurrently. Tables at different levels must be sequential (Level 1 needs Level 0's GUIDs for `@odata.bind`).
+
+```python
+# --- Level 0: All lookup tables concurrently (no FK dependencies) ---
+# Alternate keys must already exist. See dv-metadata "Alternate Keys".
+level0 = {
+    "prefix_country": [UpsertItem(
+        alternate_key={"prefix_srccountryid": r["id"]},
+        record={"prefix_name": r["name"]},  # key cols must NOT be in record body
+    ) for r in country_rows],
+    "prefix_team": [UpsertItem(...) for r in team_rows],
+    # ... all other Level 0 tables
+}
+
+# For composite-key tables (e.g., line items with multi-column PK):
+# ALL key columns go in alternate_key, NONE of them in record.
+line_items = [UpsertItem(
+    alternate_key={
+        "prefix_srcorderid": r["order_id"],
+        "prefix_srclineno": r["line_no"],
+    },
+    record={  # only non-key columns here
+        "prefix_name": f"Order-{r['order_id']}-Line-{r['line_no']}",
+        "prefix_quantity": r["qty"],
+        "prefix_unitprice": r["price"],
+    },
+) for r in order_line_rows]
+
+level0 = {
+    # ... lookup tables as above
+}
+
+with ThreadPoolExecutor(max_workers=len(level0)) as pool:
+    futures = {pool.submit(upsert_table, t, items): t for t, items in level0.items()}
+    for f in as_completed(futures):
+        table = futures[f]
+        try:
+            f.result()
+            print(f"  {table}: done", flush=True)
+        except Exception as e:
+            print(f"  {table}: FAILED — {e}", flush=True)
+            # Continue — don't kill other tables. Re-run later (upsert is idempotent).
+
+# Build lookup maps by querying back (upsert doesn't return GUIDs)
+country_map = build_map("prefix_country", "prefix_srccountryid", "prefix_countryid")
+team_map = build_map("prefix_team", "prefix_srcteamid", "prefix_teamid")
+
+# --- Level 1: Tables referencing Level 0, imported concurrently ---
+# Build items with @odata.bind using Level 0 maps, then import in parallel
+# ... repeat pattern for each level
+```
+
+**Key rules:**
+- **Parallelize across tables at the same level** — they share no data pages or indexes. Use `ThreadPoolExecutor` with one worker per table.
+- **Sequential between levels** — Level 1 needs Level 0's GUIDs for `@odata.bind`.
+- **Sequential chunks within each table** — concurrent writes to the same table cause SQL deadlocks (error 1205).
+- Use `UpsertItem` with the source system's PK as the alternate key — idempotent, safe for re-runs and partial failures.
+- **Do NOT put alternate key columns in the record body.** `UpsertMultiple` fails with "An unexpected error" if key columns appear in both. Single upsert tolerates it; bulk does not.
+- **Catch per-table failures in ThreadPoolExecutor** — wrap `f.result()` in try/except. One table failing must not kill the entire executor and prevent other tables from completing.
+- Build GUID maps by querying Dataverse after each level (upsert doesn't return GUIDs).
+- Start with `chunk_size=1000` and let the adaptive helper ramp up. Dataverse has no fixed record limit — the constraints are payload size and timeout. Narrow tables (few columns) can handle 2000-4000 per chunk.
+- `flush=True` on all print statements for real-time progress on Windows.
+- If a source row references a missing lookup ID, skip the row and log it.
+
+**Do NOT parallelize chunks within a single table.** Concurrent `UpsertMultiple`/`CreateMultiple` calls to the same table cause SQL Server deadlocks because concurrent inserts contend on shared data pages and index pages — even though the records are different.
+
+## Post-Import Verification
+
+After all levels are imported, verify record counts match the source. Count by iterating pages with a single-column select (memory-efficient — no need to load full DataFrames just for counts):
+
+```python
+def count_records(logical_name, id_col):
+    return sum(len(page) for page in client.records.get(logical_name, select=[id_col]))
+
+# Build expected counts from source data (e.g., len(rows) per table from earlier import phases)
+expected = {"prefix_department": 12, "prefix_employee": 500, "prefix_timesheet": 15000}
+for table, exp in expected.items():
+    actual = count_records(table, table + "id")  # e.g., prefix_department -> prefix_departmentid
+    status = "OK" if actual == exp else f"MISMATCH ({actual})"
+    print(f"  {table}: {status} (expected {exp})", flush=True)
+```
+
+For deeper verification (spot-check data values, not just counts), use `client.dataframe.get()` — see **dv-query**.
+
+## First-Time Import (when you are certain no re-runs are needed)
+
+If you control the environment and are certain the tables are empty, `client.records.create()` is faster than upsert (no existence check). But if the import fails partway through, re-running will create duplicates. Use this only for one-shot loads into fresh environments:
+
+```python
+def bulk_create(logical_name, records, chunk_size=1000):
+    """Import via create with adaptive chunking — faster but NOT safe for re-runs."""
+    import requests as req_lib
+    all_guids = []
+    current_size = chunk_size
+    max_size = 4000
+    i = 0
+    while i < len(records):
+        chunk = records[i:i + current_size]
+        try:
+            guids = client.records.create(logical_name, chunk)
+            all_guids.extend(guids)
+            print(f"  {logical_name}: {i + len(chunk)}/{len(records)} (chunk={current_size})", flush=True)
+            i += len(chunk)
+            current_size = min(current_size * 2, max_size)
+        except HttpError as e:
+            if e.status_code in (413, 500) and current_size > 100:
+                current_size = max(current_size // 2, 100)
+                max_size = current_size
+                print(f"  {logical_name}: chunk capped at {current_size}", flush=True)
+            else:
+                raise
+        except req_lib.exceptions.RequestException:
+            if current_size > 100:
+                current_size = max(current_size // 2, 100)
+                max_size = current_size
+                print(f"  {logical_name}: timeout, chunk capped at {current_size}", flush=True)
+            else:
+                raise
+    return all_guids
+```

--- a/.github/plugins/dataverse/skills/dv-data/references/sample-data-generation.md
+++ b/.github/plugins/dataverse/skills/dv-data/references/sample-data-generation.md
@@ -1,0 +1,136 @@
+# Sample Data Generation
+
+Generate and insert realistic sample records into any Dataverse table. Useful for development, demos, and testing.
+
+**Use the Python SDK** (`client.records.create()`) — not raw `urllib` or `requests`.
+
+## Agentic Flow
+
+### Step 1: Confirm environment and count
+
+Before creating anything, confirm:
+- **Target environment** — run `pac auth list` to show the active environment
+- **Record count** — default is **5 records** unless the user specifies otherwise
+- **Table name** — get the logical name (e.g., `account`, `contact`, `cr123_customtable`)
+
+### Step 2: Inspect the table schema
+
+Use the EntityDefinitions metadata API to discover required columns and their types. Two non-obvious bits:
+
+- **`$filter=AttributeOf eq null`** — without this, each lookup column returns a duplicated sub-attribute row (e.g. a `primarycontactid` Lookup plus a `_primarycontactid_value` pair), which makes the list twice as long and confuses downstream code.
+- **`UserLocalizedLabel` is null on unlocalized columns** — dereference safely before reading `.Label`, otherwise custom tables without display names crash the loop.
+
+```python
+import os, sys, json, urllib.request, urllib.parse
+sys.path.insert(0, os.path.join(os.getcwd(), "scripts"))
+from auth import get_token, load_env  # SDK does not support EntityDefinitions metadata
+
+load_env()
+env_url = os.environ["DATAVERSE_URL"].rstrip("/")
+TABLE = "account"   # or any other table logical name
+
+params = urllib.parse.urlencode({
+    "$select": "LogicalName,AttributeType,RequiredLevel,DisplayName",
+    "$filter": "AttributeOf eq null",
+})
+req = urllib.request.Request(
+    f"{env_url}/api/data/v9.2/EntityDefinitions(LogicalName='{TABLE}')/Attributes?{params}",
+    headers={"Authorization": f"Bearer {get_token()}", "Accept": "application/json"},
+)
+with urllib.request.urlopen(req) as resp:
+    attrs = json.loads(resp.read())["value"]
+
+for a in attrs:
+    dn = (a.get("DisplayName") or {}).get("UserLocalizedLabel")
+    label = dn["Label"] if dn else a["LogicalName"]
+    if a["RequiredLevel"]["Value"] == "ApplicationRequired":
+        print(f"REQUIRED  {a['LogicalName']:30s} {a['AttributeType']:15s} {label}", flush=True)
+```
+
+Filter or group the raw `attrs` list however the task needs — don't assume the printed shape above; inline code downstream should consume `attrs` directly.
+
+### Step 3: Generate realistic data (by AttributeType)
+
+Use the schema from Step 2 to pick a generator per column. No separate script — the agent writes this inline per request so it matches the actual table.
+
+| AttributeType | Generate |
+|---|---|
+| `String` / `Memo` | Realistic text based on column name (e.g., `name` -> company names) |
+| `Integer` / `Decimal` / `Money` | Random values within `MinValue`/`MaxValue` |
+| `Boolean` | Alternate `true`/`false` |
+| `DateTime` | Recent dates in ISO 8601 format |
+| `Picklist` / `Status` | Integer option values (e.g., `industrycode: 1`) |
+| `Lookup` | **Skip by default** — only set if user provides valid record IDs |
+| `Uniqueidentifier` (non-PK) | Skip — let Dataverse auto-generate |
+
+### Step 4: Create the records inline via the SDK — schema-driven
+
+This template is **table-agnostic by design**. It reads the `attrs` list from Step 2 and dispatches by `AttributeType` — no table-specific field names or hardcoded sample values baked in. Use it as a starting point; override/extend `fake()` when the table has domain-specific needs (e.g., look up real picklist option values, generate industry-appropriate company names for `account`, etc.).
+
+```python
+import os, sys, random, datetime
+sys.path.insert(0, os.path.join(os.getcwd(), "scripts"))
+from auth import get_credential, load_env
+from PowerPlatform.Dataverse.client import DataverseClient
+
+load_env()
+env_url = os.environ["DATAVERSE_URL"].rstrip("/")
+client = DataverseClient(base_url=env_url, credential=get_credential())
+
+TABLE = "account"   # any table logical name from Step 1
+COUNT = 5           # confirmed with user
+# `attrs` = the list returned by Step 2's EntityDefinitions query (re-run Step 2 if needed)
+
+SKIP_TYPES = {"Lookup", "Uniqueidentifier", "EntityName", "State", "Status", "Owner", "Customer"}
+
+def fake(attr, i):
+    """Context-based value by AttributeType + PII-safe heuristics on column name."""
+    name, t = attr["LogicalName"], attr["AttributeType"]
+    if t in ("String", "Memo"):
+        if "email" in name: return f"user{i}@example.com"
+        if any(s in name for s in ("phone", "telephone", "fax")): return f"555-01{i:02d}"
+        if "url" in name or "website" in name: return f"https://example.com/{name}/{i}"
+        return f"Sample {name} {i}"
+    if t in ("Integer", "BigInt"):          return random.randint(1, 1000)
+    if t in ("Decimal", "Double", "Money"): return round(random.uniform(1, 10_000), 2)
+    if t == "Boolean":                       return bool(i % 2)
+    if t == "DateTime":
+        d = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=i)
+        return d.isoformat(timespec="seconds").replace("+00:00", "Z")
+    if t in ("Picklist", "Status"):
+        return 1   # placeholder — for real picklists, look up valid OptionSet values first
+    return None    # skip Lookup, Uniqueidentifier, and anything unhandled
+
+required = [a for a in attrs
+            if a["RequiredLevel"]["Value"] == "ApplicationRequired"
+            and a["AttributeType"] not in SKIP_TYPES]
+
+records = []
+for i in range(COUNT):
+    rec = {}
+    for a in required:
+        v = fake(a, i)
+        if v is not None:
+            rec[a["LogicalName"]] = v
+    records.append(rec)
+
+# CreateMultiple for count >= 10, individual creates otherwise.
+if COUNT >= 10:
+    ids = client.records.create(TABLE, records)
+    print(f"Created {len(ids)} records via CreateMultiple", flush=True)
+else:
+    ids = [client.records.create(TABLE, r) for r in records]
+    print(f"Created {len(ids)} records individually", flush=True)
+
+print(f"View: {env_url}/main.aspx?pagetype=entitylist&etn={TABLE}", flush=True)
+```
+
+**Why schema-driven and not a hardcoded 5-account template:** a template that bakes in `account`-shaped columns (`name`, `telephone1`, `revenue`, `numberofemployees`) biases the agent toward copy-paste-then-hack whenever the user asks for `contact` or `cr123_project` records. The `fake()` function above dispatches per-attribute so the same snippet produces correct fields for any table. Override `fake()` when you need domain-specific values — e.g. real company names for `account.name`, valid status-reason integers for a custom picklist.
+
+## Safety Rules for Sample Data
+
+- **Always confirm** the target environment and record count
+- Use `.example.com` domains for emails — never real domains
+- Use `555-01xx` phone numbers — obviously fake
+- Skip lookup fields unless user explicitly asks
+- Skip system fields: `createdon`, `modifiedon`, `ownerid`, `statecode`, `statuscode`

--- a/.github/plugins/dataverse/skills/dv-metadata/SKILL.md
+++ b/.github/plugins/dataverse/skills/dv-metadata/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dv-metadata
-description: Dataverse schema authoring via the Python SDK and Web API — tables, columns, relationships, forms, and views. Use when the user wants to define or evolve the data model: add a column, create a table, set up a lookup, customize a form, or build a view.
+description: Dataverse schema authoring via the Python SDK and Web API — tables, columns, relationships, forms, and views. Use when the user wants to define or evolve the data model — add a column, create a table, set up a lookup, customize a form, or build a view.
 ---
 
 # Skill: Metadata — Making Changes

--- a/.github/plugins/dataverse/skills/dv-metadata/SKILL.md
+++ b/.github/plugins/dataverse/skills/dv-metadata/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dv-metadata
-description: Creates and modifies Dataverse tables, columns, relationships, forms, and views via the Python SDK and Web API. Use when adding columns, creating tables, adding relationships, building lookup columns, or creating or modifying forms and views.
+description: Dataverse schema authoring via the Python SDK and Web API — tables, columns, relationships, forms, and views. Use when the user wants to define or evolve the data model: add a column, create a table, set up a lookup, customize a form, or build a view.
 ---
 
 # Skill: Metadata — Making Changes

--- a/.github/plugins/dataverse/skills/dv-metadata/SKILL.md
+++ b/.github/plugins/dataverse/skills/dv-metadata/SKILL.md
@@ -1,12 +1,6 @@
 ---
 name: dv-metadata
-description: >
-  Create and modify Dataverse tables, columns, relationships, forms, and views using the Python SDK and Web API.
-  Use when: "add column", "create table", "add relationship", "lookup column", "create form",
-  "create view", "modify form", "FormXml", "SavedQuery", "option set", "picklist",
-  "MetadataService", "EntityDefinitions".
-  Do not use when: writing data records (use dv-data), reading or querying records (use dv-query),
-  exporting solutions (use dv-solution).
+description: Creates and modifies Dataverse tables, columns, relationships, forms, and views via the Python SDK and Web API. Use when adding columns, creating tables, adding relationships, building lookup columns, or creating or modifying forms and views.
 ---
 
 # Skill: Metadata — Making Changes
@@ -315,205 +309,22 @@ body = {
 
 ---
 
-## Forms
+## Forms and Views
 
-Neither the MCP server nor the Python SDK supports forms. Use the Web API directly.
+The MCP server and Python SDK do not support forms or views — both require raw Web API calls (`urllib`).
 
-### Create a form
+**Quick reference:**
+- **Create form:** `POST /api/data/v9.2/systemforms` with `formxml` (form type: `2`=Main, `7`=Quick Create, `6`=Quick View, `11`=Card).
+- **Modify form:** `GET` filtered by `objecttypecode` + `type`, edit `formxml`, `PATCH` back, then publish.
+- **Publish:** `POST /api/data/v9.2/PublishXml` with `<importexportxml><entities><entity>...` — required for forms to take effect.
+- **Create view:** `POST /api/data/v9.2/savedqueries` with `fetchxml` + `layoutxml` (querytype: `0`=standard, `1`=advanced find default, `2`=associated, `4`=quick find).
 
-```python
-# POST /api/data/v9.2/systemforms
-import os, sys, json, urllib.request
-sys.path.insert(0, os.path.join(os.getcwd(), "scripts"))
-from auth import get_token, load_env  # get_token() is correct here — SDK does not support forms
+For full code samples, the form-XML templates, the control `classid` table for editing existing forms, and the publish workflow, see [`references/forms-and-views.md`](references/forms-and-views.md).
 
-load_env()
-env = os.environ["DATAVERSE_URL"].rstrip("/")
-token = get_token()
-
-form_xml = """<form type="7" name="Project Budget" id="{FORM-GUID}">
-  <tabs>
-    <tab name="{TAB-GUID}" id="{TAB-GUID}" expanded="true" showlabel="true">
-      <labels><label description="General" languagecode="1033" /></labels>
-      <columns><column width="100%">
-        <sections>
-          <section name="{SEC-GUID}" id="{SEC-GUID}" showlabel="false" showbar="false" columns="111">
-            <labels><label description="General" languagecode="1033" /></labels>
-            <rows>
-              <row>
-                <cell id="{CELL-GUID-1}" showlabel="true">
-                  <labels><label description="Name" languagecode="1033" /></labels>
-                  <control id="new_name" classid="{4273EDBD-AC1D-40d3-9FB2-095C621B552D}"
-                           datafieldname="new_name" disabled="false" />
-                </cell>
-              </row>
-            </rows>
-          </section>
-        </sections>
-      </column></columns>
-    </tab>
-  </tabs>
-  <header><rows /></header><footer><rows /></footer>
-</form>"""
-
-body = {
-    "name": "Project Budget Quick Create",
-    "objecttypecode": "new_projectbudget",
-    "type": 7,           # 7 = quick create, 2 = main
-    "formxml": form_xml,
-    "iscustomizable": {"Value": True}
-}
-
-req = urllib.request.Request(
-    f"{env}/api/data/v9.2/systemforms",
-    data=json.dumps(body).encode(),
-    headers={"Authorization": f"Bearer {token}",
-             "Content-Type": "application/json",
-             "OData-MaxVersion": "4.0",
-             "OData-Version": "4.0"},
-    method="POST"
-)
-with urllib.request.urlopen(req) as resp:
-    print(f"Created. FormId: {resp.headers.get('OData-EntityId')}")
-```
-
-**Form type codes:** `2` = Main, `7` = Quick Create, `6` = Quick View, `11` = Card
-
-### Retrieve and modify an existing form
-
-```python
-# env and token must be initialized (see form creation setup above)
-import json, urllib.request  # SDK does not support forms — raw Web API required
-
-# Step 1: GET the form
-url = (f"{env}/api/data/v9.2/systemforms"
-       f"?$filter=objecttypecode eq 'new_projectbudget' and type eq 2"
-       f"&$select=formid,name,formxml")
-req = urllib.request.Request(url, headers={
-    "Authorization": f"Bearer {token}",
-    "OData-MaxVersion": "4.0", "OData-Version": "4.0", "Accept": "application/json",
-})
-with urllib.request.urlopen(req) as resp:
-    forms = json.loads(resp.read()).get("value", [])
-
-if not forms:
-    raise ValueError("Form not found")
-
-form_id = forms[0]["formid"]
-form_xml = forms[0]["formxml"]
-
-# Step 2: Modify form_xml string as needed (e.g., add a control, reorder fields)
-# form_xml = form_xml.replace(...)
-
-# Step 3: PATCH the form back
-patch_body = json.dumps({"formxml": form_xml}).encode()
-req = urllib.request.Request(
-    f"{env}/api/data/v9.2/systemforms({form_id})",
-    data=patch_body,
-    headers={"Authorization": f"Bearer {token}",
-             "Content-Type": "application/json",
-             "OData-MaxVersion": "4.0", "OData-Version": "4.0"},
-    method="PATCH"
-)
-with urllib.request.urlopen(req) as resp:
-    print(f"Updated. Status: {resp.status}")
-# Then publish (see Publish section below)
-```
-
-### Publish forms after create/modify
-
-Forms must be published to take effect. Do this immediately after creating or modifying a form. `env` and `token` come from the form creation setup block above — if publishing standalone, re-initialize them:
-```python
-# env and token must be initialized (see form creation setup above)
-# SDK does not support form publishing — raw Web API required
-body = json.dumps({
-    "ParameterXml": "<importexportxml><entities><entity>new_projectbudget</entity></entities></importexportxml>"
-}).encode()
-req = urllib.request.Request(
-    f"{env}/api/data/v9.2/PublishXml",
-    data=body,
-    headers={"Authorization": f"Bearer {token}",
-             "Content-Type": "application/json",
-             "OData-MaxVersion": "4.0", "OData-Version": "4.0"},
-    method="POST"
-)
-with urllib.request.urlopen(req) as resp:
-    print(f"Published. Status: {resp.status}")
-```
-Replace `new_projectbudget` with the logical name of the entity whose form you modified.
-
----
-
-## Views
-
-Neither the MCP server nor the Python SDK supports views. Use the Web API directly.
-
-### Create a view
-
-```python
-# POST /api/data/v9.2/savedqueries
-fetch_xml = """<fetch version="1.0" output-format="xml-platform" mapping="logical">
-  <entity name="new_projectbudget">
-    <attribute name="new_name" />
-    <attribute name="new_amount" />
-    <attribute name="new_status" />
-    <order attribute="new_name" descending="false" />
-    <filter type="and">
-      <condition attribute="statecode" operator="eq" value="0" />
-      <condition attribute="ownerid" operator="eq-userid" />
-    </filter>
-  </entity>
-</fetch>"""
-
-layout_xml = """<grid name="resultset" jump="new_name" select="1" icon="1" preview="1">
-  <row name="result" id="new_projectbudgetid">
-    <cell name="new_name" width="200" />
-    <cell name="new_amount" width="125" />
-    <cell name="new_status" width="125" />
-  </row>
-</grid>"""
-
-body = {
-    "name": "My Open Budgets",
-    "returnedtypecode": "new_projectbudget",
-    "querytype": 0,       # 0 = standard view
-    "fetchxml": fetch_xml,
-    "layoutxml": layout_xml,
-    "isdefault": False,
-    "isprivate": False,
-    "isquickfindquery": False,
-}
-# POST to /api/data/v9.2/savedqueries
-```
-
-**querytype values:** `0` = standard view, `1` = advanced find default, `2` = associated view, `4` = quick find
-
----
-
-## When to Edit Existing Form XML Directly
-
-If the form is already in the repo (pulled via `pac solution unpack`), targeted edits are acceptable — e.g., reordering fields, changing a label, adding a control to an existing section. For these cases, use this control classid reference:
-
-| Field type | Control classid |
-|---|---|
-| Text (nvarchar) | `{4273EDBD-AC1D-40d3-9FB2-095C621B552D}` |
-| Currency (money) | `{533B9108-5A8B-42cb-BD37-52D1B8E7C741}` |
-| Choice (picklist) | `{3EF39988-22BB-4f0b-BBBE-64B5A3748AEE}` |
-| Lookup | `{270BD3DB-D9AF-4782-9025-509E298DEC0A}` |
-| Date/Time | `{5B773807-9FB2-42db-97C3-7A91EFF8ADFF}` |
-| Whole Number | `{C6D124CA-7EDA-4a60-AEA9-7FB8D318B68F}` |
-| Decimal | `{C3EFE0C3-0EC6-42be-8349-CBD9079C5A6F}` |
-| Toggle (boolean) | `{67FAC785-CD58-4f9f-ABB3-4B7DDC6ED5ED}` |
-| Subgrid | `{E7A81278-8635-4d9e-8D4D-59480B391C5B}` |
-| Multiline Text (memo) | `{E0DECE4B-6FC8-4a8f-A065-082708572369}` |
-
-All `id` attributes in form XML must be unique GUIDs. Generate them inside your Python script:
-```python
-import uuid
-guid = str(uuid.uuid4()).upper()
-```
-
-**Do not use `python -c` for GUID generation on Windows** — multiline `python -c` commands break in Git Bash due to quoting differences. Always write a `.py` script instead.
+Key invariants:
+- All `id` attributes in form XML must be unique GUIDs (`str(uuid.uuid4()).upper()`).
+- Do not use `python -c` for GUID generation on Windows — write a `.py` file.
+- Forms must be published after every create or modify, otherwise changes are invisible to users.
 
 ---
 
@@ -575,52 +386,17 @@ Always translate error codes to plain English before presenting them to the user
 
 ## Metadata Propagation Delays and Lock Contention
 
-After creating tables, columns, or alternate keys, Dataverse runs internal metadata operations (index building, cache propagation) that can take 3-30 seconds. Submitting another metadata operation while these are still running causes lock contention errors ("another operation is running").
+After creating tables / columns / alternate keys, Dataverse runs internal metadata operations (index build, cache propagation) for 3–30 seconds. Submitting another metadata operation while these run causes lock-contention errors.
 
-**Common symptoms:**
-- Picklist columns fail with `0x80040216` immediately after table creation
-- Lookup `@odata.bind` operations fail with "Invalid property" shortly after column creation
+**Mitigation — phased creation, not interleaved.** Create ALL tables → wait 15–30s → create ALL alternate keys → wait 15–30s → create ALL lookups. Do NOT interleave operations on the same table.
+
+**Symptoms** (any of these means propagation isn't done):
+- Picklist column creation fails with `0x80040216`
+- Lookup `@odata.bind` fails with "Invalid property"
 - `update_table` (MCP) fails with "EntityId not found in MetadataCache"
-- Alternate key creation fails with lock contention after table creation
-- Lookup creation fails with "another customization operation is running"
+- Lookup or alternate-key creation fails with "another customization operation is running"
 
-**Mitigation — use phased creation, not interleaved:**
-
-When creating many tables with alternate keys and lookups (e.g., multi-table import schema), create them in phases rather than interleaving operations on the same table:
-
-1. **Phase 1: Create ALL tables** (5-8s delay between each)
-2. **Wait 15-30s** for metadata propagation
-3. **Phase 2: Create ALL alternate keys** (3s delay between each)
-4. **Wait 15-30s** for index building
-5. **Phase 3: Create ALL lookups** (3s delay between each)
-
-Do NOT interleave: `create table A → create key A → create table B → create key B`. This causes lock contention because key A's index build blocks table B's creation.
-
-**Retry pattern:** Wrap all metadata operations with retry for transient lock errors:
-
-```python
-import time
-
-def retry_metadata(fn, description, max_attempts=5):
-    for attempt in range(max_attempts):
-        try:
-            return fn()
-        except Exception as e:
-            err = str(e)
-            if "already exists" in err.lower() or "0x80040237" in err:
-                print(f"  {description}: already exists, skipping")
-                return None
-            if "another" in err.lower() and "running" in err.lower():
-                wait = 10 * (attempt + 1)
-                print(f"  {description}: lock contention, waiting {wait}s (attempt {attempt+1}/{max_attempts})...")
-                time.sleep(wait)
-                continue
-            raise
-    print(f"  WARNING: {description} failed after {max_attempts} attempts")
-    return None
-```
-
----
+For the `retry_metadata` helper that catches transient lock errors and the full phased-creation sequence, see [`references/metadata-propagation.md`](references/metadata-propagation.md).
 
 ## Session Closing: Pull to Repo
 
@@ -659,86 +435,15 @@ GET /api/data/v9.2/EntityDefinitions(LogicalName='new_projectbudget')?$select=Lo
 
 ## Alternate Keys (Required for Upsert)
 
-An alternate key tells Dataverse how to uniquely identify a record using a business column instead of the GUID primary key. This is required for `UpsertMultiple` — without it, Dataverse has no way to detect whether a record already exists.
+`UpsertMultiple` requires an alternate key on the column(s) Dataverse should use to identify existing records. Always create alternate keys on source-system ID columns (`prefix_Src*Id`) at schema-setup time so every import is idempotent.
 
-**When to create alternate keys:** Always create them on source-system ID columns (`prefix_Src*Id`) during schema setup, before data import. This makes every import idempotent from the start — re-running never creates duplicates.
+**Quick reference:**
+- SDK call: `client.tables.create_alternate_key(table, key_name, [columns], display_name=...)`. Composite keys: pass multiple columns.
+- Wrap in try/except for `HttpError` containing `"already exists"` or `0x80048d0b` to make the script re-runnable.
+- Index creation is **async** — for large tables, poll `client.tables.get_alternate_keys(table)` until `status == "Active"` before using.
+- Constraints: max 16 columns / 900 bytes / 10 keys per table; valid types are Integer / Decimal / String / DateTime / Lookup / OptionSet.
 
-**How the agent decides which column:**
-- **Database source (SQLite, SQL Server):** Read the schema to identify primary keys — this is unambiguous. The source PK column maps directly to the alternate key:
-  - Source `Country.Country_Id` (INTEGER PRIMARY KEY) → alternate key on `prefix_srccountryid`
-  - Source composite PK (`Order_Id, Line_No`) → composite alternate key on both columns
-- **Excel/CSV source:** Inspect the data for columns with all-unique values and naming conventions suggesting an ID (`*_ID`, `*_Code`). **Propose the candidate to the user and get confirmation** before creating the key — uniqueness in the current data doesn't guarantee it's the intended business key.
-- **No identifiable unique column:** Ask the user which column(s) uniquely identify each row. Do not guess.
-
-**SDK approach (preferred):**
-
-```python
-import os, sys
-sys.path.insert(0, os.path.join(os.getcwd(), "scripts"))
-from auth import get_credential, load_env
-from PowerPlatform.Dataverse.client import DataverseClient
-
-load_env()
-client = DataverseClient(os.environ["DATAVERSE_URL"], get_credential())
-
-# Single-column key (most common for imports)
-key = client.tables.create_alternate_key(
-    "prefix_Country",
-    "prefix_SrcCountryIdKey",
-    ["prefix_srccountryid"],
-    display_name="Source Country ID",
-)
-print(f"Key created: {key.schema_name} (status: {key.status})")
-
-# Composite key (for tables with multi-column PKs in the source)
-key = client.tables.create_alternate_key(
-    "prefix_OrderLine",
-    "prefix_OrderLineSourceKey",
-    ["prefix_srcorderid", "prefix_srclineno"],
-    display_name="Source Order Line Key",
-)
-```
-
-**Idempotent key creation** — catch "already exists" to make the script re-runnable:
-
-```python
-from PowerPlatform.Dataverse.core.errors import HttpError
-
-def ensure_alternate_key(table, key_name, columns, display_name):
-    try:
-        key = client.tables.create_alternate_key(table, key_name, columns, display_name=display_name)
-        print(f"  Key created: {key_name} on {table}")
-    except HttpError as e:
-        if "already exists" in str(e).lower() or "0x80048d0b" in str(e):
-            print(f"  Key already exists: {key_name}")
-        else:
-            raise
-
-# Create keys for all import tables
-ensure_alternate_key("prefix_Country", "prefix_SrcCountryIdKey",
-    ["prefix_srccountryid"], "Source Country ID")
-ensure_alternate_key("prefix_City", "prefix_SrcCityIdKey",
-    ["prefix_srccityid"], "Source City ID")
-```
-
-**Check key status** — index creation is async for tables with existing data:
-
-```python
-keys = client.tables.get_alternate_keys("prefix_Country")
-for k in keys:
-    print(f"  {k.schema_name}: {k.status}")  # Pending, Active, or Failed
-```
-
-**Constraints:**
-- Valid column types for keys: Integer, Decimal, String, DateTime, Lookup, OptionSet
-- Max 16 columns per key, 900 bytes total key size
-- Max 10 alternate keys per table
-- Index creation is **async** — Dataverse builds the index in the background. For small tables (<10K rows) this is near-instant. For large existing tables, check `EntityKeyIndexStatus` for Active/Failed before using the key.
-- If the key column has non-unique data, index creation **fails** (no data corruption — the key just stays in Failed state). Fix the data, then call `ReactivateEntityKey`.
-
-**Safety:** Creating an alternate key on a column with unique data is a non-destructive metadata operation. It adds a database index — it does not modify existing records. If the column data isn't actually unique, the key creation fails harmlessly.
-
----
+For SDK code samples (single + composite + idempotent + status-check), the agent decision rules for which column to pick (DB source vs Excel/CSV), and the failure-handling notes, see [`references/alternate-keys.md`](references/alternate-keys.md).
 
 ## EntityDefinitions Filter Limitation
 

--- a/.github/plugins/dataverse/skills/dv-metadata/references/alternate-keys.md
+++ b/.github/plugins/dataverse/skills/dv-metadata/references/alternate-keys.md
@@ -1,0 +1,80 @@
+# Alternate Keys
+
+An alternate key tells Dataverse how to uniquely identify a record using a business column instead of the GUID primary key. This is required for `UpsertMultiple` — without it, Dataverse has no way to detect whether a record already exists.
+
+**When to create alternate keys:** Always create them on source-system ID columns (`prefix_Src*Id`) during schema setup, before data import. This makes every import idempotent from the start — re-running never creates duplicates.
+
+**How the agent decides which column:**
+- **Database source (SQLite, SQL Server):** Read the schema to identify primary keys — this is unambiguous. The source PK column maps directly to the alternate key:
+  - Source `Country.Country_Id` (INTEGER PRIMARY KEY) → alternate key on `prefix_srccountryid`
+  - Source composite PK (`Order_Id, Line_No`) → composite alternate key on both columns
+- **Excel/CSV source:** Inspect the data for columns with all-unique values and naming conventions suggesting an ID (`*_ID`, `*_Code`). **Propose the candidate to the user and get confirmation** before creating the key — uniqueness in the current data doesn't guarantee it's the intended business key.
+- **No identifiable unique column:** Ask the user which column(s) uniquely identify each row. Do not guess.
+
+**SDK approach (preferred):**
+
+```python
+import os, sys
+sys.path.insert(0, os.path.join(os.getcwd(), "scripts"))
+from auth import get_credential, load_env
+from PowerPlatform.Dataverse.client import DataverseClient
+
+load_env()
+client = DataverseClient(os.environ["DATAVERSE_URL"], get_credential())
+
+# Single-column key (most common for imports)
+key = client.tables.create_alternate_key(
+    "prefix_Country",
+    "prefix_SrcCountryIdKey",
+    ["prefix_srccountryid"],
+    display_name="Source Country ID",
+)
+print(f"Key created: {key.schema_name} (status: {key.status})")
+
+# Composite key (for tables with multi-column PKs in the source)
+key = client.tables.create_alternate_key(
+    "prefix_OrderLine",
+    "prefix_OrderLineSourceKey",
+    ["prefix_srcorderid", "prefix_srclineno"],
+    display_name="Source Order Line Key",
+)
+```
+
+**Idempotent key creation** — catch "already exists" to make the script re-runnable:
+
+```python
+from PowerPlatform.Dataverse.core.errors import HttpError
+
+def ensure_alternate_key(table, key_name, columns, display_name):
+    try:
+        key = client.tables.create_alternate_key(table, key_name, columns, display_name=display_name)
+        print(f"  Key created: {key_name} on {table}")
+    except HttpError as e:
+        if "already exists" in str(e).lower() or "0x80048d0b" in str(e):
+            print(f"  Key already exists: {key_name}")
+        else:
+            raise
+
+# Create keys for all import tables
+ensure_alternate_key("prefix_Country", "prefix_SrcCountryIdKey",
+    ["prefix_srccountryid"], "Source Country ID")
+ensure_alternate_key("prefix_City", "prefix_SrcCityIdKey",
+    ["prefix_srccityid"], "Source City ID")
+```
+
+**Check key status** — index creation is async for tables with existing data:
+
+```python
+keys = client.tables.get_alternate_keys("prefix_Country")
+for k in keys:
+    print(f"  {k.schema_name}: {k.status}")  # Pending, Active, or Failed
+```
+
+**Constraints:**
+- Valid column types for keys: Integer, Decimal, String, DateTime, Lookup, OptionSet
+- Max 16 columns per key, 900 bytes total key size
+- Max 10 alternate keys per table
+- Index creation is **async** — Dataverse builds the index in the background. For small tables (<10K rows) this is near-instant. For large existing tables, check `EntityKeyIndexStatus` for Active/Failed before using the key.
+- If the key column has non-unique data, index creation **fails** (no data corruption — the key just stays in Failed state). Fix the data, then call `ReactivateEntityKey`.
+
+**Safety:** Creating an alternate key on a column with unique data is a non-destructive metadata operation. It adds a database index — it does not modify existing records. If the column data isn't actually unique, the key creation fails harmlessly.

--- a/.github/plugins/dataverse/skills/dv-metadata/references/forms-and-views.md
+++ b/.github/plugins/dataverse/skills/dv-metadata/references/forms-and-views.md
@@ -1,0 +1,194 @@
+# Forms and Views — Web API patterns
+
+Neither the MCP server nor the Python SDK supports forms or views. Use the Web API directly via `urllib`.
+
+## Create a form
+
+```python
+# POST /api/data/v9.2/systemforms
+import os, sys, json, urllib.request
+sys.path.insert(0, os.path.join(os.getcwd(), "scripts"))
+from auth import get_token, load_env  # get_token() is correct here — SDK does not support forms
+
+load_env()
+env = os.environ["DATAVERSE_URL"].rstrip("/")
+token = get_token()
+
+form_xml = """<form type="7" name="Project Budget" id="{FORM-GUID}">
+  <tabs>
+    <tab name="{TAB-GUID}" id="{TAB-GUID}" expanded="true" showlabel="true">
+      <labels><label description="General" languagecode="1033" /></labels>
+      <columns><column width="100%">
+        <sections>
+          <section name="{SEC-GUID}" id="{SEC-GUID}" showlabel="false" showbar="false" columns="111">
+            <labels><label description="General" languagecode="1033" /></labels>
+            <rows>
+              <row>
+                <cell id="{CELL-GUID-1}" showlabel="true">
+                  <labels><label description="Name" languagecode="1033" /></labels>
+                  <control id="new_name" classid="{4273EDBD-AC1D-40d3-9FB2-095C621B552D}"
+                           datafieldname="new_name" disabled="false" />
+                </cell>
+              </row>
+            </rows>
+          </section>
+        </sections>
+      </column></columns>
+    </tab>
+  </tabs>
+  <header><rows /></header><footer><rows /></footer>
+</form>"""
+
+body = {
+    "name": "Project Budget Quick Create",
+    "objecttypecode": "new_projectbudget",
+    "type": 7,           # 7 = quick create, 2 = main
+    "formxml": form_xml,
+    "iscustomizable": {"Value": True}
+}
+
+req = urllib.request.Request(
+    f"{env}/api/data/v9.2/systemforms",
+    data=json.dumps(body).encode(),
+    headers={"Authorization": f"Bearer {token}",
+             "Content-Type": "application/json",
+             "OData-MaxVersion": "4.0",
+             "OData-Version": "4.0"},
+    method="POST"
+)
+with urllib.request.urlopen(req) as resp:
+    print(f"Created. FormId: {resp.headers.get('OData-EntityId')}")
+```
+
+**Form type codes:** `2` = Main, `7` = Quick Create, `6` = Quick View, `11` = Card
+
+## Retrieve and modify an existing form
+
+```python
+# env and token must be initialized (see form creation setup above)
+import json, urllib.request  # SDK does not support forms — raw Web API required
+
+# Step 1: GET the form
+url = (f"{env}/api/data/v9.2/systemforms"
+       f"?$filter=objecttypecode eq 'new_projectbudget' and type eq 2"
+       f"&$select=formid,name,formxml")
+req = urllib.request.Request(url, headers={
+    "Authorization": f"Bearer {token}",
+    "OData-MaxVersion": "4.0", "OData-Version": "4.0", "Accept": "application/json",
+})
+with urllib.request.urlopen(req) as resp:
+    forms = json.loads(resp.read()).get("value", [])
+
+if not forms:
+    raise ValueError("Form not found")
+
+form_id = forms[0]["formid"]
+form_xml = forms[0]["formxml"]
+
+# Step 2: Modify form_xml string as needed (e.g., add a control, reorder fields)
+# form_xml = form_xml.replace(...)
+
+# Step 3: PATCH the form back
+patch_body = json.dumps({"formxml": form_xml}).encode()
+req = urllib.request.Request(
+    f"{env}/api/data/v9.2/systemforms({form_id})",
+    data=patch_body,
+    headers={"Authorization": f"Bearer {token}",
+             "Content-Type": "application/json",
+             "OData-MaxVersion": "4.0", "OData-Version": "4.0"},
+    method="PATCH"
+)
+with urllib.request.urlopen(req) as resp:
+    print(f"Updated. Status: {resp.status}")
+# Then publish (see Publish section below)
+```
+
+## Publish forms after create/modify
+
+Forms must be published to take effect. Do this immediately after creating or modifying a form. `env` and `token` come from the form creation setup block above — if publishing standalone, re-initialize them:
+
+```python
+# env and token must be initialized (see form creation setup above)
+# SDK does not support form publishing — raw Web API required
+body = json.dumps({
+    "ParameterXml": "<importexportxml><entities><entity>new_projectbudget</entity></entities></importexportxml>"
+}).encode()
+req = urllib.request.Request(
+    f"{env}/api/data/v9.2/PublishXml",
+    data=body,
+    headers={"Authorization": f"Bearer {token}",
+             "Content-Type": "application/json",
+             "OData-MaxVersion": "4.0", "OData-Version": "4.0"},
+    method="POST"
+)
+with urllib.request.urlopen(req) as resp:
+    print(f"Published. Status: {resp.status}")
+```
+
+Replace `new_projectbudget` with the logical name of the entity whose form you modified.
+
+## Create a view
+
+```python
+# POST /api/data/v9.2/savedqueries
+fetch_xml = """<fetch version="1.0" output-format="xml-platform" mapping="logical">
+  <entity name="new_projectbudget">
+    <attribute name="new_name" />
+    <attribute name="new_amount" />
+    <attribute name="new_status" />
+    <order attribute="new_name" descending="false" />
+    <filter type="and">
+      <condition attribute="statecode" operator="eq" value="0" />
+      <condition attribute="ownerid" operator="eq-userid" />
+    </filter>
+  </entity>
+</fetch>"""
+
+layout_xml = """<grid name="resultset" jump="new_name" select="1" icon="1" preview="1">
+  <row name="result" id="new_projectbudgetid">
+    <cell name="new_name" width="200" />
+    <cell name="new_amount" width="125" />
+    <cell name="new_status" width="125" />
+  </row>
+</grid>"""
+
+body = {
+    "name": "My Open Budgets",
+    "returnedtypecode": "new_projectbudget",
+    "querytype": 0,       # 0 = standard view
+    "fetchxml": fetch_xml,
+    "layoutxml": layout_xml,
+    "isdefault": False,
+    "isprivate": False,
+    "isquickfindquery": False,
+}
+# POST to /api/data/v9.2/savedqueries
+```
+
+**querytype values:** `0` = standard view, `1` = advanced find default, `2` = associated view, `4` = quick find
+
+## When to Edit Existing Form XML Directly
+
+If the form is already in the repo (pulled via `pac solution unpack`), targeted edits are acceptable — e.g., reordering fields, changing a label, adding a control to an existing section. For these cases, use this control classid reference:
+
+| Field type | Control classid |
+|---|---|
+| Text (nvarchar) | `{4273EDBD-AC1D-40d3-9FB2-095C621B552D}` |
+| Currency (money) | `{533B9108-5A8B-42cb-BD37-52D1B8E7C741}` |
+| Choice (picklist) | `{3EF39988-22BB-4f0b-BBBE-64B5A3748AEE}` |
+| Lookup | `{270BD3DB-D9AF-4782-9025-509E298DEC0A}` |
+| Date/Time | `{5B773807-9FB2-42db-97C3-7A91EFF8ADFF}` |
+| Whole Number | `{C6D124CA-7EDA-4a60-AEA9-7FB8D318B68F}` |
+| Decimal | `{C3EFE0C3-0EC6-42be-8349-CBD9079C5A6F}` |
+| Toggle (boolean) | `{67FAC785-CD58-4f9f-ABB3-4B7DDC6ED5ED}` |
+| Subgrid | `{E7A81278-8635-4d9e-8D4D-59480B391C5B}` |
+| Multiline Text (memo) | `{E0DECE4B-6FC8-4a8f-A065-082708572369}` |
+
+All `id` attributes in form XML must be unique GUIDs. Generate them inside your Python script:
+
+```python
+import uuid
+guid = str(uuid.uuid4()).upper()
+```
+
+**Do not use `python -c` for GUID generation on Windows** — multiline `python -c` commands break in Git Bash due to quoting differences. Always write a `.py` script instead.

--- a/.github/plugins/dataverse/skills/dv-metadata/references/metadata-propagation.md
+++ b/.github/plugins/dataverse/skills/dv-metadata/references/metadata-propagation.md
@@ -1,0 +1,46 @@
+# Metadata Propagation Delays and Lock Contention
+
+After creating tables, columns, or alternate keys, Dataverse runs internal metadata operations (index building, cache propagation) that can take 3-30 seconds. Submitting another metadata operation while these are still running causes lock contention errors ("another operation is running").
+
+**Common symptoms:**
+- Picklist columns fail with `0x80040216` immediately after table creation
+- Lookup `@odata.bind` operations fail with "Invalid property" shortly after column creation
+- `update_table` (MCP) fails with "EntityId not found in MetadataCache"
+- Alternate key creation fails with lock contention after table creation
+- Lookup creation fails with "another customization operation is running"
+
+**Mitigation — use phased creation, not interleaved:**
+
+When creating many tables with alternate keys and lookups (e.g., multi-table import schema), create them in phases rather than interleaving operations on the same table:
+
+1. **Phase 1: Create ALL tables** (5-8s delay between each)
+2. **Wait 15-30s** for metadata propagation
+3. **Phase 2: Create ALL alternate keys** (3s delay between each)
+4. **Wait 15-30s** for index building
+5. **Phase 3: Create ALL lookups** (3s delay between each)
+
+Do NOT interleave: `create table A → create key A → create table B → create key B`. This causes lock contention because key A's index build blocks table B's creation.
+
+**Retry pattern:** Wrap all metadata operations with retry for transient lock errors:
+
+```python
+import time
+
+def retry_metadata(fn, description, max_attempts=5):
+    for attempt in range(max_attempts):
+        try:
+            return fn()
+        except Exception as e:
+            err = str(e)
+            if "already exists" in err.lower() or "0x80040237" in err:
+                print(f"  {description}: already exists, skipping")
+                return None
+            if "another" in err.lower() and "running" in err.lower():
+                wait = 10 * (attempt + 1)
+                print(f"  {description}: lock contention, waiting {wait}s (attempt {attempt+1}/{max_attempts})...")
+                time.sleep(wait)
+                continue
+            raise
+    print(f"  WARNING: {description} failed after {max_attempts} attempts")
+    return None
+```

--- a/.github/plugins/dataverse/skills/dv-overview/SKILL.md
+++ b/.github/plugins/dataverse/skills/dv-overview/SKILL.md
@@ -1,13 +1,6 @@
 ---
 name: dv-overview
-description: >
-  Core rules and tool routing for all Dataverse tasks. Loaded automatically before other skills.
-  Use when: any request involving Dataverse, Dynamics 365, Power Platform, tables, columns, solutions,
-  records, queries, CRM, metadata, plugins, SDK, Web API, PAC CLI, or environment operations.
-  Also use for: "how do I", "what tool", "which skill", "where do I start", "help with Dataverse",
-  "create table", "create column", "build solution", "query data", "bulk import", "sample data",
-  "support agent", "customer table", "ticket table".
-  This skill must be loaded before any other Dataverse skill.
+description: Core rules and tool routing for all Dataverse tasks; loaded before any other Dataverse skill. Use when handling any request involving Dataverse, Dynamics 365, Power Platform, tables, columns, solutions, records, queries, metadata, plugins, the SDK, the Web API, PAC CLI, or environment operations.
 ---
 
 # Skill: Overview — What to Use and When

--- a/.github/plugins/dataverse/skills/dv-overview/SKILL.md
+++ b/.github/plugins/dataverse/skills/dv-overview/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dv-overview
-description: Core rules and tool routing for all Dataverse tasks; loaded before any other Dataverse skill. Use when handling any request involving Dataverse, Dynamics 365, Power Platform, tables, columns, solutions, records, queries, metadata, plugins, the SDK, the Web API, PAC CLI, or environment operations.
+description: Tool routing and cross-cutting rules for Dataverse work — which skill applies to which task, environment-confirmation, and pull-to-repo. Use when the user mentions Dataverse, Dynamics 365, Power Platform, or CRM; this skill picks the specialist (dv-connect / dv-data / dv-metadata / dv-query / dv-solution / dv-admin / dv-security) for the request.
 ---
 
 # Skill: Overview — What to Use and When

--- a/.github/plugins/dataverse/skills/dv-query/SKILL.md
+++ b/.github/plugins/dataverse/skills/dv-query/SKILL.md
@@ -1,14 +1,6 @@
 ---
 name: dv-query
-description: >
-  Bulk reads, multi-page iteration, and analytics using the Python SDK and Web API.
-  Use when: "query records", "read data", "bulk read", "all records", "iterate records",
-  "expand lookup", "cross-table query", "join tables",
-  "aggregate", "group by", "average", "sum", "count with HAVING", "$apply",
-  "N:N expand", "notebook", "pandas", "DataFrame", "analyze data", "load into dataframe".
-  Do not use when: MCP is sufficient (simple filter, single-record read, small result set — use MCP first),
-  creating or modifying records (use dv-data),
-  creating tables or columns (use dv-metadata).
+description: Bulk reads, multi-page iteration, and analytics over Dataverse data via the Python SDK and Web API. Use when querying records, expanding lookups, joining across tables, aggregating with $apply, loading into pandas DataFrames, or analyzing data in notebooks.
 ---
 
 # Skill: Query — Read and Analyze Dataverse Records
@@ -186,238 +178,22 @@ for page in client.records.get(
 
 ---
 
-## $expand on N:N Relationships (Web API — SDK does not support)
+## Advanced query patterns (Web API only)
 
-> **Note:** These raw Web API examples fetch a single page only. If results exceed one page (~5000 records), you must follow `@odata.nextLink` in a loop to get all records. For most N:N and aggregation queries, a single page is sufficient.
+For aggregations and many-to-many expansion, the SDK doesn't have direct support — use raw Web API. See [`references/web-api-advanced.md`](references/web-api-advanced.md) for full code samples.
 
-```python
-import os, sys, json, urllib.request
-sys.path.insert(0, os.path.join(os.getcwd(), "scripts"))
-from auth import get_token, load_env  # get_token() is correct here — SDK cannot do this
-
-load_env()
-env = os.environ["DATAVERSE_URL"].rstrip("/")
-token = get_token()
-
-# Tickets with their linked KB articles (N:N)
-url = (f"{env}/api/data/v9.2/new_tickets"
-       f"?$select=new_name"
-       f"&$expand=new_ticket_kbarticle($select=new_title)")
-req = urllib.request.Request(url, headers={
-    "Authorization": f"Bearer {token}",
-    "OData-MaxVersion": "4.0", "OData-Version": "4.0", "Accept": "application/json",
-})
-with urllib.request.urlopen(req, timeout=150) as resp:
-    data = json.loads(resp.read())
-    for ticket in data["value"]:
-        articles = [a["new_title"] for a in ticket.get("new_ticket_kbarticle", [])]
-        print(f"{ticket['new_name']}: {', '.join(articles)}")
-```
-
----
-
-## $apply Aggregation (Web API — SDK does not support)
-
-**Use `$apply` for any single-table aggregation** — "which X has the most Y", "total by group", "top N", "average per category". This runs server-side and returns only the grouped results. One HTTP call, no client-side processing. Limit: 50,000 source records per aggregation.
-
-**Common $apply patterns:**
-
-| User question | $apply expression |
-|---|---|
-| "total sales by status" | `groupby((statuscode),aggregate(amount with sum as total))` |
-| "which account has the most revenue" | `groupby((_parentaccountid_value),aggregate(estimatedvalue with sum as total))` then sort client-side |
-| "how many records per category" | `groupby((category),aggregate($count as count))` |
-| "average deal size by region" | `groupby((region),aggregate(amount with average as avg))` |
-
-```python
-import os, sys, json, urllib.request
-sys.path.insert(0, os.path.join(os.getcwd(), "scripts"))
-from auth import get_token, load_env  # get_token() is correct here — SDK does not support $apply
-
-load_env()
-env = os.environ["DATAVERSE_URL"].rstrip("/")
-token = get_token()
-
-def apply_query(entity_set, apply_expr):
-    """Run a $apply aggregation query. Returns list of result dicts."""
-    url = f"{env}/api/data/v9.2/{entity_set}?$apply={apply_expr}"
-    req = urllib.request.Request(url, headers={
-        "Authorization": f"Bearer {token}",
-        "OData-MaxVersion": "4.0", "OData-Version": "4.0", "Accept": "application/json",
-    })
-    with urllib.request.urlopen(req, timeout=150) as resp:
-        return json.loads(resp.read()).get("value", [])
-
-# Example 1: Count and sum by status
-results = apply_query("opportunities",
-    "groupby((statuscode),aggregate($count as count,estimatedvalue with sum as total_value))")
-for row in results:
-    print(f"Status {row['statuscode']}: {row['count']} records, ${row['total_value']:,.0f}")
-
-# Example 2: Top accounts by total deal value
-results = apply_query("opportunities",
-    "groupby((_parentaccountid_value),aggregate(estimatedvalue with sum as total))")
-top = sorted(results, key=lambda r: r.get("total", 0), reverse=True)[:10]
-for r in top:
-    print(f"Account {r['_parentaccountid_value']}: ${r['total']:,.0f}")
-```
-
-**When `$apply` won't work** (cross-table questions, complex transforms):
-
-`$apply` only works within a single entity set. For cross-table aggregation, use `client.dataframe.get()` with minimal `$select` on each table, then `pd.merge()`. The merge itself is sub-second; the bottleneck is network transfer, which `$select` minimizes:
-
-```python
-import pandas as pd
-
-# Only the columns needed — always pass select= on large tables
-df_a = client.dataframe.get("prefix_tablea",
-    select=["prefix_keycolumn", "prefix_metric"])
-df_b = client.dataframe.get("prefix_tableb",
-    select=["prefix_keycolumn", "prefix_dimension"])
-
-merged = pd.merge(df_a, df_b, on="prefix_keycolumn")
-top = merged.groupby("prefix_dimension")["prefix_metric"].sum().nlargest(10)
-print(top)
-```
-
-**Performance rules for client-side processing:**
-- Always use `$select` — fetching all columns on 100K rows transfers 10-20x more data than needed
-- Use `client.dataframe.get()`, not raw HTTP page iteration
-- pandas `merge` + `groupby` on 100K-300K rows takes seconds — the bottleneck is network transfer, not Python processing
-
----
+**Quick reference:**
+- **`$expand` on N:N relationships:** `GET /<entitySet>?$expand=<n:n_nav>($select=...)` — single page only; follow `@odata.nextLink` for >5,000 results.
+- **`$apply` for aggregations:** runs server-side, returns grouped results in one call. Patterns: `groupby((col),aggregate(metric with sum as total))`, `aggregate($count as count)`, `aggregate(amount with average as avg)`. 50K source-record limit.
+- **Cross-table aggregation:** `$apply` only works within one entity set. Use `client.dataframe.get(entity, select=[...])` per table → `pd.merge()` → `groupby()`. Always pass `select=`; without it transfers 10-20× more data.
 
 ## QueryBuilder — Fluent Query API (SDK b8+)
 
-> **Version check:** QueryBuilder requires SDK version b8 or later (`pip show PowerPlatform-Dataverse-Client` → Version ≥ 0.1.0b8). If you're on b7 or earlier, `client.query.builder()` does not exist — use `client.records.get()` instead (documented above). Do NOT introspect the SDK with `dir()` or `inspect` to discover APIs — if a method isn't documented here, it doesn't exist in the installed version.
-
-QueryBuilder offers composable filters, OR/AND logic, and `.to_dataframe()` in one chain. It calls `client.records.get()` internally — it is a convenience layer, not a replacement.
-
-```python
-# Basic — flat record iteration
-for record in client.query.builder("opportunity") \
-        .select("name", "estimatedvalue", "statuscode") \
-        .filter_eq("statuscode", 1) \
-        .order_by("estimatedvalue", descending=True) \
-        .top(100) \
-        .execute():
-    print(record["name"], record["estimatedvalue"])
-```
-
-**Direct DataFrame result** — combines query + pandas handoff in one call:
-
-```python
-df = client.query.builder("opportunity") \
-    .select("name", "estimatedvalue", "statuscode") \
-    .filter_eq("statuscode", 1) \
-    .to_dataframe()
-```
-
-**Composable filter expressions** — for OR/AND logic:
-
-```python
-from PowerPlatform.Dataverse.models.filters import eq, gt
-
-active_or_pending = (eq("statecode", 0) | eq("statecode", 1)) & gt("estimatedvalue", 10000)
-
-df = client.query.builder("opportunity") \
-    .select("name", "estimatedvalue") \
-    .where(active_or_pending) \
-    .to_dataframe()
-```
-
-**Paged execution** — when you need per-page control:
-
-```python
-for page in client.query.builder("opportunity").select("name").execute(by_page=True):
-    for record in page:
-        print(record["name"])
-```
-
----
-
-## Pandas DataFrame Handoff
-
-**Prefer `client.dataframe.get()` for any read that involves analysis, verification, comparison, or export.** Use `client.records.get()` with page iteration only when you need per-page processing (e.g., streaming to a file) or when the table is too large to fit in memory.
-
-| Task | Use | Why |
-|---|---|---|
-| Aggregate, group, pivot | `client.dataframe.get()` | pandas does this natively |
-| Compare counts after import | `client.records.get()` with single-column select | Page-count is memory-efficient; no need to load full DataFrame for a count |
-| Build a lookup map (small table) | `client.dataframe.get()` | `dict(zip(df["src_id"], df["guid"]))` — 1 line |
-| Build a lookup map (100K+ rows) | `client.records.get()` | Page iterator uses less memory |
-| Export to CSV/Excel | `client.dataframe.get()` | `df.to_csv("out.csv")` |
-| Stream large result to file | `client.records.get()` | Page-at-a-time avoids loading all into memory |
-| Cross-table join/aggregation | `client.dataframe.get()` both tables with `$select` + `pd.merge()` | pandas merge is sub-second; use `$select` to minimize network transfer |
-
-**Always pass `select=` when calling `client.dataframe.get()` or `client.records.get()`.** Omitting `select` returns every column — on a 100K-row table with 20 columns, this transfers 10-20x more data than needed and turns a 15-second query into a 90-second query. Only request the columns you need.
-
-Use `client.dataframe.get()` to pull Dataverse records directly into a pandas DataFrame — no manual page iteration needed:
-
-```python
-import pandas as pd
-
-# Returns a fully consolidated DataFrame (all pages)
-df = client.dataframe.get("opportunity",
-    select=["name", "estimatedvalue", "statuscode", "_parentaccountid_value"],
-)
-print(df.groupby("statuscode")["estimatedvalue"].agg(["count", "sum", "mean"]))
-```
-
-**DataFrame write-back** — update or create records from a DataFrame. These are write operations — agents consulting **dv-data** for writes should also check here for the DataFrame variant. **Note:** DataFrame write-back supports `create` and `update` only — not upsert. For idempotent imports with alternate keys, use `client.records.upsert()` with `UpsertItem` (see **dv-data**).
-
-```python
-# Update records — DataFrame must include the primary key column
-client.dataframe.update("opportunity", df_updates, id_column="opportunityid")
-
-# Create records — returns a Series of new GUIDs
-guids = client.dataframe.create("opportunity", df_new_records)
-```
-
-**Fallback (manual page iteration)** — use only when you need per-page processing. Prefer `client.dataframe.get()` above for the common case:
-
-```python
-all_records = []
-for page in client.records.get("opportunity",
-    select=["name", "estimatedvalue", "statuscode"],
-):
-    all_records.extend([dict(r) for r in page])  # convert Record objects to dicts
-df = pd.DataFrame(all_records)
-```
-
----
+Available in `PowerPlatform-Dataverse-Client` b8+. Chainable builder for complex queries that would be awkward as a single OData URL or FetchXML string. Full reference and examples in [`references/querybuilder.md`](references/querybuilder.md).
 
 ## Jupyter Notebook Setup
 
-> **Auth note:** Notebooks do not have a `scripts/` directory, so `scripts/auth.py` is not available. Use `InteractiveBrowserCredential` directly — this is the intended exception to the `scripts/auth.py` rule. For scripts (`.py` files), always use `scripts/auth.py`.
-
-```python
-# Cell 1: Setup
-import os
-from azure.identity import InteractiveBrowserCredential
-from PowerPlatform.Dataverse.client import DataverseClient
-
-credential = InteractiveBrowserCredential()
-client = DataverseClient(
-    base_url="https://<org>.crm.dynamics.com",  # replace with your org URL
-    credential=credential,
-)
-
-# Cell 2: Load data into pandas (direct DataFrame, no manual iteration)
-df = client.dataframe.get("account",
-    select=["name", "industrycode", "revenue", "numberofemployees"],
-)
-df.head()
-```
-
-**Prerequisites:**
-```bash
-pip install --upgrade PowerPlatform-Dataverse-Client pandas matplotlib seaborn azure-identity
-```
-
-`pandas>=2.0.0` is a required dependency of the SDK (since b7) and is installed automatically with `--upgrade`.
-
----
+For interactive querying in notebooks (auth + DataverseClient + DataFrame display), see [`references/jupyter-setup.md`](references/jupyter-setup.md).
 
 ## Common Query Errors
 

--- a/.github/plugins/dataverse/skills/dv-query/SKILL.md
+++ b/.github/plugins/dataverse/skills/dv-query/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dv-query
-description: Bulk reads, multi-page iteration, and analytics over Dataverse data via the Python SDK and Web API. Use when querying records, expanding lookups, joining across tables, aggregating with $apply, loading into pandas DataFrames, or analyzing data in notebooks.
+description: Bulk reads, multi-page iteration, and analytics over Dataverse data via the Python SDK and Web API. Use when the user wants to read, list, filter, aggregate, group, join, or analyze records — including pandas DataFrame workflows and notebook exploration.
 ---
 
 # Skill: Query — Read and Analyze Dataverse Records

--- a/.github/plugins/dataverse/skills/dv-query/references/jupyter-setup.md
+++ b/.github/plugins/dataverse/skills/dv-query/references/jupyter-setup.md
@@ -1,0 +1,29 @@
+# Jupyter Notebook Setup
+
+> **Auth note:** Notebooks do not have a `scripts/` directory, so `scripts/auth.py` is not available. Use `InteractiveBrowserCredential` directly — this is the intended exception to the `scripts/auth.py` rule. For scripts (`.py` files), always use `scripts/auth.py`.
+
+```python
+# Cell 1: Setup
+import os
+from azure.identity import InteractiveBrowserCredential
+from PowerPlatform.Dataverse.client import DataverseClient
+
+credential = InteractiveBrowserCredential()
+client = DataverseClient(
+    base_url="https://<org>.crm.dynamics.com",  # replace with your org URL
+    credential=credential,
+)
+
+# Cell 2: Load data into pandas (direct DataFrame, no manual iteration)
+df = client.dataframe.get("account",
+    select=["name", "industrycode", "revenue", "numberofemployees"],
+)
+df.head()
+```
+
+**Prerequisites:**
+```bash
+pip install --upgrade PowerPlatform-Dataverse-Client pandas matplotlib seaborn azure-identity
+```
+
+`pandas>=2.0.0` is a required dependency of the SDK (since b7) and is installed automatically with `--upgrade`.

--- a/.github/plugins/dataverse/skills/dv-query/references/querybuilder.md
+++ b/.github/plugins/dataverse/skills/dv-query/references/querybuilder.md
@@ -1,0 +1,97 @@
+# QueryBuilder — Fluent Query API (SDK b8+)
+
+> **Version check:** QueryBuilder requires SDK version b8 or later (`pip show PowerPlatform-Dataverse-Client` → Version ≥ 0.1.0b8). If you're on b7 or earlier, `client.query.builder()` does not exist — use `client.records.get()` instead (documented above). Do NOT introspect the SDK with `dir()` or `inspect` to discover APIs — if a method isn't documented here, it doesn't exist in the installed version.
+
+QueryBuilder offers composable filters, OR/AND logic, and `.to_dataframe()` in one chain. It calls `client.records.get()` internally — it is a convenience layer, not a replacement.
+
+```python
+# Basic — flat record iteration
+for record in client.query.builder("opportunity") \
+        .select("name", "estimatedvalue", "statuscode") \
+        .filter_eq("statuscode", 1) \
+        .order_by("estimatedvalue", descending=True) \
+        .top(100) \
+        .execute():
+    print(record["name"], record["estimatedvalue"])
+```
+
+**Direct DataFrame result** — combines query + pandas handoff in one call:
+
+```python
+df = client.query.builder("opportunity") \
+    .select("name", "estimatedvalue", "statuscode") \
+    .filter_eq("statuscode", 1) \
+    .to_dataframe()
+```
+
+**Composable filter expressions** — for OR/AND logic:
+
+```python
+from PowerPlatform.Dataverse.models.filters import eq, gt
+
+active_or_pending = (eq("statecode", 0) | eq("statecode", 1)) & gt("estimatedvalue", 10000)
+
+df = client.query.builder("opportunity") \
+    .select("name", "estimatedvalue") \
+    .where(active_or_pending) \
+    .to_dataframe()
+```
+
+**Paged execution** — when you need per-page control:
+
+```python
+for page in client.query.builder("opportunity").select("name").execute(by_page=True):
+    for record in page:
+        print(record["name"])
+```
+
+---
+
+## Pandas DataFrame Handoff
+
+**Prefer `client.dataframe.get()` for any read that involves analysis, verification, comparison, or export.** Use `client.records.get()` with page iteration only when you need per-page processing (e.g., streaming to a file) or when the table is too large to fit in memory.
+
+| Task | Use | Why |
+|---|---|---|
+| Aggregate, group, pivot | `client.dataframe.get()` | pandas does this natively |
+| Compare counts after import | `client.records.get()` with single-column select | Page-count is memory-efficient; no need to load full DataFrame for a count |
+| Build a lookup map (small table) | `client.dataframe.get()` | `dict(zip(df["src_id"], df["guid"]))` — 1 line |
+| Build a lookup map (100K+ rows) | `client.records.get()` | Page iterator uses less memory |
+| Export to CSV/Excel | `client.dataframe.get()` | `df.to_csv("out.csv")` |
+| Stream large result to file | `client.records.get()` | Page-at-a-time avoids loading all into memory |
+| Cross-table join/aggregation | `client.dataframe.get()` both tables with `$select` + `pd.merge()` | pandas merge is sub-second; use `$select` to minimize network transfer |
+
+**Always pass `select=` when calling `client.dataframe.get()` or `client.records.get()`.** Omitting `select` returns every column — on a 100K-row table with 20 columns, this transfers 10-20x more data than needed and turns a 15-second query into a 90-second query. Only request the columns you need.
+
+Use `client.dataframe.get()` to pull Dataverse records directly into a pandas DataFrame — no manual page iteration needed:
+
+```python
+import pandas as pd
+
+# Returns a fully consolidated DataFrame (all pages)
+df = client.dataframe.get("opportunity",
+    select=["name", "estimatedvalue", "statuscode", "_parentaccountid_value"],
+)
+print(df.groupby("statuscode")["estimatedvalue"].agg(["count", "sum", "mean"]))
+```
+
+**DataFrame write-back** — update or create records from a DataFrame. These are write operations — agents consulting **dv-data** for writes should also check here for the DataFrame variant. **Note:** DataFrame write-back supports `create` and `update` only — not upsert. For idempotent imports with alternate keys, use `client.records.upsert()` with `UpsertItem` (see **dv-data**).
+
+```python
+# Update records — DataFrame must include the primary key column
+client.dataframe.update("opportunity", df_updates, id_column="opportunityid")
+
+# Create records — returns a Series of new GUIDs
+guids = client.dataframe.create("opportunity", df_new_records)
+```
+
+**Fallback (manual page iteration)** — use only when you need per-page processing. Prefer `client.dataframe.get()` above for the common case:
+
+```python
+all_records = []
+for page in client.records.get("opportunity",
+    select=["name", "estimatedvalue", "statuscode"],
+):
+    all_records.extend([dict(r) for r in page])  # convert Record objects to dicts
+df = pd.DataFrame(all_records)
+```

--- a/.github/plugins/dataverse/skills/dv-query/references/web-api-advanced.md
+++ b/.github/plugins/dataverse/skills/dv-query/references/web-api-advanced.md
@@ -1,0 +1,99 @@
+# Web API advanced — `$expand` on N:N and `$apply` aggregation
+
+
+> **Note:** These raw Web API examples fetch a single page only. If results exceed one page (~5000 records), you must follow `@odata.nextLink` in a loop to get all records. For most N:N and aggregation queries, a single page is sufficient.
+
+```python
+import os, sys, json, urllib.request
+sys.path.insert(0, os.path.join(os.getcwd(), "scripts"))
+from auth import get_token, load_env  # get_token() is correct here — SDK cannot do this
+
+load_env()
+env = os.environ["DATAVERSE_URL"].rstrip("/")
+token = get_token()
+
+# Tickets with their linked KB articles (N:N)
+url = (f"{env}/api/data/v9.2/new_tickets"
+       f"?$select=new_name"
+       f"&$expand=new_ticket_kbarticle($select=new_title)")
+req = urllib.request.Request(url, headers={
+    "Authorization": f"Bearer {token}",
+    "OData-MaxVersion": "4.0", "OData-Version": "4.0", "Accept": "application/json",
+})
+with urllib.request.urlopen(req, timeout=150) as resp:
+    data = json.loads(resp.read())
+    for ticket in data["value"]:
+        articles = [a["new_title"] for a in ticket.get("new_ticket_kbarticle", [])]
+        print(f"{ticket['new_name']}: {', '.join(articles)}")
+```
+
+---
+
+## $apply Aggregation (Web API — SDK does not support)
+
+**Use `$apply` for any single-table aggregation** — "which X has the most Y", "total by group", "top N", "average per category". This runs server-side and returns only the grouped results. One HTTP call, no client-side processing. Limit: 50,000 source records per aggregation.
+
+**Common $apply patterns:**
+
+| User question | $apply expression |
+|---|---|
+| "total sales by status" | `groupby((statuscode),aggregate(amount with sum as total))` |
+| "which account has the most revenue" | `groupby((_parentaccountid_value),aggregate(estimatedvalue with sum as total))` then sort client-side |
+| "how many records per category" | `groupby((category),aggregate($count as count))` |
+| "average deal size by region" | `groupby((region),aggregate(amount with average as avg))` |
+
+```python
+import os, sys, json, urllib.request
+sys.path.insert(0, os.path.join(os.getcwd(), "scripts"))
+from auth import get_token, load_env  # get_token() is correct here — SDK does not support $apply
+
+load_env()
+env = os.environ["DATAVERSE_URL"].rstrip("/")
+token = get_token()
+
+def apply_query(entity_set, apply_expr):
+    """Run a $apply aggregation query. Returns list of result dicts."""
+    url = f"{env}/api/data/v9.2/{entity_set}?$apply={apply_expr}"
+    req = urllib.request.Request(url, headers={
+        "Authorization": f"Bearer {token}",
+        "OData-MaxVersion": "4.0", "OData-Version": "4.0", "Accept": "application/json",
+    })
+    with urllib.request.urlopen(req, timeout=150) as resp:
+        return json.loads(resp.read()).get("value", [])
+
+# Example 1: Count and sum by status
+results = apply_query("opportunities",
+    "groupby((statuscode),aggregate($count as count,estimatedvalue with sum as total_value))")
+for row in results:
+    print(f"Status {row['statuscode']}: {row['count']} records, ${row['total_value']:,.0f}")
+
+# Example 2: Top accounts by total deal value
+results = apply_query("opportunities",
+    "groupby((_parentaccountid_value),aggregate(estimatedvalue with sum as total))")
+top = sorted(results, key=lambda r: r.get("total", 0), reverse=True)[:10]
+for r in top:
+    print(f"Account {r['_parentaccountid_value']}: ${r['total']:,.0f}")
+```
+
+**When `$apply` won't work** (cross-table questions, complex transforms):
+
+`$apply` only works within a single entity set. For cross-table aggregation, use `client.dataframe.get()` with minimal `$select` on each table, then `pd.merge()`. The merge itself is sub-second; the bottleneck is network transfer, which `$select` minimizes:
+
+```python
+import pandas as pd
+
+# Only the columns needed — always pass select= on large tables
+df_a = client.dataframe.get("prefix_tablea",
+    select=["prefix_keycolumn", "prefix_metric"])
+df_b = client.dataframe.get("prefix_tableb",
+    select=["prefix_keycolumn", "prefix_dimension"])
+
+merged = pd.merge(df_a, df_b, on="prefix_keycolumn")
+top = merged.groupby("prefix_dimension")["prefix_metric"].sum().nlargest(10)
+print(top)
+```
+
+**Performance rules for client-side processing:**
+- Always use `$select` — fetching all columns on 100K rows transfers 10-20x more data than needed
+- Use `client.dataframe.get()`, not raw HTTP page iteration
+- pandas `merge` + `groupby` on 100K-300K rows takes seconds — the bottleneck is network transfer, not Python processing

--- a/.github/plugins/dataverse/skills/dv-security/SKILL.md
+++ b/.github/plugins/dataverse/skills/dv-security/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dv-security
-description: Assigns security roles, manages user access, and handles admin self-elevation in Dataverse environments. Use when assigning a security role, granting system administrator, self-elevating to admin, adding application users, or managing business units.
+description: Security-role assignment, user access, application users, business units, and admin self-elevation in Dataverse environments. Use when the user wants to give someone access, grant a role, become an admin, or add a service principal.
 ---
 
 # Skill: Security — Role Assignment and Self-Elevation

--- a/.github/plugins/dataverse/skills/dv-security/SKILL.md
+++ b/.github/plugins/dataverse/skills/dv-security/SKILL.md
@@ -1,14 +1,6 @@
 ---
 name: dv-security
-description: >
-  Assign security roles, manage user access, and handle admin self-elevation in Dataverse environments.
-  Use when: "assign role", "system admin", "security role", "give me admin role",
-  "assign system administrator", "role assignment", "make me admin",
-  "self-elevate", "admin access", "assign user", "application user",
-  "business unit", "who has access", "user permissions".
-  Do not use when: creating or modifying tables (use dv-metadata),
-  managing org settings or audit (use dv-admin),
-  tenant governance like DLP (use pac admin --help).
+description: Assigns security roles, manages user access, and handles admin self-elevation in Dataverse environments. Use when assigning a security role, granting system administrator, self-elevating to admin, adding application users, or managing business units.
 ---
 
 # Skill: Security — Role Assignment and Self-Elevation
@@ -23,17 +15,13 @@ Role grants and self-elevate are destructive (they change security posture and a
 
 ### Examples
 
-<example operation="assign role (user given, env missing)">
-<user>Assign System Administrator role to user@contoso.com</user>
-<bad>Which environment should I target?</bad>
-<good>I'll assign **System Administrator** to `user@contoso.com` on `<ENV_URL>`. Confirm to proceed and provide the target environment URL (or "all" to list and batch).</good>
-</example>
+**Assign role (user given, env missing):**
+- ❌ "Which environment should I target?"
+- ✅ "I'll assign **System Administrator** to `user@contoso.com` on `<ENV_URL>`. Confirm to proceed and provide the target environment URL (or 'all' to list and batch)."
 
-<example operation="admin access across all environments">
-<user>Give me admin access on all my environments</user>
-<bad>Please provide your email address.</bad>
-<good>I'll list your environments, then assign **System Administrator** in parallel on each one for `<YOUR_UPN>`. If `assign-user` fails on any environment, I'll fall back to self-elevate (logged to Purview) for that one. Confirm to proceed and provide your UPN.</good>
-</example>
+**Admin access across all environments:**
+- ❌ "Please provide your email address."
+- ✅ "I'll list your environments, then assign **System Administrator** in parallel on each one for `<YOUR_UPN>`. If `assign-user` fails on any environment, I'll fall back to self-elevate (logged to Purview) for that one. Confirm to proceed and provide your UPN."
 
 ## Skill boundaries
 

--- a/.github/plugins/dataverse/skills/dv-solution/SKILL.md
+++ b/.github/plugins/dataverse/skills/dv-solution/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dv-solution
-description: Manages Dataverse solution lifecycle — create, export, import, promote across environments, and validate deployments. Use when exporting or importing a solution, packing or unpacking, pulling from an environment, pushing to an environment, or verifying a deployment.
+description: Dataverse solution lifecycle — create, export, import, promote across environments, and validate deployments. Use when the user wants to package customizations, deploy to another environment, or move work between dev / test / prod.
 ---
 
 # Skill: Solution

--- a/.github/plugins/dataverse/skills/dv-solution/SKILL.md
+++ b/.github/plugins/dataverse/skills/dv-solution/SKILL.md
@@ -1,11 +1,6 @@
 ---
 name: dv-solution
-description: >
-  Manage Dataverse solution lifecycle — create, export, import, promote across environments, and validate deployments.
-  Use when: "export solution", "import solution", "pack solution", "unpack solution", "create solution",
-  "pull from environment", "push to environment", "validate import", "check import errors",
-  "check if table exists", "check if form is published", "verify deployment".
-  Do not use when: creating tables/columns/forms/views (use dv-metadata).
+description: Manages Dataverse solution lifecycle — create, export, import, promote across environments, and validate deployments. Use when exporting or importing a solution, packing or unpacking, pulling from an environment, pushing to an environment, or verifying a deployment.
 ---
 
 # Skill: Solution

--- a/.github/workflows/skill-evals.yml
+++ b/.github/workflows/skill-evals.yml
@@ -21,8 +21,8 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Install tiktoken (for CAT-8 token-budget evals)
-        run: pip install tiktoken
+      - name: Install eval dependencies (tiktoken for CAT-8, pyyaml for CAT-4 STRUCT-05)
+        run: pip install tiktoken pyyaml
 
       - name: Run static eval suite
         run: python .github/evals/static_checks.py

--- a/.github/workflows/skill-evals.yml
+++ b/.github/workflows/skill-evals.yml
@@ -21,6 +21,9 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: Install tiktoken (for CAT-8 token-budget evals)
+        run: pip install tiktoken
+
       - name: Run static eval suite
         run: python .github/evals/static_checks.py
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,37 @@ The one exception: Jupyter notebook blocks use `InteractiveBrowserCredential` di
 
 Every `python` fenced block must contain at least one executable line. Comment-only blocks (`# POST to ...`) must either be completed or removed. Use a plain (unlabelled) fence for non-executable fragments.
 
+### Frontmatter description
+
+Follow Anthropic's published Skills format: one third-person descriptive sentence followed by an inline `Use when ...` clause naming user-intent triggers. The two halves do different jobs — the first describes what the skill does, the second describes what to look for in a request. Don't enumerate quoted trigger phrases (burns Level 1 tokens on every interaction across all skills) and don't include `Do not use when:` lists. Hard cap: 1024 chars.
+
+Example: `Record-level CRUD and bulk operations via the Python SDK — create, update, delete, upsert, CSV import, multi-table foreign-key loads. Use when the user wants to write, modify, seed, or import data records into Dataverse tables.`
+
+### Token budget — Anthropic Skills spec
+
+- **Frontmatter (Level 1, always loaded):** ≤ 200 tokens. Strive for ~100.
+- **SKILL.md body (Level 2, loaded on trigger):** ≤ 5,000 tokens.
+- **`references/<topic>.md` (Level 3, loaded on demand):** unlimited.
+
+When a skill body grows past ~4,000 tokens, split long content (Python snippets, edge-case tables, deep-dive workflows) into `references/<topic>.md`. The body keeps a Quick Reference + key invariants + a one-line pointer to the reference. Keep references one level deep — body links directly, references don't link to other references.
+
+### Critical safety callout
+
+For skills with destructive or irreversible operations (e.g., bulk delete, role assignment, env settings), surface the most-critical rules in a top-of-file callout block right after the H1, not buried mid-body:
+
+```markdown
+> ## ⚠️ Critical safety rules — read first
+> 1. <hard-stop rule that's destructive and irreversible>
+> 2. <allowlist refusal directive, if any>
+> ...
+```
+
+The body still contains the full enforcement detail; the callout exists so the rules are visible even if a reader doesn't scroll.
+
+### Anti-hallucination tables
+
+For command-heavy skills (PAC CLI, etc.), include a Wrong/Correct mapping table. Eval data on this plugin showed flag hallucination drop from ~58% to ~2.5% with these tables present. One per command group is enough.
+
 ### Skill boundaries
 
 Every skill except `dv-overview` and `dv-connect` must have a `## Skill boundaries` section listing what it does not cover and which skill to use instead. This is the primary routing signal for the agent when it hits an out-of-scope request.
@@ -78,9 +109,19 @@ Then describe a task that exercises the changed skill in plain English. The agen
 
 ## Commit and PR Conventions
 
-- Prefix commits with `feat:`, `fix:`, `refactor:`, `add:`, or `docs:`
+- Prefix commits with `feat:`, `fix:`, `refactor:`, `add:`, or `docs:`. Plain prefix only — no scopes (`feat(skills):` etc.) — the `Validate PR title and body` check rejects them.
 - PR descriptions: lead with the theme of the change, not a per-line changelog
 - Run `python .github/evals/static_checks.py` and confirm it passes before opening a PR
+
+### Branch protection (enforced)
+
+`main` requires:
+- 2 approvals, **both** from `@microsoft/dataverse-skills-maintainers`
+- Status checks: `Static skill checks`, `Validate PR title and body`, `CodeQL`, `license/cla`
+- Last-push approval (any new commit voids prior approvals)
+- Stale-review dismissal on push
+
+Contributors who aren't on the maintainers team need two team members to review. Drive-by approvals from non-maintainers don't count toward the merge requirement.
 
 ## Version Bumping
 
@@ -117,11 +158,11 @@ It compares your branch to `main` and flags common mistakes — e.g., adding a n
 - New keywords or metadata fields
 - Expanding skill boundaries to cover new scenarios
 
-**PATCH (z)** — Backward-compatible fixes:
+**PATCH (z)** — Backward-compatible fixes and refactors with no user-visible change:
 - Bug fixes in code examples
 - Typo and grammar corrections
 - Clarifying prose without changing behavior
 - Updating links or references
-- Minor refactors that don't change skill routing
+- Refactors that preserve every routing trigger and behavior (e.g., splitting a long body into `references/`, deduplicating tables, rewording a description while preserving the same triggers)
 
 **Note:** No need to update the `version` field in the [awesome-copilot marketplace](https://github.com/github/awesome-copilot/blob/main/plugins/external.json). The entry there tracks the default branch of this repo, so version updates propagate automatically. The `version` field in awesome-copilot is cosmetic-only.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,51 +58,41 @@ We welcome new skill contributions! To add a new skill:
 
 ## Local Development
 
-Clone the repository first:
+Clone the repository:
 
 ```bash
 git clone https://github.com/microsoft/Dataverse-skills.git
 ```
 
+Then run the plugin against your local clone with the agent you're testing. The agents differ in how they load plugins from a local path: Claude Code reads the plugin directory on every launch, so edits are picked up automatically. Copilot copies the plugin into its store at install time, so refreshing after edits requires uninstall + reinstall.
+
 ### Testing with GitHub Copilot CLI
 
-To register the local plugin marketplace from the cloned repository and install the plugin:
-
-```bash
-copilot plugin marketplace add <path/to/repo>/Dataverse-skills
-copilot plugin install dataverse@dataverse-skills
-```
-
-To reinstall the plugin after pulling or making local changes:
-
-```bash
-copilot plugin uninstall dataverse@dataverse-skills
-copilot plugin install dataverse@dataverse-skills
-```
-
-To install the local version directly without marketplace registration:
+Install directly from your local plugin directory:
 
 ```bash
 copilot plugin install <path/to/repo>/.github/plugins/dataverse
 ```
 
-### Testing with Claude Code
-
-Test the plugin locally without installing from a marketplace:
+After making local changes (or pulling), uninstall and reinstall to refresh Copilot's copy:
 
 ```bash
-# 1. Create and cd into a fresh test folder
-mkdir my-test-project
-cd my-test-project
-
-# 2. Launch Claude Code with the plugin loaded from your local clone
-claude --plugin-dir "<path/to/repo>/.github/plugins/dataverse"
-
-# 3. Start with a natural language prompt, e.g.:
-#    "Create a support ticket table with customer and agent lookups"
+copilot plugin uninstall dataverse@dataverse-skills
+copilot plugin install <path/to/repo>/.github/plugins/dataverse
 ```
 
-The `--plugin-dir` path **must be in double quotes** if it contains spaces or special characters. Use the absolute path to the plugin directory in your local clone of this repo.
+### Testing with Claude Code
+
+Launch Claude Code with the plugin loaded from your local clone — no install or uninstall needed; edits take effect on the next launch:
+
+```bash
+# In a fresh test folder
+mkdir my-test-project && cd my-test-project
+
+claude --plugin-dir "<path/to/repo>/.github/plugins/dataverse"
+```
+
+Quote the path if it contains spaces or special characters; use an absolute path.
 
 ## Legal
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ We welcome new skill contributions! To add a new skill:
    - Clear step-by-step instructions
    - SDK-first approach: use `PowerPlatform-Dataverse-Client` for all supported operations, raw Web API only for gaps
    - Output formatting examples
-5. **Test locally** using `claude --plugin-dir` (see [README.md](README.md#local-development))
+5. **Test locally** using `claude --plugin-dir` (see [Local Development](#local-development) below)
 6. **Submit a pull request** with a clear description of what the skill does and why it's useful
 
 ### Improving Existing Skills
@@ -52,9 +52,57 @@ We welcome new skill contributions! To add a new skill:
 
 1. Update relevant documentation if your change affects usage
 2. Ensure your skill follows the existing formatting patterns
-3. Test your changes locally with `claude --plugin-dir`
+3. Test your changes locally with `claude --plugin-dir` (see [Local Development](#local-development) below)
 4. Your PR will be reviewed by maintainers
 5. Once approved, a maintainer will merge your contribution
+
+## Local Development
+
+Clone the repository first:
+
+```bash
+git clone https://github.com/microsoft/Dataverse-skills.git
+```
+
+### Testing with GitHub Copilot CLI
+
+To register the local plugin marketplace from the cloned repository and install the plugin:
+
+```bash
+copilot plugin marketplace add <path/to/repo>/Dataverse-skills
+copilot plugin install dataverse@dataverse-skills
+```
+
+To reinstall the plugin after pulling or making local changes:
+
+```bash
+copilot plugin uninstall dataverse@dataverse-skills
+copilot plugin install dataverse@dataverse-skills
+```
+
+To install the local version directly without marketplace registration:
+
+```bash
+copilot plugin install <path/to/repo>/.github/plugins/dataverse
+```
+
+### Testing with Claude Code
+
+Test the plugin locally without installing from a marketplace:
+
+```bash
+# 1. Create and cd into a fresh test folder
+mkdir my-test-project
+cd my-test-project
+
+# 2. Launch Claude Code with the plugin loaded from your local clone
+claude --plugin-dir "<path/to/repo>/.github/plugins/dataverse"
+
+# 3. Start with a natural language prompt, e.g.:
+#    "Create a support ticket table with customer and agent lookups"
+```
+
+The `--plugin-dir` path **must be in double quotes** if it contains spaces or special characters. Use the absolute path to the plugin directory in your local clone of this repo.
 
 ## Legal
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,7 @@ Browse [`.github/plugins/dataverse/skills/`](.github/plugins/dataverse/skills/) 
 
 ## Prerequisites
 
-- **Microsoft Dataverse** environment (included with Power Apps, Dynamics 365, or Power Platform)
-- **Python 3.10+** and **Node.js 18+**
+A Microsoft Dataverse environment, available through Power Apps, Dynamics 365, or Power Platform plans, or via the free [Power Apps Developer Plan](https://learn.microsoft.com/en-us/power-platform/developer/plan).
 
 ## Install
 
@@ -59,10 +58,10 @@ After the connect flow finishes, describe what you want — the plugin picks MCP
 
 The plugin is designed around a least-privilege model — it cannot exceed the permissions of the authenticated user. Key safeguards:
 
-- **MCP authorization** — MCP access requires developer auth, tenant admin consent, and per-environment allowlisting; other plugin tools (SDK, PAC CLI) authenticate directly
-- **Security role enforcement** — every API call is authorized server-side by Dataverse; the plugin cannot bypass or escalate permissions
+- **MCP authorization** — MCP access requires developer auth, tenant admin consent, and per-environment allowlisting; other plugin tools (SDK, PAC CLI) authenticate directly.
+- **Security role enforcement** — every API call is authorized server-side by Dataverse; the plugin cannot bypass or escalate permissions.
 - **Application-level telemetry only** — outbound Dataverse requests may carry application metadata (plugin / version / skill / agent labels) so server-side dashboards can attribute traffic. No prompts, tool arguments, or record data are transmitted.
-- **Token security** — credentials are stored in your OS native credential store or held in memory only; never passed to external services
+- **Token security** — credentials are stored in your OS native credential store or held in memory only; never passed to external services.
 
 For the full safety model — including confirmation flows, logging, irreversible operation handling, and planned improvements — see [docs/safety-and-guardrails.md](docs/safety-and-guardrails.md).
 

--- a/README.md
+++ b/README.md
@@ -2,22 +2,27 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-Agent skills and MCP configuration for [Microsoft Dataverse](https://aka.ms/DVinWorkIQLearnMore) — works with Claude Code and GitHub Copilot. These skills teach AI agents how to build and manage Dataverse solutions using natural language.
+Build, query, and manage [Microsoft Dataverse](https://learn.microsoft.com/en-us/power-apps/maker/data-platform/data-platform-intro) through natural language. The plugin teaches AI coding agents to drive the Dataverse MCP server, Dataverse CLI, Python SDK, and PAC CLI — for everything from designing data models and answering CRM questions to deploying solutions across environments.
 
-Browse the [`.github/plugins/dataverse/skills/`](.github/plugins/dataverse/skills/) folder for the full catalog.
+| Skill | What it does |
+|---|---|
+| **dv-connect** | One-time setup that installs the Dataverse CLI, Python SDK, and PAC CLI; authenticates against your Dataverse environment; and registers the Dataverse MCP server with your agent. |
+| **dv-query** | Reads, filters, paginates, and aggregates Dataverse records. Handles natural-language questions like *"show me my open deals"*, multi-page result sets, and pandas DataFrame loading for notebook analysis. |
+| **dv-data** | Single-record CRUD plus bulk import — CSV loads, multi-table imports with foreign-key dependencies, upsert by alternate key, and AI-generated sample data. |
+| **dv-metadata** | Authors and edits the Dataverse data model: tables, columns, relationships, forms, and views. |
+| **dv-solution** | Manages solution lifecycle — create, export, import, promote across environments, and validate deployments. |
+| **dv-admin** | Environment-level administration: bulk delete, retention/archival, organization settings, OrgDB settings, recycle bin, audit, and the allowlisted PPAC toggles. |
+| **dv-security** | Assigns security roles, manages user access, adds application users, configures business units, and handles admin self-elevation. |
+| **dv-overview** | Cross-cutting rules and tool routing; loaded before any other skill to direct each request to the right specialist. |
+
+Browse [`.github/plugins/dataverse/skills/`](.github/plugins/dataverse/skills/) for the full source.
 
 ## Prerequisites
 
 - **Microsoft Dataverse** environment (included with Power Apps, Dynamics 365, or Power Platform)
 - **Python 3.10+** and **Node.js 18+**
 
-## Getting Started
-
-### Claude Code
-
-```bash
-/plugin install dataverse@claude-plugins-official
-```
+## Install
 
 ### GitHub Copilot
 
@@ -25,60 +30,30 @@ Browse the [`.github/plugins/dataverse/skills/`](.github/plugins/dataverse/skill
 /plugin install dataverse@awesome-copilot
 ```
 
-## What's Included
-
-- **8 skills** covering connection setup, metadata authoring, solution management, data writes, queries/analytics, environment admin, security/role management, and tool routing
-- **MCP server** configuration for Dataverse Web API access
-- **Scripts** for authentication and MCP client enablement
-- **Templates** for CLAUDE.md project files
-
-## Local Development
-
-Clone the repository first:
+### Claude Code
 
 ```bash
-git clone https://github.com/microsoft/Dataverse-skills.git
+/plugin install dataverse@claude-plugins-official
 ```
 
-### Testing with Claude Code
+## Verify the install
 
-Test the plugin locally without installing from a marketplace:
+After installation, ask your agent:
 
-```bash
-# 1. Create and cd into a fresh test folder
-mkdir my-test-project
-cd my-test-project
+> "Connect to Dataverse"
 
-# 2. Launch Claude Code with the plugin loaded from your local clone
-claude --plugin-dir "<path/to/repo>/.github/plugins/dataverse"
+The `dv-connect` skill walks through tool checks, authentication, and MCP registration. When it finishes, you should see a `dataverse-<orgname>` MCP server registered with your agent, and `pac auth list` should show your active environment.
 
-# 3. Start with a natural language prompt, e.g.:
-#    "Create a support ticket table with customer and agent lookups"
-```
+## Try these prompts
 
-The `--plugin-dir` path **must be in double quotes** if it contains spaces or special characters. Use the absolute path to the plugin directory in your local clone of this repo.
+After the connect flow finishes, describe what you want — the plugin picks MCP, the Dataverse CLI, the Python SDK, or PAC CLI for you.
 
-### Testing with GitHub Copilot CLI
-
-To register the local plugin marketplace from the cloned repository and install the plugin:
-
-```bash
-copilot plugin marketplace add <path/to/repo>/Dataverse-skills
-copilot plugin install dataverse@dataverse-skills
-```
-
-To reinstall the plugin after pulling or making local changes:
-
-```bash
-copilot plugin uninstall dataverse@dataverse-skills
-copilot plugin install dataverse@dataverse-skills
-```
-
-To install the local version directly without marketplace registration:
-
-```bash
-copilot plugin install <path/to/repo>/.github/plugins/dataverse
-```
+- *"Show me my open deals over $100K closing this quarter"*
+- *"Import this CSV into the contacts table"*
+- *"Create a customer feedback table with name, rating, and comment columns"*
+- *"Pull the schema and pack it into a solution"*
+- *"Bulk delete activities older than 2024"*
+- *"Add a teammate to the sales team on the dev environment"*
 
 ## Safety & Security
 
@@ -86,14 +61,14 @@ The plugin is designed around a least-privilege model — it cannot exceed the p
 
 - **MCP authorization** — MCP access requires developer auth, tenant admin consent, and per-environment allowlisting; other plugin tools (SDK, PAC CLI) authenticate directly
 - **Security role enforcement** — every API call is authorized server-side by Dataverse; the plugin cannot bypass or escalate permissions
-- **No plugin telemetry** — the plugin does not collect or transmit usage analytics; data flows only to Dataverse within your tenant and to the AI host (Claude or Copilot) as part of normal operation
+- **Application-level telemetry only** — outbound Dataverse requests may carry application metadata (plugin / version / skill / agent labels) so server-side dashboards can attribute traffic. No prompts, tool arguments, or record data are transmitted.
 - **Token security** — credentials are stored in your OS native credential store or held in memory only; never passed to external services
 
 For the full safety model — including confirmation flows, logging, irreversible operation handling, and planned improvements — see [docs/safety-and-guardrails.md](docs/safety-and-guardrails.md).
 
 ## Contributing
 
-We welcome contributions — new skills, improvements to existing ones, and bug fixes. See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+We welcome contributions — new skills, improvements to existing ones, and bug fixes. See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines and local-development instructions.
 
 ## Trademarks
 

--- a/docs/safety-and-guardrails.md
+++ b/docs/safety-and-guardrails.md
@@ -129,16 +129,13 @@ For details on Dataverse auditing, see [Microsoft's auditing documentation](http
 
 ## Telemetry
 
-**The plugin does not phone home.** There is no active usage telemetry. No data about your usage, queries, or environment is transmitted to any external service beyond the Dataverse Web API calls to your own tenant.
+The plugin may add an application identifier to its outbound Dataverse requests so server-side dashboards can attribute traffic. The identifier carries plugin / version / skill / agent labels — application-level metadata, not personal data under [GDPR Article 4(1)](https://gdpr-info.eu/art-4-gdpr/). Server-side aggregation uses Entra `oid` / `tid` claims that Dataverse already logs on every authenticated request; counting distinct users / tenants is cardinality measurement, not individual tracking.
 
-Usage metrics are gathered passively through public GitHub repository signals (clone counts, stars, forks) only.
+The pattern matches Azure CLI, `gh`, and Azure SDKs (always-on, no consent prompt — tool-identifying metadata is convention, not telemetry).
 
-If telemetry is introduced in the future, it will be:
+**Not collected:** prompt bodies, tool arguments, record data, file contents, command strings.
 
-- **Opt-in**, not opt-out
-- Free of PII (no email, username, tenant ID, or environment URL)
-- Not in the authentication code path
-- Documented in the README before activation
+**Future telemetry surfaces.** If a separate telemetry payload pipeline is ever introduced — distinct from the application-identifying metadata above (for example, OTEL events or per-call timing) — it will be opt-in, free of PII, kept out of the authentication code path, and documented in the README before activation.
 
 ## Areas Under Exploration
 

--- a/docs/safety-and-guardrails.md
+++ b/docs/safety-and-guardrails.md
@@ -129,13 +129,7 @@ For details on Dataverse auditing, see [Microsoft's auditing documentation](http
 
 ## Telemetry
 
-The plugin may add an application identifier to its outbound Dataverse requests so server-side dashboards can attribute traffic. The identifier carries plugin / version / skill / agent labels — application-level metadata, not personal data under [GDPR Article 4(1)](https://gdpr-info.eu/art-4-gdpr/). Server-side aggregation uses Entra `oid` / `tid` claims that Dataverse already logs on every authenticated request; counting distinct users / tenants is cardinality measurement, not individual tracking.
-
-The pattern matches Azure CLI, `gh`, and Azure SDKs (always-on, no consent prompt — tool-identifying metadata is convention, not telemetry).
-
-**Not collected:** prompt bodies, tool arguments, record data, file contents, command strings.
-
-**Future telemetry surfaces.** If a separate telemetry payload pipeline is ever introduced — distinct from the application-identifying metadata above (for example, OTEL events or per-call timing) — it will be opt-in, free of PII, kept out of the authentication code path, and documented in the README before activation.
+The plugin may add an application identifier to its outbound Dataverse requests so server-side dashboards can attribute traffic. The identifier carries plugin / version / skill / agent labels — application-level metadata only, not personal data. Prompts, tool arguments, record data, file contents, and command strings are not transmitted.
 
 ## Areas Under Exploration
 


### PR DESCRIPTION
## Summary

Adopts Anthropic's published Skills authoring spec across all 8 skills and enforces it with new token-budget evals. Refreshes user-facing docs to match.

## What changed

**Skills**
- Frontmatters rewritten in Anthropic format (single descriptive sentence + inline `Use when ...` clause; no enumerated trigger-phrase lists).
- Long-form content in `dv-admin`, `dv-data`, `dv-metadata`, `dv-query` moved to `references/<topic>.md`. Bodies retain quick reference + key invariants + pointer.
- `dv-admin`: critical safety rules surfaced in a callout at the top of the file.
- `dv-data`: top-of-file Preview-Before-Running section relocated into `## Sample Data Generation` as Confirmation-flow examples.

**Evals**
- New CAT-8: frontmatter ≤ 200 tokens, body ≤ 5,000 tokens, `references/` required when body > 4,000 tokens.
- CAT-4 updated to Anthropic's description format (`Use when` hint, 1024-char limit).
- New CAT-4 `EVAL-STRUCT-05`: frontmatter must parse as valid YAML (catches unquoted colons that break GitHub's preview and real YAML loaders).
- `tiktoken` and `pyyaml` added to CI.

**Docs**
- `README.md` rewritten with skill catalog, install per agent, verify-the-install, and try-these-prompts.
- `CLAUDE.md` — token budgets, frontmatter format, references pattern, branch-protection requirements.
- `CONTRIBUTING.md` — absorbed local-development steps.
- `docs/safety-and-guardrails.md` — telemetry section refreshed.

**Version:** 1.4.0 → 1.4.2 (PATCH; refactor with no user-visible behavior change).

## Verification

`python .github/evals/static_checks.py` passes (8 categories, 46 Python blocks). Cross-reference audit shows every link resolves and every `references/*.md` is linked from its parent SKILL.md.

## Test plan

- [ ] Spot-check skill routing on a few representative prompts
- [ ] Confirm CAT-8 fails on intentional regressions (e.g., a skill body inflated past 5k tokens)
- [ ] All required checks pass: CodeQL, license/cla, PR Metadata Check, Skill Evals