### PR TITLE
feat: add dv-skill for Dataverse Business Skills management

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "dataverse-skills",
   "metadata": {
     "description": "Official Dataverse plugin marketplace for agent-guided development",
-    "version": "1.5.0"
+    "version": "1.6.0"
   },
   "owner": {
     "name": "Microsoft",
@@ -13,7 +13,7 @@
       "name": "dataverse",
       "description": "Agent skills for building on, analyzing, and managing Microsoft Dataverse — with Dataverse MCP, PAC CLI, and Python SDK.",
       "source": "./.github/plugins/dataverse",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "homepage": "https://github.com/microsoft/Dataverse-skills"
     }
   ]

--- a/.github/plugins/dataverse/.claude-plugin/plugin.json
+++ b/.github/plugins/dataverse/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dataverse",
   "description": "Agent skills for building on, analyzing, and managing Microsoft Dataverse — with Dataverse MCP, PAC CLI, and Python SDK.",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "author": {
     "name": "Microsoft",
     "url": "https://www.microsoft.com"

--- a/.github/plugins/dataverse/.github/plugin/plugin.json
+++ b/.github/plugins/dataverse/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dataverse",
   "description": "Agent skills for building on, analyzing, and managing Microsoft Dataverse — with Dataverse MCP, PAC CLI, and Python SDK.",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "author": {
     "name": "Microsoft",
     "url": "https://www.microsoft.com"

--- a/.github/plugins/dataverse/scripts/auth.py
+++ b/.github/plugins/dataverse/scripts/auth.py
@@ -191,7 +191,7 @@ def get_token(scope=None):
 _ALLOWED_SKILLS = frozenset({
     "dv-overview", "dv-connect", "dv-data", "dv-query",
     "dv-metadata", "dv-solution", "dv-admin", "dv-security",
-    "unknown",
+    "dv-skill", "unknown",
 })
 _ALLOWED_AGENTS = frozenset({
     "claude-code", "copilot", "cursor", "codex", "unknown",

--- a/.github/plugins/dataverse/skills/dv-data/SKILL.md
+++ b/.github/plugins/dataverse/skills/dv-data/SKILL.md
@@ -27,6 +27,10 @@ Use the official Microsoft Power Platform Dataverse Client Python SDK for all da
 
 **If MCP tools are available** (`create_record`, `update_record`) and the task is ≤10 records, **use MCP directly — no script needed.** Only write a Python script when the task requires: bulk operations (10+ records), data transformation, retry logic, CSV import, or operations the SDK supports that MCP cannot (upsert, file uploads). Sequential MCP tool calls are not "multi-step logic" — use MCP for those.
 
+## Consult Business Skills — Mandatory
+
+**Before generating any Python SDK code, consult Dataverse Business Skills.** Extract keywords from the user's request, query the skill entity, and incorporate any matching skill instructions as context. If no skills match, proceed normally. See **dv-skill** § Consult Helper for the full pattern.
+
 ## SDK-First Rule
 
 **If an operation is in the "supports" list below, you MUST use the SDK — not `urllib`, `requests`, or raw HTTP.**

--- a/.github/plugins/dataverse/skills/dv-overview/SKILL.md
+++ b/.github/plugins/dataverse/skills/dv-overview/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dv-overview
-description: Tool routing and cross-cutting rules for Dataverse work — which skill applies to which task, environment-confirmation, and pull-to-repo. Use when the user mentions Dataverse, Dynamics 365, Power Platform, or CRM; this skill picks the specialist (dv-connect / dv-data / dv-metadata / dv-query / dv-solution / dv-admin / dv-security) for the request.
+description: Tool routing and cross-cutting rules for Dataverse work — which skill applies to which task, environment-confirmation, and pull-to-repo. Use when the user mentions Dataverse, Dynamics 365, Power Platform, or CRM; this skill picks the specialist (dv-connect / dv-data / dv-metadata / dv-query / dv-solution / dv-admin / dv-security / dv-skill) for the request.
 ---
 
 # Skill: Overview — What to Use and When
@@ -206,6 +206,7 @@ Each skill's frontmatter contains WHEN/DO NOT USE WHEN triggers that Claude uses
 | **dv-solution** | Solution create/export/import/pack/unpack, post-import validation |
 | **dv-admin** | Bulk delete, data retention/archival, org settings (audit, plugin trace, session timeout), OrgDB settings (MCP, search, copilot, fabric), recycle bin. PAC CLI for bulk delete/retention/org settings; Python SDK for OrgDB XML and recycle bin. Multi-environment: parallel with `&` and `wait` |
 | **dv-security** | Role assignment (`pac admin assign-user`), self-elevation (`pac admin self-elevate`). **PAC CLI only** |
+| **dv-skill** | Manage Dataverse Business Skills (environment-specific `skill` entity records) — list, create, update, delete skills and skill resources via Python SDK |
 
 ---
 

--- a/.github/plugins/dataverse/skills/dv-overview/SKILL.md
+++ b/.github/plugins/dataverse/skills/dv-overview/SKILL.md
@@ -151,45 +151,19 @@ It does **not** cover:
 
 ---
 
-## Tool Capabilities — Which Tool for Which Job
+## Tool Capabilities — Quick Reference
 
-Understanding the real limits of each tool prevents hallucinated paths. This is the one piece of context no individual skill owns.
+**Tool priority (always follow this order):** MCP (simple reads/queries, ≤10 record writes) → Python SDK (bulk reads, scripted writes, analytics) → Web API (forms, views, option sets, `$apply`, N:N `$expand`) → PAC CLI (solution lifecycle). Schema creation → SDK via `dv-metadata`.
 
-| Tool | Use for | Does NOT support |
-| --- | --- | --- |
-| **MCP Server** | Data CRUD (create/read/update/delete records), table create/update/delete/list/describe, column add via `update_table`, keyword search, single-record fetch | Forms, Views, Relationships, Option Sets, Solutions. **Note:** table creation may timeout but still succeed — always `describe_table` before retrying. Run queries sequentially (parallel calls timeout). Column names with spaces normalize to underscores (e.g., `"Specialty Area"` → `cr9ac_specialty_area`). **SQL limitations:** The `read_query` tool uses Dataverse SQL, which does NOT support: `DISTINCT`, `HAVING`, subqueries, `OFFSET`, `UNION`, `CASE`/`IF`, `CAST`/`CONVERT`, or date functions. For analytical queries that need these (e.g., finding duplicates, unmatched records, filtered aggregates), use `$apply` (single-table aggregation) or `client.dataframe.get()` with pandas (cross-table) — see `dv-query`. **Bulk operations:** MCP `create_record` creates one record at a time. For 10+ records, use the Python SDK `CreateMultiple` instead — see `dv-data`. |
-| **Python SDK (`dv-data`)** | **Preferred for all scripted data writes.** Record CRUD, upsert (alternate keys), bulk create/update/upsert (CreateMultiple/UpdateMultiple/UpsertMultiple), CSV import with lookup resolution, file column uploads (chunked >128MB) | Forms, Views, global Option Sets, record association (`$ref`), `$apply` aggregation, N:N `$expand`, table/column/relationship creation (use `dv-metadata`), custom action invocation |
-| **Python SDK (`dv-query`)** | **Preferred for bulk reads and analytics.** Multi-page record iteration, OData queries (select/filter/expand/orderby), QueryBuilder fluent API (b8+), GUID-free display (formatted values), `$expand` to resolve lookups, pandas DataFrame handoff (`client.dataframe.get()`) for cross-table joins and exports, Jupyter notebook snippets | `$apply` aggregation (use Web API), N:N `$expand` (use Web API) |
-| **Web API** | Everything — forms, views, relationships, option sets, columns, table definitions, unbound actions, `$ref` association | Nothing (full MetadataService + OData access) |
-| **PAC CLI** | Solution export/import/pack/unpack, environment create/list/delete/reset, auth profile management, plugin updates (`pac plugin push` — first-time registration requires Web API), user/role assignment (`pac admin assign-user`), solution component management | Data CRUD, metadata creation (tables/columns/forms) |
-| **Azure CLI** | App registrations, service principals, credential management | Dataverse-specific operations |
-| **GitHub CLI** | Repo management, GitHub secrets, Actions workflow status | Dataverse-specific operations |
+**Volume guidance:** MCP `create_record` for 1-10 records; SDK `client.records.create(table, list)` for 10+. MCP `read_query` for small results; SDK `client.dataframe.get()` for bulk reads/analytics. `$apply` aggregation requires raw Web API.
 
-**Tool priority (always follow this order):** MCP for simple reads/queries (small result set, no paging) and ≤10 record writes → Python SDK for bulk reads, scripted writes, bulk operations, and analysis → Web API for operations the SDK doesn't cover (forms, views, option sets, `$apply`, N:N `$expand`) → PAC CLI for solution lifecycle. Schema creation (tables/columns/relationships) → SDK via `dv-metadata`. MCP tools not in your tool list? → Load `dv-connect` to set them up (see below).
+**MCP SQL limitations:** No `DISTINCT`, `HAVING`, subqueries, `OFFSET`, `UNION`, `CASE`/`IF`, `CAST`/`CONVERT`, or date functions. Use `$apply` or pandas for these.
 
-**Volume guidance — writes:** MCP `create_record` for 1-10 records. For 10+ records, use `dv-data` (`client.records.create(table, list_of_dicts)`) — it uses `CreateMultiple` internally. **Note:** the SDK does not chunk automatically; for large datasets, chunk in your script starting at 1,000 and adapt up or down based on success (see `dv-data` for the adaptive pattern).
-
-**Volume guidance — reads:** MCP `read_query` for simple filters and small result sets (no paging needed). For bulk reads (multi-page iteration, all-records loads, DataFrame handoff), use `dv-query` SDK — it streams pages automatically and avoids MCP SQL limitations. For aggregation queries (`$apply`), use the Web API directly (see `dv-query`).
+**MCP availability:** If MCP tools aren't in your tool list and the user explicitly asked for MCP → don't fall back, load `dv-connect` to configure. If the user just asked a data question → answer with SDK, then offer MCP setup.
 
 Note: The Python SDK is in **preview** — breaking changes possible.
 
-### MCP Availability Check
-
-If the user's request involves MCP — either explicitly ("connect via MCP", "use MCP", "query via MCP") or implicitly (conversational data queries where MCP would be the natural tool) — check whether Dataverse MCP tools are available in your current tool list (e.g., `list_tables`, `describe_table`, `read_query`, `create_record`).
-
-**If MCP tools are NOT available and the user explicitly asked for MCP** (e.g., "use MCP to query", "why isn't MCP working"):
-1. **Do NOT silently fall back** to the Python SDK or Web API
-2. Tell the user: "Dataverse MCP tools aren't configured in this session yet."
-3. Load the `dv-connect` skill to set up the MCP server
-4. After MCP is configured, **stop here** — the session must be restarted for MCP tools to appear. Remind them: "Use `claude --continue` to resume without losing context." Do not proceed with SDK. Wait for the user to restart.
-
-**If MCP tools are NOT available and the user asked a data question without explicitly requesting MCP** (e.g., "how many accounts with 'jeff'?", "show me open tickets"):
-1. This is a SDK fallback case — use the Python SDK to answer the question. Do not block the user.
-2. After answering, offer: "MCP would handle this conversationally — want me to set it up?"
-
-The distinction matters: explicit MCP request → block and set up MCP. Implicit/conversational question → answer with SDK, offer MCP setup.
-
-**If MCP tools ARE available**, prefer MCP for simple reads/queries/small CRUD. Use the SDK only when a script is needed.
+For full tool capability matrix, volume guidance, and MCP availability logic, see `references/tool-capabilities.md`.
 
 ---
 

--- a/.github/plugins/dataverse/skills/dv-overview/references/tool-capabilities.md
+++ b/.github/plugins/dataverse/skills/dv-overview/references/tool-capabilities.md
@@ -1,0 +1,39 @@
+# Tool Capabilities — Which Tool for Which Job
+
+Understanding the real limits of each tool prevents hallucinated paths. This is the one piece of context no individual skill owns.
+
+| Tool | Use for | Does NOT support |
+| --- | --- | --- |
+| **MCP Server** | Data CRUD (create/read/update/delete records), table create/update/delete/list/describe, column add via `update_table`, keyword search, single-record fetch | Forms, Views, Relationships, Option Sets, Solutions. **Note:** table creation may timeout but still succeed — always `describe_table` before retrying. Run queries sequentially (parallel calls timeout). Column names with spaces normalize to underscores (e.g., `"Specialty Area"` → `cr9ac_specialty_area`). **SQL limitations:** The `read_query` tool uses Dataverse SQL, which does NOT support: `DISTINCT`, `HAVING`, subqueries, `OFFSET`, `UNION`, `CASE`/`IF`, `CAST`/`CONVERT`, or date functions. For analytical queries that need these (e.g., finding duplicates, unmatched records, filtered aggregates), use `$apply` (single-table aggregation) or `client.dataframe.get()` with pandas (cross-table) — see `dv-query`. **Bulk operations:** MCP `create_record` creates one record at a time. For 10+ records, use the Python SDK `CreateMultiple` instead — see `dv-data`. |
+| **Python SDK (`dv-data`)** | **Preferred for all scripted data writes.** Record CRUD, upsert (alternate keys), bulk create/update/upsert (CreateMultiple/UpdateMultiple/UpsertMultiple), CSV import with lookup resolution, file column uploads (chunked >128MB) | Forms, Views, global Option Sets, record association (`$ref`), `$apply` aggregation, N:N `$expand`, table/column/relationship creation (use `dv-metadata`), custom action invocation |
+| **Python SDK (`dv-query`)** | **Preferred for bulk reads and analytics.** Multi-page record iteration, OData queries (select/filter/expand/orderby), QueryBuilder fluent API (b8+), GUID-free display (formatted values), `$expand` to resolve lookups, pandas DataFrame handoff (`client.dataframe.get()`) for cross-table joins and exports, Jupyter notebook snippets | `$apply` aggregation (use Web API), N:N `$expand` (use Web API) |
+| **Web API** | Everything — forms, views, relationships, option sets, columns, table definitions, unbound actions, `$ref` association | Nothing (full MetadataService + OData access) |
+| **PAC CLI** | Solution export/import/pack/unpack, environment create/list/delete/reset, auth profile management, plugin updates (`pac plugin push` — first-time registration requires Web API), user/role assignment (`pac admin assign-user`), solution component management | Data CRUD, metadata creation (tables/columns/forms) |
+| **Azure CLI** | App registrations, service principals, credential management | Dataverse-specific operations |
+| **GitHub CLI** | Repo management, GitHub secrets, Actions workflow status | Dataverse-specific operations |
+
+**Tool priority (always follow this order):** MCP for simple reads/queries (small result set, no paging) and ≤10 record writes → Python SDK for bulk reads, scripted writes, bulk operations, and analysis → Web API for operations the SDK doesn't cover (forms, views, option sets, `$apply`, N:N `$expand`) → PAC CLI for solution lifecycle. Schema creation (tables/columns/relationships) → SDK via `dv-metadata`. MCP tools not in your tool list? → Load `dv-connect` to set them up (see below).
+
+**Volume guidance — writes:** MCP `create_record` for 1-10 records. For 10+ records, use `dv-data` (`client.records.create(table, list_of_dicts)`) — it uses `CreateMultiple` internally. **Note:** the SDK does not chunk automatically; for large datasets, chunk in your script starting at 1,000 and adapt up or down based on success (see `dv-data` for the adaptive pattern).
+
+**Volume guidance — reads:** MCP `read_query` for simple filters and small result sets (no paging needed). For bulk reads (multi-page iteration, all-records loads, DataFrame handoff), use `dv-query` SDK — it streams pages automatically and avoids MCP SQL limitations. For aggregation queries (`$apply`), use the Web API directly (see `dv-query`).
+
+Note: The Python SDK is in **preview** — breaking changes possible.
+
+## MCP Availability Check
+
+If the user's request involves MCP — either explicitly ("connect via MCP", "use MCP", "query via MCP") or implicitly (conversational data queries where MCP would be the natural tool) — check whether Dataverse MCP tools are available in your current tool list (e.g., `list_tables`, `describe_table`, `read_query`, `create_record`).
+
+**If MCP tools are NOT available and the user explicitly asked for MCP** (e.g., "use MCP to query", "why isn't MCP working"):
+1. **Do NOT silently fall back** to the Python SDK or Web API
+2. Tell the user: "Dataverse MCP tools aren't configured in this session yet."
+3. Load the `dv-connect` skill to set up the MCP server
+4. After MCP is configured, **stop here** — the session must be restarted for MCP tools to appear. Remind them: "Use `claude --continue` to resume without losing context." Do not proceed with SDK. Wait for the user to restart.
+
+**If MCP tools are NOT available and the user asked a data question without explicitly requesting MCP** (e.g., "how many accounts with 'jeff'?", "show me open tickets"):
+1. This is a SDK fallback case — use the Python SDK to answer the question. Do not block the user.
+2. After answering, offer: "MCP would handle this conversationally — want me to set it up?"
+
+The distinction matters: explicit MCP request → block and set up MCP. Implicit/conversational question → answer with SDK, offer MCP setup.
+
+**If MCP tools ARE available**, prefer MCP for simple reads/queries/small CRUD. Use the SDK only when a script is needed.

--- a/.github/plugins/dataverse/skills/dv-query/SKILL.md
+++ b/.github/plugins/dataverse/skills/dv-query/SKILL.md
@@ -11,6 +11,10 @@ description: Bulk reads, multi-page iteration, and analytics over Dataverse data
 
 **All reads use the SDK — not `urllib`, `requests`, or raw HTTP.** This is the same rule as dv-data's SDK-First Rule, applied to reads. If you find yourself writing `urllib.request` or `get_token()` for a query, STOP — the SDK handles it. The only exceptions are `$apply` aggregation and N:N `$expand`, documented below.
 
+## Consult Business Skills — Mandatory
+
+**Before generating any Python SDK code, consult Dataverse Business Skills.** Extract keywords from the user's request, query the skill entity, and incorporate any matching skill instructions as context. If no skills match, proceed normally. See **dv-skill** § Consult Helper for the full pattern.
+
 ## How to Answer Data Questions
 
 When the user asks a question about their data, pick the approach by **what they're asking**, not by which API you know:

--- a/.github/plugins/dataverse/skills/dv-skill/SKILL.md
+++ b/.github/plugins/dataverse/skills/dv-skill/SKILL.md
@@ -1,0 +1,206 @@
+---
+name: dv-skill
+description: Manage the Dataverse skill entity — list, create, update, delete, and attach resource files to skill records that provide domain-specific instructions. Use when the user wants to create, view, edit, remove, or organize skill or skillresource records in their Dataverse environment.
+---
+
+# Skill: Dataverse Business Skills — CRUD and Resource Management
+
+> **This skill uses Python exclusively.** Do not use Node.js, JavaScript, or any other language for Dataverse scripting. See the overview skill's Hard Rules.
+
+## What Are Dataverse Business Skills?
+
+Business Skills are records in the `skill` entity that provide domain-specific guidance for handling tasks. They are **environment-specific** — authored and curated within each Dataverse environment, and will differ across environments. This distinguishes them from static skills (like this `dv-skill` file) which are bundled with the plugin and are the same everywhere.
+
+Each skill record has:
+
+- **Name** — display name (e.g., `Sales-Call-Logging`)
+- **Unique name** — prefixed identifier (e.g., `new_salescalllogging`); auto-generated if omitted
+- **Description** — short summary of what the skill does
+- **Body** — the full instruction/prompt content
+- **Scope** — JSON array of app scope names the skill is associated with
+- **Resources** — attached files (markdown, templates) stored on the `skillresource` table's `filecontent` column
+
+## Skill boundaries
+
+| Need | Use instead |
+|---|---|
+| Query or read data records | **dv-query** |
+| Create/update/delete data records | **dv-data** |
+| Create tables, columns, relationships | **dv-metadata** |
+| Export or deploy solutions | **dv-solution** |
+| Environment settings, bulk delete | **dv-admin** |
+| Security roles, user access | **dv-security** |
+
+---
+
+### Scope Management
+
+When updating a skill's scope:
+- **Merge** (default): omit `unlinkScope` or set `false` — new scopes are added to existing
+- **Replace**: set `unlinkScope: true` — existing scopes are replaced with the provided list
+
+---
+
+## Python SDK — CRUD Examples
+
+### Setup
+
+```python
+import os, sys
+sys.path.insert(0, os.path.join(os.getcwd(), "scripts"))
+from auth import get_client
+
+client = get_client("dv-skill")
+```
+
+### List All Skills
+
+```python
+skills = client.records.get("skill", select="name,uniquename,description,body")
+for skill in skills:
+    print(f"{skill['name']} ({skill['uniquename']})")
+```
+
+### Create a Skill
+
+```python
+client.records.create("skill", {
+    "name": "My-Skill-Name",
+    "uniquename": "new_myskillname",
+    "description": "Short description of what this skill does",
+    "body": "Full instruction content..."
+})
+```
+
+### Update a Skill by ID
+
+```python
+skill_id = "00000000-0000-0000-0000-000000000000"  # replace with actual GUID
+client.records.update("skill", skill_id, {
+    "description": "Updated description",
+    "body": "Updated instruction content..."
+})
+```
+
+### Delete a Skill by ID
+
+```python
+skill_id = "00000000-0000-0000-0000-000000000000"  # replace with actual GUID
+client.records.delete("skill", skill_id)
+```
+
+### Bulk Upsert Skills from a List
+
+```python
+skills_to_load = [
+    {"name": "Skill-A", "uniquename": "new_skilla", "description": "Desc A", "body": "Instructions A"},
+    {"name": "Skill-B", "uniquename": "new_skillb", "description": "Desc B", "body": "Instructions B"},
+]
+
+for skill in skills_to_load:
+    existing = client.records.get("skill", filter=f"uniquename eq '{skill['uniquename']}'")
+    if existing:
+        client.records.update("skill", existing[0]["skillid"], skill)
+        print(f"{skill['name']}: updated")
+    else:
+        client.records.create("skill", skill)
+        print(f"{skill['name']}: created")
+```
+
+---
+
+## Skill Resources — File Attachments
+
+Skills can have attached resource files (markdown docs, templates, reference material) stored on the `skillresource` table.
+
+### List Resources for a Skill
+
+```python
+resources = client.records.get(
+    "skillresource",
+    filter=f"_skillid_value eq '{skill_id}'",
+    select="name,filecontent"
+)
+for r in resources:
+    print(r["name"])
+```
+
+### Upload a Resource File
+
+Use the SDK file column upload for the `filecontent` attribute on `skillresource`:
+
+```python
+# Create the resource record first
+resource_id = client.records.create("skillresource", {
+    "name": "myfile.md",
+    "skillid@odata.bind": f"skills({skill_id})"
+})
+
+# Upload file content to the file column
+client.records.upload_file("skillresource", resource_id, "filecontent", "myfile.md")
+```
+
+### Download a Resource File
+
+```python
+client.records.download_file("skillresource", resource_id, "filecontent", "downloaded.md")
+```
+
+---
+
+## Consult Helper — Mandatory Skill Consumption for Python SDK
+
+The Python SDK path **must** consult Business Skills before executing any operation. This ensures domain awareness regardless of which surface handles the request.
+
+### Rule: Always Consult Before Executing
+
+**Before generating or running any Python SDK code, query Dataverse for relevant Business Skills.** Extract keywords from the user's request (table names, domain terms, action verbs) and search for matching skills. If matching skills are found, incorporate their `body` as domain context. If no skills match, proceed normally.
+
+Finding no matching skills is fine — skipping the check is not.
+
+| Step | Action |
+|---|---|
+| 1 | Extract keywords from the user's request |
+| 2 | Query skill table via `client.records.get('skill', ...)` |
+| 3 | If results found → read `body` and incorporate as context |
+| 4 | If no results → proceed with standard SDK code |
+| 5 | Generate/run the Python operation guided by any retrieved instructions |
+
+### Consult via Python
+
+```python
+import os, sys
+sys.path.insert(0, os.path.join(os.getcwd(), "scripts"))
+from auth import get_client
+
+client = get_client("dv-skill")
+
+def consult_skills(client, keywords):
+    """Fetch Business Skills matching any of the given keywords.
+    Returns a list of {name, body} dicts with domain instructions."""
+    filter_clauses = " or ".join(
+        f"contains(name,'{kw}')" for kw in keywords
+    )
+    results = client.records.get("skill", select="name,body", filter=filter_clauses)
+    return [{"name": s["name"], "body": s["body"]} for s in results]
+```
+
+### End-to-End Example — SDK with Skill Consultation
+
+```python
+import os, sys
+sys.path.insert(0, os.path.join(os.getcwd(), "scripts"))
+from auth import get_client
+
+client = get_client("dv-skill")
+
+# Step 1: Consult — fetch domain instructions
+skills = client.records.get("skill", select="name,body", filter="contains(name,'Refund')")
+
+# Step 2: Display retrieved skill instructions for agent context
+for skill in skills:
+    print(f"--- Skill: {skill['name']} ---")
+    print(skill["body"])
+```
+
+After retrieving the skill instructions, the agent incorporates them as context before generating the SDK code for the actual operation (e.g., creating records, running queries).

--- a/.gitignore
+++ b/.gitignore
@@ -421,3 +421,15 @@ FodyWeavers.xsd
 *.snk
 solutions/*.zip
 .claude/mcp_settings.json
+
+.vscode/settings.json
+plugins/**/bin/
+plugins/**/obj/
+
+# Local-only artifacts from running evals against a personal Dataverse org
+.mcp.json
+.env
+scripts/
+evals/*.py
+evals/results/
+

--- a/evals/tests/dv_data.biceval.json
+++ b/evals/tests/dv_data.biceval.json
@@ -1,7 +1,7 @@
 {
   "group": "DataverseSkills",
   "scenarioName": "Data",
-  "description": "Verifies SDK patterns for record creation in Dataverse tables.",
+  "description": "Ablation tests for the dv-data skill. Each test measures whether loading the skill produces measurably better answers than baseline (no skill). Focus: bulk patterns and SDK routing that a naive model gets wrong.",
   "enabled_evaluators": [
     {
       "name": "CortexConfigurations:Common/Skills/correctness.prompty",
@@ -11,56 +11,167 @@
   ],
   "tests": [
     {
-      "test_id": "data_001",
-      "prompt": "Write a Python script that creates a single ticket record in my Dataverse new_ticket table with a title and priority field.",
-      "expected_response": "Agent uses Python SDK pattern: DataverseClient + client.records.create('new_ticket', {dict}). Single-record create.",
-      "category": "data",
-      "description": "Single-record create via SDK on Dataverse table",
+      "test_id": "data_001_bulk_create",
+      "prompt": "Efficiently create 500 ticket records in my Dataverse new_ticket table. Each ticket should have a unique title and a priority value. Optimize for the fewest HTTP calls.",
+      "expected_response": "Agent uses bulk create via CreateMultiple — one HTTP call per chunk, NOT a per-record for-loop.",
+      "category": "ablation-bulk",
+      "description": "Ablation: Without dv-data, models default to per-record loops. With dv-data, agent uses list-arg CreateMultiple.",
       "priority": 1,
-      "tags": {"Suite": "Regression", "Domain": "Data", "Skill": "dv-data"},
-      "custom_metadata": {"skill": "dv-data", "tool_routing": "SDK"},
+      "tags": {"Suite": "Ablation", "Domain": "Data", "Skill": "dv-data", "Type": "bulk"},
+      "custom_metadata": {
+        "skill": "dv-data",
+        "tool_routing": "SDK",
+        "ablation_hypothesis": "Without dv-data skill, the model defaults to a per-record for-loop (common LLM pattern for Dataverse). With dv-data loaded, the skill teaches passing a list to client.records.create which uses CreateMultiple internally.",
+        "baseline_expected": "Agent writes a for-loop calling client.records.create(table, single_dict) 500 times, or uses raw HTTP POST per record. 500 HTTP round-trips.",
+        "treatment_expected": "Agent passes a list to client.records.create(table, list_of_dicts). SDK sends one CreateMultiple POST. Agent may chunk for large payloads."
+      },
       "assertions": [
-        "PRIORITY_1: Agent uses the official Python SDK for the create. Hand-rolled urllib/requests POST is NOT acceptable.",
-        "PRIORITY_1: Agent calls client.records.create with the table name and a record dict.",
-        "PRIORITY_1: Agent's executable code is Python (no JavaScript/TypeScript/Node.js or PowerShell).",
-        "PRIORITY_2: CONTAINS: new_ticket",
-        "PRIORITY_2: SKILL_LOADED: dv-data"
-      ]
-    },
-    {
-      "test_id": "data_002_bulk_create",
-      "prompt": "Write a Python script that efficiently creates 500 ticket records in my Dataverse new_ticket table. Each ticket should have a unique title and a priority value. Optimize for the fewest HTTP calls.",
-      "expected_response": "Agent uses Python SDK bulk create via CreateMultiple — one HTTP call per chunk, NOT a per-record for-loop.",
-      "category": "data",
-      "description": "Bulk-create 500 records — must use list-arg / CreateMultiple, not per-record loop.",
-      "priority": 1,
-      "tags": {"Suite": "Regression", "Domain": "Data", "Skill": "dv-data", "Type": "bulk"},
-      "custom_metadata": {"skill": "dv-data", "tool_routing": "SDK", "trap": "per-record loop antipattern"},
-      "assertions": [
-        "PRIORITY_1: Agent uses the bulk/list form of client.records.create — passes a Python list as the records argument. Per-record for-loops must FAIL.",
-        "PRIORITY_1: CONTAINS: new_ticket",
+        "PRIORITY_1: Agent uses the bulk/list form of client.records.create — passes a list as the records argument. Per-record for-loops must FAIL.",
+        "PRIORITY_1: NOT_CONTAINS: for record in records",
         "PRIORITY_1: NOT_CONTAINS: There is no batch API",
         "PRIORITY_1: NOT_CONTAINS: one HTTP call per record",
-        "PRIORITY_1: NOT_CONTAINS: no chunking helper",
-        "PRIORITY_2: Agent mentions CreateMultiple, batch semantics, or bulk_create helpers from the dv-data skill.",
+        "PRIORITY_2: Agent mentions CreateMultiple, batch semantics, chunking, or adaptive chunk_size.",
         "PRIORITY_2: SKILL_LOADED: dv-data"
       ]
     },
     {
-      "test_id": "data_003_skill_contract",
-      "prompt": "Before writing any code, tell me exactly what the dv-data skill says about creating multiple records. Quote or closely paraphrase the specific method calls, patterns, and helpers it documents for bulk operations. Do not use your own knowledge — only report what the loaded skill teaches.",
-      "expected_response": "Agent reports skill content: CreateMultiple, bulk_create helper, list-arg to client.records.create, adaptive chunking. A regressed skill would instead teach per-record loops.",
-      "category": "data",
-      "description": "Skill-contract test — agent must report what the skill ACTUALLY teaches, not generate code from prior knowledge.",
+      "test_id": "data_002_sdk_routing",
+      "prompt": "Create a contact record in Dataverse with firstname, lastname, and emailaddress1 fields.",
+      "expected_response": "Agent uses the official SDK (get_client + client.records.create) or MCP create_record — not urllib/requests. Either path is valid; raw HTTP is not.",
+      "category": "ablation-routing",
+      "description": "Ablation: Without dv-data, models use urllib/requests for Dataverse writes. With dv-data, agent uses official SDK for scripted operations.",
       "priority": 1,
-      "tags": {"Suite": "Regression", "Domain": "Data", "Skill": "dv-data", "Type": "skill-contract"},
-      "custom_metadata": {"skill": "dv-data", "test_kind": "skill-contract", "trap": "agent echoes regressed skill content verbatim"},
+      "tags": {"Suite": "Ablation", "Domain": "Data", "Skill": "dv-data", "Type": "routing"},
+      "custom_metadata": {
+        "skill": "dv-data",
+        "tool_routing": "SDK-or-MCP",
+        "ablation_hypothesis": "Without dv-data skill, models commonly generate urllib.request or requests-based Dataverse code (the pattern found in most web tutorials). With dv-data loaded, the SDK-First Rule enforces client.records.create for scripted operations, or MCP for simple <=10 record tasks.",
+        "baseline_expected": "Agent writes raw HTTP POST to /api/data/v9.2/contacts using urllib.request or requests library with manual token handling.",
+        "treatment_expected": "Agent uses SDK (get_client + client.records.create) when a script is requested, OR MCP create_record when no script is needed. Either is correct — raw HTTP is not."
+      },
+      "assertions": [
+        "PRIORITY_1: Agent does NOT use urllib.request or requests library for a simple record create. Uses either SDK client.records.create OR MCP create_record tool.",
+        "PRIORITY_1: NOT_CONTAINS: urllib.request",
+        "PRIORITY_1: NOT_CONTAINS: requests.post",
+        "PRIORITY_1: NOT_CONTAINS: requests.patch",
+        "PRIORITY_2: If agent writes a script, it uses get_client from the auth module (documented SDK pattern).",
+        "PRIORITY_2: SKILL_LOADED: dv-data"
+      ]
+    },
+    {
+      "test_id": "data_003_chunking_awareness",
+      "prompt": "Import 50,000 records from a large CSV file into my Dataverse new_order table. The CSV has columns: order_id, customer_name, total_amount, order_date.",
+      "expected_response": "Agent chunks the records (starting at ~1000 per batch) and iterates with client.records.create per chunk. Does NOT attempt to send all 50K in a single call.",
+      "category": "ablation-chunking",
+      "description": "Ablation: Without dv-data, models send all records in one call (timeout) or fall back to per-record loops. With dv-data, agent applies adaptive chunking.",
+      "priority": 1,
+      "tags": {"Suite": "Ablation", "Domain": "Data", "Skill": "dv-data", "Type": "bulk"},
+      "custom_metadata": {
+        "skill": "dv-data",
+        "tool_routing": "SDK",
+        "ablation_hypothesis": "Without dv-data skill, models either (a) attempt to send all 50K records in one API call (causing timeout) or (b) fall back to per-record loops. With dv-data loaded, the skill teaches that the SDK does NOT chunk automatically and that scripts must chunk manually starting at 1000.",
+        "baseline_expected": "Agent either sends all 50K in one call (timeout/payload failure) or uses a per-record loop (50K HTTP calls). No mention of chunking strategy.",
+        "treatment_expected": "Agent implements explicit chunking (chunk_size starting at ~1000), iterates chunks with client.records.create(table, chunk). May mention adaptive sizing or timeout constraints."
+      },
+      "assertions": [
+        "PRIORITY_1: Agent implements explicit chunking logic — splits records into batches before calling client.records.create. Evidence: a loop over chunks (e.g., range(0, len(records), chunk_size) or similar).",
+        "PRIORITY_1: NOT_CONTAINS: There is no batch API",
+        "PRIORITY_1: Agent does NOT attempt to send all 50,000 records in a single unbounded call without chunking.",
+        "PRIORITY_2: Agent uses a chunk size in the range 500-4000 (matching skill guidance of starting at 1000).",
+        "PRIORITY_2: SKILL_LOADED: dv-data"
+      ]
+    },
+    {
+      "test_id": "data_004_skill_contract",
+      "prompt": "Before writing any code, tell me exactly what the dv-data skill says about creating multiple records. Quote or closely paraphrase the specific method calls, patterns, and helpers it documents for bulk operations. Do not use your own knowledge — only report what the loaded skill teaches.",
+      "expected_response": "Agent reports skill content: CreateMultiple, list-arg to client.records.create, adaptive chunking (start 1000, double on success, halve on failure). A model without the skill cannot answer this accurately.",
+      "category": "ablation-contract",
+      "description": "Ablation: Without dv-data loaded, agent cannot report skill-specific content and will hallucinate or refuse. With dv-data, agent accurately reports the bulk patterns.",
+      "priority": 1,
+      "tags": {"Suite": "Ablation", "Domain": "Data", "Skill": "dv-data", "Type": "skill-contract"},
+      "custom_metadata": {
+        "skill": "dv-data",
+        "test_kind": "skill-contract",
+        "ablation_hypothesis": "Without dv-data skill loaded, the agent cannot know what a specific skill document teaches. It will either refuse ('I don't have access to that skill') or hallucinate content. With dv-data loaded, it can accurately report the documented patterns.",
+        "baseline_expected": "Agent says it doesn't have access to the skill content, or halluccinates incorrect patterns (e.g., OData batch requests, per-record loops, $batch endpoint).",
+        "treatment_expected": "Agent accurately reports: list-arg to client.records.create uses CreateMultiple internally, SDK does not chunk automatically, adaptive chunking pattern (start 1000, double/halve), bulk_create/bulk_upsert helpers."
+      },
       "assertions": [
         "PRIORITY_1: SKILL_LOADED: dv-data",
         "PRIORITY_1: NOT_CONTAINS: per-record operations only",
         "PRIORITY_1: NOT_CONTAINS: one HTTP call per record",
         "PRIORITY_1: Agent's summary mentions bulk/batch SDK methods (CreateMultiple, UpdateMultiple, or UpsertMultiple) OR bulk helpers (bulk_create, bulk_upsert) OR passing a list to client.records.create. If the agent says the skill recommends per-record loops or says there is no batch API, this FAILS.",
-        "PRIORITY_2: CONTAINS: CreateMultiple"
+        "PRIORITY_2: CONTAINS: CreateMultiple",
+        "PRIORITY_2: Agent mentions adaptive chunking or chunk_size starting at 1000."
+      ]
+    },
+    {
+      "test_id": "data_005_mcp_routing",
+      "prompt": "Create a single account record in Dataverse with the name 'Contoso Ltd' and the phone number '555-0100'.",
+      "expected_response": "Agent uses the MCP create_record tool directly — no script. Single record, simple fields, MCP is the correct path.",
+      "category": "ablation-mcp",
+      "description": "Ablation: Without dv-data, agent writes a full Python script for 1 record. With dv-data, agent uses MCP tool directly (no script needed).",
+      "priority": 1,
+      "tags": {"Suite": "Ablation", "Domain": "Data", "Skill": "dv-data", "Type": "mcp-routing"},
+      "custom_metadata": {
+        "skill": "dv-data",
+        "tool_routing": "MCP",
+        "ablation_hypothesis": "Without dv-data skill, the agent defaults to writing a Python script (sys.path.insert, get_client, client.records.create) even for a single record. With dv-data loaded, the 'Check MCP First' rule directs: if MCP tools are available and task is <=10 records, use MCP directly — no script needed.",
+        "baseline_expected": "Agent writes a full Python script: import os/sys, sys.path.insert, from auth import get_client, client.records.create('account', {...}). Unnecessary overhead for 1 record.",
+        "treatment_expected": "Agent calls the MCP create_record tool directly with tablename='account' and item={'name': 'Contoso Ltd', 'telephone1': '555-0100'}. No Python script generated."
+      },
+      "assertions": [
+        "PRIORITY_1: Agent uses MCP create_record tool (or equivalent MCP tool call) instead of writing a script. If agent generates a full script with sys.path.insert and get_client for a single record, this FAILS.",
+        "PRIORITY_1: CONTAINS: Contoso",
+        "PRIORITY_1: NOT_CONTAINS: sys.path.insert",
+        "PRIORITY_2: SKILL_LOADED: dv-data",
+        "PRIORITY_2: Agent does not generate unnecessary boilerplate (import os, from auth import) for this simple operation."
+      ]
+    },
+    {
+      "test_id": "data_006_mcp_boundary",
+      "prompt": "Create 5 contact records in Dataverse: John Smith, Jane Doe, Bob Johnson, Alice Williams, and Charlie Brown. Each should have a firstname and lastname.",
+      "expected_response": "Agent uses MCP create_record tool 5 times (one per contact) — still within the <=10 record MCP threshold. Does NOT write a script for 5 simple sequential creates.",
+      "category": "ablation-mcp",
+      "description": "Ablation: Without dv-data, agent writes a script with a loop. With dv-data, agent uses sequential MCP calls for <=10 records.",
+      "priority": 1,
+      "tags": {"Suite": "Ablation", "Domain": "Data", "Skill": "dv-data", "Type": "mcp-routing"},
+      "custom_metadata": {
+        "skill": "dv-data",
+        "tool_routing": "MCP",
+        "ablation_hypothesis": "Without dv-data skill, the agent sees 5 records and writes a Python script with a list and client.records.create. With dv-data loaded, the skill states MCP for 1-10 records and clarifies 'Sequential MCP tool calls are not multi-step logic — use MCP for those.' The agent makes 5 MCP calls instead.",
+        "baseline_expected": "Agent writes a Python script: defines a list of 5 dicts, calls client.records.create('contact', records). Treats it as a bulk operation requiring a script.",
+        "treatment_expected": "Agent makes 5 sequential MCP create_record calls, one per contact. No Python script. Recognizes this is within the MCP threshold."
+      },
+      "assertions": [
+        "PRIORITY_1: Agent uses MCP create_record tool for each contact (5 calls) OR uses MCP in a loop. Does NOT write a standalone script with sys.path.insert for only 5 records.",
+        "PRIORITY_1: NOT_CONTAINS: sys.path.insert",
+        "PRIORITY_1: NOT_CONTAINS: get_client",
+        "PRIORITY_2: SKILL_LOADED: dv-data",
+        "PRIORITY_2: All 5 contacts are created (John Smith, Jane Doe, Bob Johnson, Alice Williams, Charlie Brown)."
+      ]
+    },
+    {
+      "test_id": "data_007_webapi_fallback",
+      "prompt": "Associate an existing contact record with an existing account record using a many-to-many relationship (N:N) in Dataverse. The relationship is called 'new_account_contact'.",
+      "expected_response": "Agent uses raw Web API (get_token + urllib.request) with POST to /$ref endpoint. Does NOT attempt to use the SDK for N:N association — the SDK does not support it.",
+      "category": "ablation-webapi",
+      "description": "Ablation: Without dv-data, agent tries SDK for N:N (fails) or guesses wrong endpoint. With dv-data, agent correctly uses raw Web API $ref POST.",
+      "priority": 1,
+      "tags": {"Suite": "Ablation", "Domain": "Data", "Skill": "dv-data", "Type": "webapi-fallback"},
+      "custom_metadata": {
+        "skill": "dv-data",
+        "tool_routing": "WebAPI",
+        "ablation_hypothesis": "Without dv-data skill, the agent either (a) tries to use client.records.create/update for N:N association (which fails — SDK doesn't support it) or (b) guesses a wrong endpoint format. With dv-data loaded, the 'What This SDK Does NOT Support' section explicitly lists N:N record association and provides the correct pattern: POST /api/data/v9.2/<entity>(<id>)/<nav-property>/$ref.",
+        "baseline_expected": "Agent attempts SDK-based approach (client.records.update with @odata.bind, or invents a non-existent client.records.associate method). May also use incorrect URL format for the $ref endpoint.",
+        "treatment_expected": "Agent uses get_token() + urllib.request to POST to /api/data/v9.2/accounts(<id>)/new_account_contact/$ref with the contact @odata.id in the request body. Correctly identifies this as an SDK-unsupported operation requiring raw Web API."
+      },
+      "assertions": [
+        "PRIORITY_1: Agent uses raw Web API with $ref endpoint for the N:N association itself. The association operation must NOT use SDK client.records methods.",
+        "PRIORITY_1: CONTAINS: $ref",
+        "PRIORITY_1: Agent correctly identifies N:N association as outside SDK scope — uses get_token/urllib OR explains why raw Web API is needed.",
+        "PRIORITY_2: SKILL_LOADED: dv-data",
+        "PRIORITY_2: URL pattern includes the navigation property name and /$ref suffix."
       ]
     }
   ]

--- a/evals/tests/dv_skill.biceval.json
+++ b/evals/tests/dv_skill.biceval.json
@@ -1,7 +1,7 @@
 {
   "group": "DataverseSkills",
   "scenarioName": "Skill",
-  "description": "Verifies Business Skill management, consumption parity, and mandatory consult enforcement for the dv-skill skill.",
+  "description": "Ablation tests for the dv-skill skill. Each test measures whether loading dv-skill produces measurably better answers than baseline (no skill). Focus: mandatory consult enforcement and skill-entity awareness that a naive model lacks.",
   "enabled_evaluators": [
     {
       "name": "CortexConfigurations:Common/Skills/correctness.prompty",
@@ -11,100 +11,167 @@
   ],
   "tests": [
     {
-      "test_id": "skill_001_create",
-      "prompt": "Create a Dataverse Business Skill called 'Refund-Handling' with a description 'Guides agents through the refund process' and body containing step-by-step refund instructions.",
-      "expected_response": "Agent uses Python SDK client.records.create('skill', {...}) with name, description, and body fields.",
-      "category": "skill-management",
-      "description": "Create a Business Skill — routes to dv-skill, uses MCP or Web API",
-      "priority": 1,
-      "tags": {"Suite": "Regression", "Domain": "Skill", "Skill": "dv-skill"},
-      "custom_metadata": {"skill": "dv-skill", "tool_routing": "MCP-or-WebAPI"},
-      "assertions": [
-        "PRIORITY_1: SKILL_LOADED: dv-skill",
-        "PRIORITY_1: Agent creates a skill with name 'Refund-Handling'. Must use Python SDK client.records.create('skill', {...}).",
-        "PRIORITY_1: NOT_CONTAINS: urllib.request",
-        "PRIORITY_2: CONTAINS: Refund-Handling"
-      ]
-    },
-    {
-      "test_id": "skill_002_list",
-      "prompt": "List all Business Skills available in my Dataverse environment.",
-      "expected_response": "Agent uses Python SDK client.records.get('skill') to list all skills.",
-      "category": "skill-management",
-      "description": "List all skills — confirms Python Web API path works for listing",
-      "priority": 1,
-      "tags": {"Suite": "Regression", "Domain": "Skill", "Skill": "dv-skill"},
-      "custom_metadata": {"skill": "dv-skill", "tool_routing": "MCP-or-WebAPI"},
-      "assertions": [
-        "PRIORITY_1: SKILL_LOADED: dv-skill",
-        "PRIORITY_1: Agent queries the skill table to list all skills. Uses Python SDK client.records.get('skill'). Raw urllib is NOT acceptable.",
-        "PRIORITY_1: NOT_CONTAINS: urllib.request",
-        "PRIORITY_2: CONTAINS: skill"
-      ]
-    },
-    {
-      "test_id": "skill_003_consult_enforcement",
-      "prompt": "Write a Python script that imports refund records from a CSV into the new_refund table, following our team's refund handling process.",
+      "test_id": "skill_001_consult_domain_task",
+      "prompt": "Import refund records from a CSV into the new_refund table, following our team's refund handling process.",
       "expected_response": "Agent FIRST queries Dataverse Business Skills for relevant domain instructions (e.g., searching for 'refund' skills), THEN generates the SDK import code incorporating any retrieved skill instructions. The consult step must come before the data operation.",
-      "category": "consult-enforcement",
-      "description": "Mandatory consult — agent must query Business Skills before generating SDK code for domain-specific tasks",
+      "category": "ablation-consult",
+      "description": "Ablation: Without dv-skill, agent jumps straight to SDK code. With dv-skill, agent queries Business Skills first for domain context.",
       "priority": 1,
-      "tags": {"Suite": "Regression", "Domain": "Data", "Skill": "dv-data", "Type": "consult"},
-      "custom_metadata": {"skill": "dv-data", "tool_routing": "SDK", "consult_expected": true},
+      "tags": {"Suite": "Ablation", "Domain": "Data", "Skill": "dv-skill", "Type": "consult"},
+      "custom_metadata": {
+        "skill": "dv-skill",
+        "tool_routing": "SDK",
+        "consult_expected": true,
+        "ablation_hypothesis": "Without dv-skill loaded, the agent has no knowledge of the mandatory consult pattern. It will generate a CSV import script directly without checking if the org has Business Skills with domain-specific refund instructions. With dv-skill loaded, the mandatory consult rule forces the agent to query the skill table first.",
+        "baseline_expected": "Agent generates a standard CSV-to-Dataverse import script (read CSV, build records list, call client.records.create). No mention of Business Skills, no skill query step. Domain instructions are ignored.",
+        "treatment_expected": "Agent queries client.records.list('skill', filter=contains(name,'refund')) BEFORE generating import code. If a matching skill is found, its body is incorporated as domain context guiding the import logic."
+      },
       "assertions": [
-        "PRIORITY_1: Agent queries or searches Dataverse Business Skills BEFORE generating the CSV import code. Evidence: Python SDK client.records.get('skill', filter=...). If agent jumps straight to SDK code without consulting skills, this FAILS.",
-        "PRIORITY_1: Agent uses Python SDK (client.records.create with list arg or CreateMultiple) for the actual data import — not urllib for the import itself.",
-        "PRIORITY_2: SKILL_LOADED: dv-data",
+        "PRIORITY_1: Agent queries or searches Dataverse Business Skills BEFORE generating the import code. Evidence: MCP search/describe/read_query for skills, OR SDK client.records.list('skill', ...). Any path that checks skills first is valid.",
+        "PRIORITY_1: Agent uses an appropriate method for the bulk data import — SDK client.records.create with list arg for 10+ records, or MCP create_record for <=10 records. Per-record urllib loops FAIL.",
+        "PRIORITY_2: SKILL_LOADED: dv-skill",
         "PRIORITY_2: CONTAINS: refund"
       ]
     },
     {
-      "test_id": "skill_004_consult_skip_generic",
-      "prompt": "Write a Python script that creates 100 generic test accounts in my Dataverse account table with random names.",
-      "expected_response": "Agent still consults Business Skills (mandatory rule), but finding no relevant skills, proceeds directly with SDK bulk create. The consult check happens but does not block execution when no skills match.",
-      "category": "consult-enforcement",
-      "description": "Mandatory consult fires even for generic tasks — finding nothing is fine, skipping the check is not",
+      "test_id": "skill_002_consult_generic_task",
+      "prompt": "Create 100 generic test accounts in my Dataverse account table with random names.",
+      "expected_response": "Agent still consults Business Skills (mandatory rule), but finding no relevant skills, proceeds directly with SDK bulk create. The consult check happens regardless of whether the task seems domain-specific.",
+      "category": "ablation-consult",
+      "description": "Ablation: Without dv-skill, agent never consults skills for generic tasks. With dv-skill, mandatory consult fires even when no match is expected.",
       "priority": 1,
-      "tags": {"Suite": "Regression", "Domain": "Data", "Skill": "dv-data", "Type": "consult"},
-      "custom_metadata": {"skill": "dv-data", "tool_routing": "SDK", "consult_expected": true},
+      "tags": {"Suite": "Ablation", "Domain": "Data", "Skill": "dv-skill", "Type": "consult"},
+      "custom_metadata": {
+        "skill": "dv-skill",
+        "tool_routing": "SDK",
+        "consult_expected": true,
+        "ablation_hypothesis": "Without dv-skill, the agent sees no reason to query Business Skills for a generic 'create test accounts' task — it will jump straight to SDK code. With dv-skill loaded, the mandatory rule says 'Finding no matching skills is fine — skipping the check is not.' The agent must still perform the consult step.",
+        "baseline_expected": "Agent generates bulk account creation code immediately. No mention of Business Skills or skill consultation. Goes straight to client.records.create('account', records).",
+        "treatment_expected": "Agent queries skill table (e.g., filter on 'account' keywords), finds no matches, explicitly states no relevant skills found, then proceeds with bulk create. The consult step is visible in the output even though it yielded no results."
+      },
       "assertions": [
-        "PRIORITY_1: Agent queries or acknowledges checking Business Skills before generating the bulk create code. Evidence: Python SDK client.records.get('skill', ...), or explicit statement that skills were checked. If no mention of skill consultation at all, this FAILS.",
-        "PRIORITY_1: Agent uses bulk SDK pattern (list arg to client.records.create or CreateMultiple) for the 100 accounts. Per-record loops FAIL.",
+        "PRIORITY_1: Agent queries or acknowledges checking Business Skills before generating the bulk create code. Evidence: MCP search/describe/read_query, OR SDK client.records.list('skill', ...), OR explicit statement that skills were checked. Any path that performs the consult is valid.",
+        "PRIORITY_1: Agent uses a bulk-appropriate method for 100 records — SDK list-arg (CreateMultiple) or equivalent batch operation. Per-record loops or 100 individual MCP calls FAIL.",
         "PRIORITY_1: NOT_CONTAINS: There is no batch API",
-        "PRIORITY_2: SKILL_LOADED: dv-data"
+        "PRIORITY_2: SKILL_LOADED: dv-skill",
+        "PRIORITY_2: Agent explicitly states no matching skills were found before proceeding."
       ]
     },
     {
-      "test_id": "skill_005_delete",
-      "prompt": "Delete the Business Skill named 'Old-Process' from my Dataverse environment.",
-      "expected_response": "Agent uses Python SDK client.records.delete('skill', id). Must first look up the skill by name to get the ID, then delete.",
-      "category": "skill-management",
-      "description": "Delete a skill — confirms routing and correct API usage",
+      "test_id": "skill_003_skill_entity_awareness",
+      "prompt": "I need to store our team's process documentation in Dataverse so our AI agents can reference it at runtime. How should I structure this?",
+      "expected_response": "Agent recommends the Business Skills entity (skill table) with name, description, body fields, and optionally skillresource attachments. Does NOT suggest creating a custom table or using SharePoint.",
+      "category": "ablation-awareness",
+      "description": "Ablation: Without dv-skill, agent suggests custom tables or external storage. With dv-skill, agent knows about the native skill entity purpose-built for this.",
       "priority": 1,
-      "tags": {"Suite": "Regression", "Domain": "Skill", "Skill": "dv-skill"},
-      "custom_metadata": {"skill": "dv-skill", "tool_routing": "MCP-or-WebAPI"},
+      "tags": {"Suite": "Ablation", "Domain": "Skill", "Skill": "dv-skill", "Type": "awareness"},
+      "custom_metadata": {
+        "skill": "dv-skill",
+        "tool_routing": "SDK",
+        "ablation_hypothesis": "Without dv-skill, the agent has no knowledge of the Dataverse Business Skills entity. It will suggest creating a custom table (e.g., new_process_doc) or using SharePoint/Blob storage for process documentation. With dv-skill loaded, the agent knows the skill entity exists specifically for storing domain instructions that AI agents consume at runtime.",
+        "baseline_expected": "Agent suggests creating a custom table (new_documentation or similar), or recommends SharePoint, Blob Storage, or Dataverse Notes for storing documentation. No mention of the native skill entity.",
+        "treatment_expected": "Agent recommends the skill entity with its purpose-built fields (name, description, body) and explains that Business Skills are designed for AI agent consumption. May mention skillresource for file attachments."
+      },
       "assertions": [
-        "PRIORITY_1: SKILL_LOADED: dv-skill",
-        "PRIORITY_1: Agent deletes the skill using Python SDK client.records.delete('skill', id). Raw urllib is NOT acceptable.",
-        "PRIORITY_1: NOT_CONTAINS: urllib.request",
-        "PRIORITY_2: CONTAINS: Old-Process"
+        "PRIORITY_1: Agent recommends the 'skill' entity (Business Skills) for storing process documentation. NOT a custom table or external storage.",
+        "PRIORITY_1: CONTAINS: skill",
+        "PRIORITY_1: Agent explains that the skill entity has name, description, and body fields suitable for AI agent consumption.",
+        "PRIORITY_2: SKILL_LOADED: dv-skill",
+        "PRIORITY_2: Agent mentions skillresource for attaching additional files or templates."
       ]
     },
     {
-      "test_id": "skill_006_skill_contract",
-      "prompt": "Before writing any code, tell me exactly what the dv-skill skill says about consuming Business Skills when using the Python SDK. Quote or closely paraphrase the mandatory consult rule. Do not use your own knowledge — only report what the loaded skill teaches.",
-      "expected_response": "Agent reports skill content: mandatory consultation before any Python SDK operation, always query skills entity, extract keywords, incorporate body as context. Agent must NOT say consultation is optional or only for domain-specific tasks.",
-      "category": "skill-contract",
-      "description": "Skill-contract test — agent must report mandatory consult rule accurately",
+      "test_id": "skill_004_consult_sequence",
+      "prompt": "Process new support cases in my Dataverse incident table. For each open case, update the priority based on our team's escalation rules.",
+      "expected_response": "Agent queries Business Skills for escalation/priority/support keywords FIRST to discover org-specific rules, then generates the update logic incorporating those rules. Without the consult, agent would hardcode generic escalation logic.",
+      "category": "ablation-consult",
+      "description": "Ablation: Without dv-skill, agent invents escalation rules. With dv-skill, agent discovers org-specific rules from Business Skills before generating logic.",
       "priority": 1,
-      "tags": {"Suite": "Regression", "Domain": "Skill", "Skill": "dv-skill", "Type": "skill-contract"},
-      "custom_metadata": {"skill": "dv-skill", "test_kind": "skill-contract"},
+      "tags": {"Suite": "Ablation", "Domain": "Data", "Skill": "dv-skill", "Type": "consult"},
+      "custom_metadata": {
+        "skill": "dv-skill",
+        "tool_routing": "SDK",
+        "consult_expected": true,
+        "ablation_hypothesis": "Without dv-skill, the agent will invent generic escalation rules (e.g., 'if SLA breached, set priority to High'). With dv-skill loaded, the mandatory consult forces the agent to query Business Skills for org-specific escalation rules before generating any logic. The agent discovers real rules rather than hallucinating them.",
+        "baseline_expected": "Agent hardcodes generic escalation logic (e.g., time-based priority bumps, keyword matching). Rules are invented by the model, not sourced from the org's Dataverse.",
+        "treatment_expected": "Agent queries skill table for keywords like 'escalation', 'priority', 'support', 'incident'. If skills exist, their body content drives the update logic. If none exist, agent asks the user for rules rather than inventing them."
+      },
+      "assertions": [
+        "PRIORITY_1: Agent queries Business Skills BEFORE writing the update logic. Evidence: MCP search/describe for skills, OR SDK client.records.list('skill', ...), OR read_query on skill table. Any path that checks for domain rules is valid.",
+        "PRIORITY_1: Agent does NOT invent escalation rules from scratch without first consulting Business Skills.",
+        "PRIORITY_2: SKILL_LOADED: dv-skill",
+        "PRIORITY_2: Agent uses keywords like 'escalation', 'priority', 'support', or 'incident' in the skill query."
+      ]
+    },
+    {
+      "test_id": "skill_005_skill_contract",
+      "prompt": "Before writing any code, tell me exactly what the dv-skill skill says about consuming Business Skills before performing Dataverse operations. Quote or closely paraphrase the mandatory consult rule. Do not use your own knowledge — only report what the loaded skill teaches.",
+      "expected_response": "Agent reports skill content: mandatory consultation before any Dataverse operation (SDK or otherwise), always query skills entity, extract keywords, incorporate body as context. Agent must NOT say consultation is optional.",
+      "category": "ablation-contract",
+      "description": "Ablation: Without dv-skill loaded, agent cannot report the mandatory consult rule. With dv-skill, agent accurately quotes the rule and step sequence.",
+      "priority": 1,
+      "tags": {"Suite": "Ablation", "Domain": "Skill", "Skill": "dv-skill", "Type": "skill-contract"},
+      "custom_metadata": {
+        "skill": "dv-skill",
+        "test_kind": "skill-contract",
+        "ablation_hypothesis": "Without dv-skill loaded, the agent has no knowledge of the mandatory consult rule. It will either refuse to answer ('I don't have access to that skill') or hallucinate a plausible-sounding but incorrect rule. With dv-skill loaded, it can accurately report the documented mandatory consultation pattern.",
+        "baseline_expected": "Agent says it doesn't have access to the dv-skill content, or invents a plausible but incorrect description (e.g., 'skills are optional references' or 'consult only for complex tasks').",
+        "treatment_expected": "Agent accurately states: consultation is MANDATORY before any Dataverse operation, step sequence is extract keywords -> query skill table -> incorporate body -> proceed. 'Finding no matching skills is fine — skipping the check is not.'"
+      },
       "assertions": [
         "PRIORITY_1: SKILL_LOADED: dv-skill",
         "PRIORITY_1: Agent states that skill consultation is MANDATORY (not optional, not just recommended). If agent says 'optional' or 'only when domain-specific', this FAILS.",
         "PRIORITY_1: NOT_CONTAINS: optional",
         "PRIORITY_1: NOT_CONTAINS: only for domain-specific",
-        "PRIORITY_2: Agent mentions the step sequence: extract keywords → query skills → incorporate body → proceed with SDK code."
+        "PRIORITY_2: Agent mentions the step sequence: extract keywords, query skills, incorporate body, proceed with the operation.",
+        "PRIORITY_2: CONTAINS: mandatory"
+      ]
+    },
+    {
+      "test_id": "skill_006_mcp_crud",
+      "prompt": "Create a Business Skill in my Dataverse environment called 'Onboarding-Checklist' with description 'New hire onboarding steps' and a body listing the first-week tasks.",
+      "expected_response": "Agent uses the MCP upsert_skill tool directly to create the skill. Single record, simple CRUD — MCP is the correct path per the skill's MCP-first rule.",
+      "category": "ablation-mcp",
+      "description": "Ablation: Without dv-skill, agent writes a full Python script for skill CRUD. With dv-skill + MCP available, agent uses the MCP upsert_skill tool directly.",
+      "priority": 1,
+      "tags": {"Suite": "Ablation", "Domain": "Skill", "Skill": "dv-skill", "Type": "mcp-routing"},
+      "custom_metadata": {
+        "skill": "dv-skill",
+        "tool_routing": "MCP",
+        "ablation_hypothesis": "Without dv-skill loaded, the agent has no guidance on MCP-vs-SDK routing for skill records. It defaults to writing a Python script (get_client, client.records.create('skill', {...})). With dv-skill loaded and MCP tools available (upsert_skill), the agent recognizes this as a single-record operation and uses MCP directly — no script overhead.",
+        "baseline_expected": "Agent writes a Python script: sys.path.insert, from auth import get_client, client.records.create('skill', {name, description, body}). Full boilerplate for a single record create.",
+        "treatment_expected": "Agent calls the MCP upsert_skill tool with name='Onboarding-Checklist', description='New hire onboarding steps', and body containing first-week tasks. No Python script generated."
+      },
+      "assertions": [
+        "PRIORITY_1: Agent uses MCP upsert_skill tool (or equivalent MCP tool call) to create the skill. If agent writes a full script with sys.path.insert and get_client for this single skill creation, this FAILS.",
+        "PRIORITY_1: CONTAINS: Onboarding-Checklist",
+        "PRIORITY_1: NOT_CONTAINS: sys.path.insert",
+        "PRIORITY_2: SKILL_LOADED: dv-skill",
+        "PRIORITY_2: Agent does not generate unnecessary boilerplate for a single-record MCP operation."
+      ]
+    },
+    {
+      "test_id": "skill_007_webapi_resource_upload",
+      "prompt": "Upload a markdown file called 'escalation-matrix.md' as a resource attachment to the Business Skill named 'Support-Triage' in my Dataverse environment.",
+      "expected_response": "Agent uses the SDK file upload pattern (client.records.upload_file on skillresource table) or MCP init_file_upload/commit_file_upload flow. Correctly identifies skillresource as the target table with filecontent as the file column.",
+      "category": "ablation-webapi",
+      "description": "Ablation: Without dv-skill, agent doesn't know about skillresource table or file upload pattern. With dv-skill, agent uses the documented file attachment workflow.",
+      "priority": 1,
+      "tags": {"Suite": "Ablation", "Domain": "Skill", "Skill": "dv-skill", "Type": "file-upload"},
+      "custom_metadata": {
+        "skill": "dv-skill",
+        "tool_routing": "SDK-or-MCP",
+        "ablation_hypothesis": "Without dv-skill, the agent has no knowledge of the skillresource entity or its file upload pattern. It might try to store file content in the skill body field, create a custom entity, or use a Note attachment. With dv-skill loaded, the agent knows the documented flow: create skillresource record linked to the skill, then upload file content to the 'filecontent' column via SDK upload_file or MCP init_file_upload + commit_file_upload.",
+        "baseline_expected": "Agent either (a) tries to stuff markdown content into the skill body field, (b) creates a Note/Annotation attachment, (c) suggests SharePoint, or (d) doesn't know how to attach files to skills.",
+        "treatment_expected": "Agent creates a skillresource record with skillid@odata.bind pointing to the Support-Triage skill, then uploads the file via client.records.upload_file('skillresource', resource_id, 'filecontent', 'escalation-matrix.md') or uses MCP init_file_upload + commit_file_upload."
+      },
+      "assertions": [
+        "PRIORITY_1: Agent targets the 'skillresource' table (not annotation, note, or a custom table) for the file attachment.",
+        "PRIORITY_1: CONTAINS: skillresource",
+        "PRIORITY_1: CONTAINS: filecontent",
+        "PRIORITY_1: Agent links the resource to the parent skill via skillid@odata.bind or equivalent lookup binding.",
+        "PRIORITY_2: SKILL_LOADED: dv-skill",
+        "PRIORITY_2: Agent uses either SDK upload_file or MCP init_file_upload/commit_file_upload flow for the actual file content."
       ]
     }
   ]

--- a/evals/tests/dv_skill.biceval.json
+++ b/evals/tests/dv_skill.biceval.json
@@ -1,0 +1,111 @@
+{
+  "group": "DataverseSkills",
+  "scenarioName": "Skill",
+  "description": "Verifies Business Skill management, consumption parity, and mandatory consult enforcement for the dv-skill skill.",
+  "enabled_evaluators": [
+    {
+      "name": "CortexConfigurations:Common/Skills/correctness.prompty",
+      "passing_score": 3,
+      "priority": 1
+    }
+  ],
+  "tests": [
+    {
+      "test_id": "skill_001_create",
+      "prompt": "Create a Dataverse Business Skill called 'Refund-Handling' with a description 'Guides agents through the refund process' and body containing step-by-step refund instructions.",
+      "expected_response": "Agent uses Python SDK client.records.create('skill', {...}) with name, description, and body fields.",
+      "category": "skill-management",
+      "description": "Create a Business Skill — routes to dv-skill, uses MCP or Web API",
+      "priority": 1,
+      "tags": {"Suite": "Regression", "Domain": "Skill", "Skill": "dv-skill"},
+      "custom_metadata": {"skill": "dv-skill", "tool_routing": "MCP-or-WebAPI"},
+      "assertions": [
+        "PRIORITY_1: SKILL_LOADED: dv-skill",
+        "PRIORITY_1: Agent creates a skill with name 'Refund-Handling'. Must use Python SDK client.records.create('skill', {...}).",
+        "PRIORITY_1: NOT_CONTAINS: urllib.request",
+        "PRIORITY_2: CONTAINS: Refund-Handling"
+      ]
+    },
+    {
+      "test_id": "skill_002_list",
+      "prompt": "List all Business Skills available in my Dataverse environment.",
+      "expected_response": "Agent uses Python SDK client.records.get('skill') to list all skills.",
+      "category": "skill-management",
+      "description": "List all skills — confirms Python Web API path works for listing",
+      "priority": 1,
+      "tags": {"Suite": "Regression", "Domain": "Skill", "Skill": "dv-skill"},
+      "custom_metadata": {"skill": "dv-skill", "tool_routing": "MCP-or-WebAPI"},
+      "assertions": [
+        "PRIORITY_1: SKILL_LOADED: dv-skill",
+        "PRIORITY_1: Agent queries the skill table to list all skills. Uses Python SDK client.records.get('skill'). Raw urllib is NOT acceptable.",
+        "PRIORITY_1: NOT_CONTAINS: urllib.request",
+        "PRIORITY_2: CONTAINS: skill"
+      ]
+    },
+    {
+      "test_id": "skill_003_consult_enforcement",
+      "prompt": "Write a Python script that imports refund records from a CSV into the new_refund table, following our team's refund handling process.",
+      "expected_response": "Agent FIRST queries Dataverse Business Skills for relevant domain instructions (e.g., searching for 'refund' skills), THEN generates the SDK import code incorporating any retrieved skill instructions. The consult step must come before the data operation.",
+      "category": "consult-enforcement",
+      "description": "Mandatory consult — agent must query Business Skills before generating SDK code for domain-specific tasks",
+      "priority": 1,
+      "tags": {"Suite": "Regression", "Domain": "Data", "Skill": "dv-data", "Type": "consult"},
+      "custom_metadata": {"skill": "dv-data", "tool_routing": "SDK", "consult_expected": true},
+      "assertions": [
+        "PRIORITY_1: Agent queries or searches Dataverse Business Skills BEFORE generating the CSV import code. Evidence: Python SDK client.records.get('skill', filter=...). If agent jumps straight to SDK code without consulting skills, this FAILS.",
+        "PRIORITY_1: Agent uses Python SDK (client.records.create with list arg or CreateMultiple) for the actual data import — not urllib for the import itself.",
+        "PRIORITY_2: SKILL_LOADED: dv-data",
+        "PRIORITY_2: CONTAINS: refund"
+      ]
+    },
+    {
+      "test_id": "skill_004_consult_skip_generic",
+      "prompt": "Write a Python script that creates 100 generic test accounts in my Dataverse account table with random names.",
+      "expected_response": "Agent still consults Business Skills (mandatory rule), but finding no relevant skills, proceeds directly with SDK bulk create. The consult check happens but does not block execution when no skills match.",
+      "category": "consult-enforcement",
+      "description": "Mandatory consult fires even for generic tasks — finding nothing is fine, skipping the check is not",
+      "priority": 1,
+      "tags": {"Suite": "Regression", "Domain": "Data", "Skill": "dv-data", "Type": "consult"},
+      "custom_metadata": {"skill": "dv-data", "tool_routing": "SDK", "consult_expected": true},
+      "assertions": [
+        "PRIORITY_1: Agent queries or acknowledges checking Business Skills before generating the bulk create code. Evidence: Python SDK client.records.get('skill', ...), or explicit statement that skills were checked. If no mention of skill consultation at all, this FAILS.",
+        "PRIORITY_1: Agent uses bulk SDK pattern (list arg to client.records.create or CreateMultiple) for the 100 accounts. Per-record loops FAIL.",
+        "PRIORITY_1: NOT_CONTAINS: There is no batch API",
+        "PRIORITY_2: SKILL_LOADED: dv-data"
+      ]
+    },
+    {
+      "test_id": "skill_005_delete",
+      "prompt": "Delete the Business Skill named 'Old-Process' from my Dataverse environment.",
+      "expected_response": "Agent uses Python SDK client.records.delete('skill', id). Must first look up the skill by name to get the ID, then delete.",
+      "category": "skill-management",
+      "description": "Delete a skill — confirms routing and correct API usage",
+      "priority": 1,
+      "tags": {"Suite": "Regression", "Domain": "Skill", "Skill": "dv-skill"},
+      "custom_metadata": {"skill": "dv-skill", "tool_routing": "MCP-or-WebAPI"},
+      "assertions": [
+        "PRIORITY_1: SKILL_LOADED: dv-skill",
+        "PRIORITY_1: Agent deletes the skill using Python SDK client.records.delete('skill', id). Raw urllib is NOT acceptable.",
+        "PRIORITY_1: NOT_CONTAINS: urllib.request",
+        "PRIORITY_2: CONTAINS: Old-Process"
+      ]
+    },
+    {
+      "test_id": "skill_006_skill_contract",
+      "prompt": "Before writing any code, tell me exactly what the dv-skill skill says about consuming Business Skills when using the Python SDK. Quote or closely paraphrase the mandatory consult rule. Do not use your own knowledge — only report what the loaded skill teaches.",
+      "expected_response": "Agent reports skill content: mandatory consultation before any Python SDK operation, always query skills entity, extract keywords, incorporate body as context. Agent must NOT say consultation is optional or only for domain-specific tasks.",
+      "category": "skill-contract",
+      "description": "Skill-contract test — agent must report mandatory consult rule accurately",
+      "priority": 1,
+      "tags": {"Suite": "Regression", "Domain": "Skill", "Skill": "dv-skill", "Type": "skill-contract"},
+      "custom_metadata": {"skill": "dv-skill", "test_kind": "skill-contract"},
+      "assertions": [
+        "PRIORITY_1: SKILL_LOADED: dv-skill",
+        "PRIORITY_1: Agent states that skill consultation is MANDATORY (not optional, not just recommended). If agent says 'optional' or 'only when domain-specific', this FAILS.",
+        "PRIORITY_1: NOT_CONTAINS: optional",
+        "PRIORITY_1: NOT_CONTAINS: only for domain-specific",
+        "PRIORITY_2: Agent mentions the step sequence: extract keywords → query skills → incorporate body → proceed with SDK code."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adds a new **dv-skill** skill that teaches the agent how to manage Dataverse Business Skills (the skill entity) - list, create, update, delete skills and skill resources via the Python SDK.

## Changes

- New skill: .github/plugins/dataverse/skills/dv-skill/SKILL.md
- Updated dv-overview routing table to include dv-skill
- Added mandatory Consult Business Skills section to dv-data and dv-query
- Registered dv-skill in auth.py allowed skills list
- Added eval test: evals/tests/dv_skill.biceval.json
- Version bump: 1.5.0 to 1.6.0 (MINOR - new skill addition)