### PR TITLE
fix: use check-first pattern for idempotent table creation

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "dataverse-skills",
   "metadata": {
     "description": "Official Dataverse plugin marketplace for agent-guided development",
-    "version": "1.4.4"
+    "version": "1.4.5"
   },
   "owner": {
     "name": "Microsoft",
@@ -13,7 +13,7 @@
       "name": "dataverse",
       "description": "Agent skills for building on, analyzing, and managing Microsoft Dataverse — with Dataverse MCP, PAC CLI, and Python SDK.",
       "source": "./.github/plugins/dataverse",
-      "version": "1.4.4",
+      "version": "1.4.5",
       "homepage": "https://github.com/microsoft/Dataverse-skills"
     }
   ]

--- a/.github/plugins/dataverse/.claude-plugin/plugin.json
+++ b/.github/plugins/dataverse/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dataverse",
   "description": "Agent skills for building on, analyzing, and managing Microsoft Dataverse — with Dataverse MCP, PAC CLI, and Python SDK.",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "author": {
     "name": "Microsoft",
     "url": "https://www.microsoft.com"

--- a/.github/plugins/dataverse/.github/plugin/plugin.json
+++ b/.github/plugins/dataverse/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dataverse",
   "description": "Agent skills for building on, analyzing, and managing Microsoft Dataverse — with Dataverse MCP, PAC CLI, and Python SDK.",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "author": {
     "name": "Microsoft",
     "url": "https://www.microsoft.com"

--- a/.github/plugins/dataverse/skills/dv-metadata/SKILL.md
+++ b/.github/plugins/dataverse/skills/dv-metadata/SKILL.md
@@ -72,7 +72,7 @@ The only time you write files directly is when editing something that already ex
 ## Creating a Table
 
 **If creating multiple tables for a data import**, also see these sections later in this skill:
-- **Idempotent Table Creation** — catch "already exists" for re-runnable scripts
+- **Idempotent Table Creation** — check-first pattern for re-runnable scripts
 - **Alternate Keys** — required for upsert; create immediately after each table
 - **Metadata Propagation Delays and Lock Contention** — phased creation to avoid lock errors
 
@@ -408,24 +408,18 @@ pac solution list-components --solutionUniqueName <SOLUTION_NAME> --environment 
 
 ## Idempotent Table Creation
 
-When creating tables programmatically (e.g., a schema setup script that may be re-run), catch `0x80040237` to skip tables that already exist:
+When creating tables programmatically (e.g., a schema setup script that may be re-run), use a check-first pattern — query `client.tables.get()` before creating. This is explicit, avoids masking unrelated errors, and lets you branch logic based on whether the table was created or reused:
 
 ```python
-try:
-    info = client.tables.create(schema_name, columns, solution=SOLUTION, primary_column="prefix_name")
+def ensure_table(client, schema_name, columns, solution, primary_column="prefix_Name", display_name=None):
+    existing = client.tables.get(schema_name)
+    if existing:
+        print(f"Reusing: {schema_name}")
+        return existing
+    info = client.tables.create(schema_name, columns, solution=solution,
+                                primary_column=primary_column, display_name=display_name)
     print(f"Created: {info['table_schema_name']}")
-except Exception as e:
-    err = str(e)
-    if "already exists" in err.lower() or "0x80040237" in err:
-        print("Already exists, skipping")
-    else:
-        raise
-```
-
-To pre-check without creating, query `EntityDefinitions` directly:
-```python
-# Returns 404 if the table does not exist
-GET /api/data/v9.2/EntityDefinitions(LogicalName='new_projectbudget')?$select=LogicalName
+    return info
 ```
 
 ---
@@ -436,7 +430,7 @@ GET /api/data/v9.2/EntityDefinitions(LogicalName='new_projectbudget')?$select=Lo
 
 **Quick reference:**
 - SDK call: `client.tables.create_alternate_key(table, key_name, [columns], display_name=...)`. Composite keys: pass multiple columns.
-- Wrap in try/except for `HttpError` containing `"already exists"` or `0x80048d0b` to make the script re-runnable.
+- Use a check-first pattern with `client.tables.get_alternate_keys(table)` to skip keys that already exist — see `references/alternate-keys.md` for the `ensure_alternate_key` helper.
 - Index creation is **async** — for large tables, poll `client.tables.get_alternate_keys(table)` until `status == "Active"` before using.
 - Constraints: max 16 columns / 900 bytes / 10 keys per table; valid types are Integer / Decimal / String / DateTime / Lookup / OptionSet.
 

--- a/.github/plugins/dataverse/skills/dv-metadata/references/alternate-keys.md
+++ b/.github/plugins/dataverse/skills/dv-metadata/references/alternate-keys.md
@@ -40,25 +40,21 @@ key = client.tables.create_alternate_key(
 )
 ```
 
-**Idempotent key creation** — catch "already exists" to make the script re-runnable:
+**Idempotent key creation** — check first to make the script re-runnable:
 
 ```python
-from PowerPlatform.Dataverse.core.errors import HttpError
-
-def ensure_alternate_key(table, key_name, columns, display_name):
-    try:
-        key = client.tables.create_alternate_key(table, key_name, columns, display_name=display_name)
-        print(f"  Key created: {key_name} on {table}")
-    except HttpError as e:
-        if "already exists" in str(e).lower() or "0x80048d0b" in str(e):
-            print(f"  Key already exists: {key_name}")
-        else:
-            raise
+def ensure_alternate_key(client, table, key_name, columns, display_name):
+    existing = client.tables.get_alternate_keys(table)
+    if any(k.schema_name.lower() == key_name.lower() for k in existing):
+        print(f"  Key already exists: {key_name}")
+        return
+    key = client.tables.create_alternate_key(table, key_name, columns, display_name=display_name)
+    print(f"  Key created: {key_name} on {table}")
 
 # Create keys for all import tables
-ensure_alternate_key("prefix_Country", "prefix_SrcCountryIdKey",
+ensure_alternate_key(client, "prefix_Country", "prefix_SrcCountryIdKey",
     ["prefix_srccountryid"], "Source Country ID")
-ensure_alternate_key("prefix_City", "prefix_SrcCityIdKey",
+ensure_alternate_key(client, "prefix_City", "prefix_SrcCityIdKey",
     ["prefix_srccityid"], "Source City ID")
 ```
 

--- a/.github/plugins/dataverse/skills/dv-metadata/references/metadata-propagation.md
+++ b/.github/plugins/dataverse/skills/dv-metadata/references/metadata-propagation.md
@@ -21,7 +21,7 @@ When creating many tables with alternate keys and lookups (e.g., multi-table imp
 
 Do NOT interleave: `create table A → create key A → create table B → create key B`. This causes lock contention because key A's index build blocks table B's creation.
 
-**Retry pattern:** Wrap all metadata operations with retry for transient lock errors:
+**Retry pattern:** Wrap metadata operations with retry for transient lock errors. Use check-first helpers (`ensure_table`, `ensure_alternate_key`) to handle "already exists" before calling this — the retry wrapper only handles lock contention:
 
 ```python
 import time
@@ -32,9 +32,6 @@ def retry_metadata(fn, description, max_attempts=5):
             return fn()
         except Exception as e:
             err = str(e)
-            if "already exists" in err.lower() or "0x80040237" in err:
-                print(f"  {description}: already exists, skipping")
-                return None
             if "another" in err.lower() and "running" in err.lower():
                 wait = 10 * (attempt + 1)
                 print(f"  {description}: lock contention, waiting {wait}s (attempt {attempt+1}/{max_attempts})...")


### PR DESCRIPTION
  **Summary**

  - Replaces exception-based idempotency (try/except catching 0x80040237 / "already exists") with
  explicit check-first helpers (ensure_table, ensure_alternate_key) that call client.tables.get() /
  client.tables.get_alternate_keys() before creating
  - Removes the "already exists" catch from the retry_metadata helper in metadata-propagation.md —
  callers now handle existence checks upstream, and the retry wrapper focuses solely on lock
  contention
  - Bumps plugin version 1.4.4 → 1.4.5 (patch — code example fix)

  **Test plan**

  - static_checks.py passes (pre-existing dv-overview budget warning unrelated)
  - version_bump_check.py passes (patch bump, patch required)
  - Agent generates check-first table creation code when prompted via claude --plugin-dir
  - Agent generates check-first alternate key code when prompted

  Closes #48

VALIDATION
<img width="933" height="641" alt="image" src="https://github.com/user-attachments/assets/a91f93d8-0ce7-478b-aad6-ce4284f55b9d" />
