### PR TITLE
fix: Updating the project-scoped MCP config path for GitHub Copilot CLI

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "dataverse-skills",
   "metadata": {
     "description": "Official Dataverse plugin marketplace for agent-guided development",
-    "version": "1.4.2"
+    "version": "1.4.3"
   },
   "owner": {
     "name": "Microsoft",
@@ -13,7 +13,7 @@
       "name": "dataverse",
       "description": "Agent skills for building on, analyzing, and managing Microsoft Dataverse — with Dataverse MCP, PAC CLI, and Python SDK.",
       "source": "./.github/plugins/dataverse",
-      "version": "1.4.2",
+      "version": "1.4.3",
       "homepage": "https://github.com/microsoft/Dataverse-skills"
     }
   ]

--- a/.github/plugins/dataverse/.claude-plugin/plugin.json
+++ b/.github/plugins/dataverse/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dataverse",
   "description": "Agent skills for building on, analyzing, and managing Microsoft Dataverse — with Dataverse MCP, PAC CLI, and Python SDK.",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "author": {
     "name": "Microsoft",
     "url": "https://www.microsoft.com"

--- a/.github/plugins/dataverse/.github/plugin/plugin.json
+++ b/.github/plugins/dataverse/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dataverse",
   "description": "Agent skills for building on, analyzing, and managing Microsoft Dataverse — with Dataverse MCP, PAC CLI, and Python SDK.",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "author": {
     "name": "Microsoft",
     "url": "https://www.microsoft.com"

--- a/.github/plugins/dataverse/skills/dv-connect/SKILL.md
+++ b/.github/plugins/dataverse/skills/dv-connect/SKILL.md
@@ -202,7 +202,7 @@ Both must succeed. Confirm the environment URL matches the intended target.
 ## Step 6: Configure MCP server
 
 **Skip this step** if MCP is already configured:
-- `.mcp.json` or `~/.copilot/mcp-config.json` or `.mcp/copilot/mcp.json` contains a Dataverse server entry
+- `.mcp.json` or `~/.copilot/mcp-config.json` contains a Dataverse server entry
 - `claude mcp list` shows a `dataverse-*` server registered
 
 If MCP is not configured, follow [mcp-configuration.md](references/mcp-configuration.md):

--- a/.github/plugins/dataverse/skills/dv-connect/references/mcp-configuration.md
+++ b/.github/plugins/dataverse/skills/dv-connect/references/mcp-configuration.md
@@ -40,7 +40,7 @@ The options are:
 
 Based on the scope, set the `CONFIG_PATH` variable:
 - **Global**: `~/.copilot/mcp-config.json` (use the user's home directory)
-- **Project**: `.mcp/copilot/mcp.json` (relative to the current working directory)
+- **Project**: `.mcp.json` (relative to the current working directory)
 
 Store this path for use in steps 2 and 5.
 
@@ -233,21 +233,16 @@ This is the `SERVER_NAME`.
 
 **Update the configuration file:**
 
-1. If `CONFIG_PATH` is for a **project-scoped** configuration (`.mcp/copilot/mcp.json`), ensure the directory exists first:
-   ```bash
-   mkdir -p .mcp/copilot
-   ```
-
-2. Read the existing configuration file at `CONFIG_PATH`, or create a new empty config if it doesn't exist:
+1. Read the existing configuration file at `CONFIG_PATH`, or create a new empty config if it doesn't exist:
    ```json
    {}
    ```
 
-3. Determine which top-level key to use:
+2. Determine which top-level key to use:
    - If the config already has `"servers"`, use that
    - Otherwise, use `"mcpServers"`
 
-4. Add or update the server entry:
+3. Add or update the server entry:
    ```json
    {
      "mcpServers": {
@@ -259,7 +254,7 @@ This is the `SERVER_NAME`.
    }
    ```
 
-5. Write the updated configuration back to `CONFIG_PATH` with proper JSON formatting (2-space indentation).
+4. Write the updated configuration back to `CONFIG_PATH` with proper JSON formatting (2-space indentation).
 
 **Important notes:**
 - Do NOT overwrite other entries in the configuration file
@@ -414,7 +409,7 @@ If something goes wrong, help the user check:
   3. Verify the MCP Client ID appears under **Allowed clients**
 - If using the Preview endpoint, verify that the Preview MCP endpoint is also enabled in the same Features page
 - **If TOOL_TYPE is `copilot`:**
-  - For project-scoped configuration, ensure the `.mcp/copilot/mcp.json` file was created successfully
+  - For project-scoped configuration, ensure the `.mcp.json` file was created successfully
   - For global configuration, check permissions on the `~/.copilot/` directory
 - **If TOOL_TYPE is `claude`:**
   - Ensure the `claude` CLI is installed and available in their PATH


### PR DESCRIPTION
Up until recently GitHub Copilot CLI did not officially support configuring MCP servers at the project level, and the part of the `dv-connect` skill/`mcp-configuration` reference that covered that was largely a placeholder.

Copilot does support project-scoped MCP configurations in `.mcp.json` at the project root now: https://github.com/github/copilot-cli-for-beginners/blob/main/06-mcp-servers/README.md#mcp-configuration-file

Which has been reported as
#49

This PR updates the previous incorrect placeholder path to `.mcp.json`. Tested locally that this works (note the "Source" path at the bottom):

<img width="951" height="693" alt="image" src="https://github.com/user-attachments/assets/32524a77-8e5d-4c26-acc0-39f6696ebebe" />
