### PR TITLE
fix: Prevent publisher prefix in table display names

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "dataverse-skills",
   "metadata": {
     "description": "Official Dataverse plugin marketplace for agent-guided development",
-    "version": "1.4.3"
+    "version": "1.4.4"
   },
   "owner": {
     "name": "Microsoft",
@@ -13,7 +13,7 @@
       "name": "dataverse",
       "description": "Agent skills for building on, analyzing, and managing Microsoft Dataverse — with Dataverse MCP, PAC CLI, and Python SDK.",
       "source": "./.github/plugins/dataverse",
-      "version": "1.4.3",
+      "version": "1.4.4",
       "homepage": "https://github.com/microsoft/Dataverse-skills"
     }
   ]

--- a/.github/plugins/dataverse/.claude-plugin/plugin.json
+++ b/.github/plugins/dataverse/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dataverse",
   "description": "Agent skills for building on, analyzing, and managing Microsoft Dataverse — with Dataverse MCP, PAC CLI, and Python SDK.",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "author": {
     "name": "Microsoft",
     "url": "https://www.microsoft.com"

--- a/.github/plugins/dataverse/.github/plugin/plugin.json
+++ b/.github/plugins/dataverse/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dataverse",
   "description": "Agent skills for building on, analyzing, and managing Microsoft Dataverse — with Dataverse MCP, PAC CLI, and Python SDK.",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "author": {
     "name": "Microsoft",
     "url": "https://www.microsoft.com"

--- a/.github/plugins/dataverse/skills/dv-connect/SKILL.md
+++ b/.github/plugins/dataverse/skills/dv-connect/SKILL.md
@@ -22,7 +22,7 @@ Run these checks in order. If **all four pass**, skip straight to Step 7 (final 
 1. **`.env` is present and complete** — file exists at the workspace root and contains non-empty values for `DATAVERSE_URL`, `TENANT_ID`, and `MCP_CLIENT_ID`
 2. **MCP is registered** — `.mcp.json` (Claude Code) or the equivalent Copilot config file has a `dataverse-*` server entry pointing at the `DATAVERSE_URL` from `.env`
 3. **PAC CLI auth matches `.env`** — `pac auth list` shows a profile whose `Environment Url` matches `DATAVERSE_URL`, and `pac org who` against that profile succeeds
-4. **Python SDK is importable** — `python -c "from PowerPlatform.Dataverse.client import DataverseClient; import pandas"` exits 0
+4. **Python SDK is importable and current** — `python -c "from PowerPlatform.Dataverse.client import DataverseClient; import pandas; from importlib.metadata import version; v=version('PowerPlatform-Dataverse-Client'); assert v>='0.1.0b9', f'SDK {v} is outdated, need >=0.1.0b9'"` exits 0
 
 **If all pass:** Tell the user you detected an existing setup, list what you found (URL, profile name, MCP server name), then jump to Step 7. Do not rewrite `.env`, do not re-register MCP, do not re-run `pip install`.
 

--- a/.github/plugins/dataverse/skills/dv-metadata/SKILL.md
+++ b/.github/plugins/dataverse/skills/dv-metadata/SKILL.md
@@ -94,6 +94,7 @@ info = client.tables.create(
     {"new_Amount": "decimal", "new_Description": "string"},
     solution="MySolution",
     primary_column="new_Name",
+    display_name="Project Budget",  # human-readable name; plural auto-appends "s"
 )
 print(f"Created: {info['table_schema_name']}")
 ```
@@ -131,14 +132,10 @@ entity = {
 
 ## Column Naming: Avoid `*Id` Suffix Collisions
 
-**Never name a regular column with an `Id` suffix** (e.g., `prefix_CountryId`, `prefix_PlayerId`). When you later create a lookup relationship to another table, Dataverse auto-generates a navigation property with the `Id` suffix (e.g., `prefix_CountryId`). If a regular integer column with the same name already exists, the lookup creation fails with a schema name collision.
+**Never name a regular column with an `Id` suffix** (e.g., `prefix_CountryId`). Dataverse auto-generates a navigation property with the `Id` suffix when you create a lookup — if a regular column with that name exists, lookup creation fails with a schema name collision.
 
-**Pattern for source system IDs:**
-- WRONG: `prefix_DepartmentId` (int) — collides when lookup `prefix_DepartmentId` is created later
-- RIGHT: `prefix_SrcDepartmentId` (int) — `Src` prefix distinguishes source IDs from Dataverse lookups
-- RIGHT: `prefix_DepartmentSourceId` (int) — `SourceId` suffix is also safe
-
-This matters most in multi-table imports where you store the source system's integer FK as a column and then create a Dataverse lookup relationship for the same reference.
+- WRONG: `prefix_DepartmentId` (int) — collides with auto-generated lookup
+- RIGHT: `prefix_SrcDepartmentId` or `prefix_DepartmentSourceId`
 
 ---
 


### PR DESCRIPTION
## Summary

  - Adds `display_name=` to the `tables.create` example in dv-metadata so the agent generates clean display names (e.g., "Project Budget" instead of "new_ProjectBudget")
  - Adds SDK version floor check (`>=0.1.0b9`) to Step 0 in dv-connect so existing users with an older SDK automatically get upgraded on next connect
  - Bumps plugin version to 1.4.3

  Fixes #34

  ## Test plan

  - [X] `python .github/evals/static_checks.py` passes (dv-overview budget failure is pre-existing)
  - [X] `python .github/evals/version_bump_check.py` passes
  - [X] Start a new Claude session with `claude --plugin-dir .github/plugins/dataverse`, ask it to create a solution with custom tables, and verify the generated script uses
  `display_name=` with clean names