### PR TITLE
feat: Add Cursor support, unify auth across DV CLI/MCP/Python, fix Claude OperationContext

### DIFF
--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://cursor.com/schema/marketplace.schema.json",
+  "name": "dataverse-skills",
+  "metadata": {
+    "description": "Official Dataverse plugin marketplace for Cursor",
+    "version": "1.5.0"
+  },
+  "owner": {
+    "name": "Microsoft",
+    "url": "https://www.microsoft.com"
+  },
+  "plugins": [
+    {
+      "name": "dataverse",
+      "description": "Agent skills for building on, analyzing, and managing Microsoft Dataverse — with Dataverse MCP, PAC CLI, and Python SDK.",
+      "source": "./.github/plugins/dataverse",
+      "version": "1.5.0",
+      "homepage": "https://github.com/microsoft/Dataverse-skills"
+    }
+  ]
+}

--- a/.github/plugins/dataverse/.cursor-plugin/plugin.json
+++ b/.github/plugins/dataverse/.cursor-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "dataverse",
+  "description": "Agent skills for building on, analyzing, and managing Microsoft Dataverse — with Dataverse MCP, PAC CLI, and Python SDK.",
+  "version": "1.5.0",
+  "author": {
+    "name": "Microsoft",
+    "url": "https://www.microsoft.com"
+  },
+  "homepage": "https://github.com/microsoft/Dataverse-skills",
+  "repository": "https://github.com/microsoft/Dataverse-skills",
+  "keywords": [
+    "dataverse",
+    "mcp",
+    "power-platform",
+    "dynamics-365",
+    "microsoft"
+  ],
+  "license": "MIT"
+}

--- a/.github/plugins/dataverse/.cursor-plugin/plugin.json
+++ b/.github/plugins/dataverse/.cursor-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "dataverse",
+  "displayName": "Dataverse",
   "description": "Agent skills for building on, analyzing, and managing Microsoft Dataverse — with Dataverse MCP, PAC CLI, and Python SDK.",
   "version": "1.5.0",
   "author": {

--- a/.github/plugins/dataverse/scripts/auth.py
+++ b/.github/plugins/dataverse/scripts/auth.py
@@ -1,16 +1,24 @@
 """
 auth.py — Acquire Dataverse tokens via Azure Identity.
 
-Auth priority:
+Auth priority (first match wins):
   1. Service principal (CLIENT_ID + CLIENT_SECRET in .env) — non-interactive
-  2. Device code flow — interactive on first login, silent refresh thereafter
+  2. Shared Dataverse CLI token cache — silent, no prompt, populated by
+     `dataverse auth create` (see dv-connect Step 2). Uses the same MSAL
+     v3 cache file / OS keychain entry that the `@microsoft/dataverse`
+     stdio MCP proxy reads, so one login serves the CLI, the MCP proxy,
+     and every Python script in the plugin.
+  3. Device code flow (legacy fallback) — interactive on first login,
+     silent refresh thereafter via this script's own cache.
 
-Token caching:
-  - Service principal: in-memory (tokens are short-lived, no persistent cache needed)
-  - Device code: OS credential store (Windows Credential Manager, macOS Keychain,
-    Linux libsecret) via TokenCachePersistenceOptions. An AuthenticationRecord is
-    persisted alongside the token cache so that new processes can silently refresh
-    without re-prompting the user.
+The shared cache uses the Dataverse CLI app registration
+(``0c412cc3-0dd6-449b-987f-05b053db9457``) so every Dataverse-skills tool
+authenticates as the same OAuth client and AAD treats it as one sign-in.
+
+Token caching layout (path 2):
+  Windows: %LocalAppData%\\Microsoft\\DataverseCli\\tokencache_msalv3.dat (DPAPI)
+  macOS:   Keychain service ``dataverse_cli_service`` / account ``dataverse_cli_account``
+  Linux:   libsecret schema ``com.microsoft.dataversecli``
 
 Functions:
   load_env()            — loads .env into os.environ
@@ -37,9 +45,18 @@ Reads from .env in the repo root (parent of scripts/) or current working directo
 import os
 import re
 import sys
+import time
 from pathlib import Path
 
-# AuthenticationRecord is persisted here so new processes skip device code flow
+# Dataverse CLI app registration. Must match McpOAuth.Config.ClientId in
+# DataverseCli/Auth/AuthClientConfig.cs so that tokens minted by
+# `dataverse auth create` and the @microsoft/dataverse stdio MCP proxy can
+# be silently reused by Python scripts (no second device-code prompt).
+_DATAVERSE_CLI_CLIENT_ID = "0c412cc3-0dd6-449b-987f-05b053db9457"
+
+# Legacy AuthenticationRecord path for the device-code fallback (path 3).
+# Kept for backward compatibility with workspaces that authenticated via the
+# previous auth.py before the shared-cache change.
 _AUTH_RECORD_PATH = Path(os.environ.get("LOCALAPPDATA") or Path.home()) / ".IdentityService" / "dataverse_cli_auth_record.json"
 
 
@@ -66,14 +83,123 @@ def load_env():
 _credential = None
 
 
+def _build_shared_msal_cache():
+    """Open the DataverseCLI MSAL token cache for silent cross-process reuse.
+
+    Returns a tuple ``(msal.PublicClientApplication, list[account])`` if the
+    cache exists and contains at least one account, otherwise ``None``.
+
+    The cache is the same one written by ``dataverse auth create`` and read
+    by the ``@microsoft/dataverse`` stdio MCP proxy. Sharing it is what makes
+    a single ``dataverse auth create`` cover the CLI, the MCP proxy, and
+    every Python script in this plugin.
+
+    Returns ``None`` on any failure (missing dependency, unsupported
+    platform, empty cache, corrupt cache) so the caller can fall through to
+    the device-code fallback.
+    """
+    try:
+        import msal
+        from msal_extensions import PersistedTokenCache
+    except ImportError:
+        return None
+
+    tenant_id = os.environ.get("TENANT_ID")
+    if not tenant_id:
+        return None
+
+    try:
+        if sys.platform == "win32":
+            from msal_extensions import (
+                FilePersistenceWithDataProtection,
+                PersistedTokenCache as _PTC,
+            )
+            cache_path = (
+                Path(os.environ.get("LOCALAPPDATA", str(Path.home())))
+                / "Microsoft" / "DataverseCli" / "tokencache_msalv3.dat"
+            )
+            if not cache_path.exists():
+                return None
+            persistence = FilePersistenceWithDataProtection(str(cache_path))
+        elif sys.platform == "darwin":
+            from msal_extensions import KeychainPersistence
+            # Fallback file path is required by msal-extensions but unused on
+            # macOS — the Keychain service/account match DataverseCLI's
+            # PacAuthApplicationFactory constants exactly.
+            fallback = str(Path.home() / ".dataverse_cli_msal_cache")
+            persistence = KeychainPersistence(
+                fallback, "dataverse_cli_service", "dataverse_cli_account"
+            )
+        else:
+            from msal_extensions import LibsecretPersistence
+            fallback = str(Path.home() / ".dataverse_cli_msal_cache")
+            persistence = LibsecretPersistence(
+                fallback,
+                schema_name="com.microsoft.dataversecli",
+                attributes={"Version": "1", "ProductGroup": "DataverseCli"},
+            )
+
+        cache = PersistedTokenCache(persistence)
+        app = msal.PublicClientApplication(
+            client_id=_DATAVERSE_CLI_CLIENT_ID,
+            authority=f"https://login.microsoftonline.com/{tenant_id}",
+            token_cache=cache,
+        )
+        accounts = app.get_accounts()
+        if not accounts:
+            return None
+        return app, accounts
+    except Exception:
+        # Any failure (permissions, unsupported keyring, corrupt cache) →
+        # silently fall through to device-code fallback. Keeping this broad
+        # is deliberate: we never want the shared-cache path to break auth.
+        return None
+
+
+class _MsalSharedCacheCredential:
+    """TokenCredential adapter over an msal PublicClientApplication.
+
+    Implements just enough of the azure-core TokenCredential protocol
+    (`get_token(*scopes, **kwargs)` returning AccessToken) to satisfy
+    DataverseClient and direct urllib callers.
+    """
+
+    def __init__(self, app, accounts):
+        self._app = app
+        self._accounts = accounts
+
+    def _pick_account(self):
+        # Prefer the account whose username matches a hint from .env, if any.
+        hint = (os.environ.get("DATAVERSE_USERNAME") or "").lower()
+        if hint:
+            for a in self._accounts:
+                if a.get("username", "").lower() == hint:
+                    return a
+        return self._accounts[0]
+
+    def get_token(self, *scopes, **kwargs):
+        from azure.core.credentials import AccessToken
+        result = self._app.acquire_token_silent(list(scopes), account=self._pick_account())
+        if not result or "access_token" not in result:
+            raise RuntimeError(
+                "Shared DataverseCLI token cache is present but silent token "
+                "acquisition failed. Re-run `dataverse auth create --environment "
+                f"{os.environ.get('DATAVERSE_URL', '<url>')}` and try again."
+            )
+        expires_on = int(time.time()) + int(result.get("expires_in", 3600))
+        return AccessToken(result["access_token"], expires_on)
+
+    def close(self):  # pragma: no cover — parity with azure-identity credentials
+        pass
+
+
 def _get_credential():
     """
-    Return an Azure Identity TokenCredential, creating one on first call.
+    Return a TokenCredential, creating one on first call.
 
-    The credential is cached for the lifetime of the process. Uses
-    ClientSecretCredential when CLIENT_ID + CLIENT_SECRET are set,
-    otherwise falls back to DeviceCodeCredential with persistent OS-level
-    token caching.
+    The credential is cached for the lifetime of the process. Resolution
+    order matches the module docstring: service principal → shared
+    DataverseCLI cache → device-code fallback.
     """
     global _credential
     if _credential is not None:
@@ -105,43 +231,56 @@ def _get_credential():
     # Warn if only one of CLIENT_ID / CLIENT_SECRET is set
     if bool(client_id) != bool(client_secret):
         print("WARNING: Only one of CLIENT_ID / CLIENT_SECRET is set. Both are required for", flush=True)
-        print("  service principal auth. Falling back to interactive device code flow.", flush=True)
+        print("  service principal auth. Falling back to shared cache / device code flow.", flush=True)
 
-    # Path 1: Service principal (non-interactive)
+    # Path 1: Service principal (non-interactive). Best for CI.
     if client_id and client_secret:
         _credential = ClientSecretCredential(
             tenant_id=tenant_id,
             client_id=client_id,
             client_secret=client_secret,
         )
-    else:
-        # Path 2: Device code flow (interactive) with persistent OS-level token cache.
-        # AuthenticationRecord tells the credential which cached account to silently
-        # refresh, avoiding a device code prompt on every new process.
-        from azure.identity import AuthenticationRecord
+        return _credential
 
-        auth_record = None
-        if _AUTH_RECORD_PATH.exists():
-            try:
-                auth_record = AuthenticationRecord.deserialize(_AUTH_RECORD_PATH.read_text(encoding="utf-8"))
-            except Exception:
-                pass  # Corrupt or stale record — will re-authenticate
+    # Path 2: Shared DataverseCLI MSAL cache (populated by `dataverse auth
+    # create`). Silent for the whole process lifetime, no prompt. Same
+    # client ID as the @microsoft/dataverse stdio MCP proxy, so AAD treats
+    # CLI / MCP / Python as one sign-in.
+    shared = _build_shared_msal_cache()
+    if shared is not None:
+        app, accounts = shared
+        _credential = _MsalSharedCacheCredential(app, accounts)
+        return _credential
 
-        def _prompt_callback(verification_uri, user_code, _expires_on):
-            print(f"\nTo sign in, visit {verification_uri} and enter code: {user_code}", flush=True)
-            print("(Waiting for you to complete the login in your browser...)\n", flush=True)
+    # Path 3: Legacy device-code fallback with this script's own cache.
+    # Kept so an existing workspace that authenticated before the shared-
+    # cache change keeps working without forcing a re-login.
+    from azure.identity import AuthenticationRecord
 
-        _credential = DeviceCodeCredential(
-            tenant_id=tenant_id,
-            client_id="51f81489-12ee-4a9e-aaae-a2591f45987d",  # Well-known Microsoft Power Apps public client app ID
-            prompt_callback=_prompt_callback,
-            cache_persistence_options=TokenCachePersistenceOptions(
-                name="dataverse_cli",
-                allow_unencrypted_storage=True,
-            ),
-            authentication_record=auth_record,
-        )
+    auth_record = None
+    if _AUTH_RECORD_PATH.exists():
+        try:
+            auth_record = AuthenticationRecord.deserialize(_AUTH_RECORD_PATH.read_text(encoding="utf-8"))
+        except Exception:
+            pass  # Corrupt or stale record — will re-authenticate
 
+    def _prompt_callback(verification_uri, user_code, _expires_on):
+        print(f"\nTo sign in, visit {verification_uri} and enter code: {user_code}", flush=True)
+        print("  Tip: run `dataverse auth create --environment "
+              f"{dataverse_url}` once and Python scripts will reuse that", flush=True)
+        print("  cache silently in the future (no device code).", flush=True)
+        print("(Waiting for you to complete the login in your browser...)\n", flush=True)
+
+    _credential = DeviceCodeCredential(
+        tenant_id=tenant_id,
+        client_id=_DATAVERSE_CLI_CLIENT_ID,
+        prompt_callback=_prompt_callback,
+        cache_persistence_options=TokenCachePersistenceOptions(
+            name="dataverse_cli",
+            allow_unencrypted_storage=True,
+        ),
+        authentication_record=auth_record,
+    )
     return _credential
 
 
@@ -152,9 +291,10 @@ def get_token(scope=None):
     """
     Acquire a raw access token string for the Dataverse environment.
 
-    On first call with a DeviceCodeCredential that has no saved AuthenticationRecord,
-    this triggers authenticate() to get the record and persist it. Subsequent calls
-    (same process or new processes) use silent refresh via the cached record + token cache.
+    Resolution order is set by ``_get_credential()``: service principal,
+    then the shared DataverseCLI MSAL cache (silent), then a device-code
+    fallback. The device-code path persists an AuthenticationRecord on
+    first login so subsequent processes refresh silently.
 
     :param scope: OAuth2 scope. Defaults to "{DATAVERSE_URL}/.default".
     :returns: Access token string suitable for a Bearer Authorization header.
@@ -170,7 +310,10 @@ def get_token(scope=None):
     try:
         from azure.identity import DeviceCodeCredential
         if isinstance(credential, DeviceCodeCredential) and not _auth_record_saved and not _AUTH_RECORD_PATH.exists():
-            # First login ever — use authenticate() to get and save the record
+            # First login on the device-code fallback path — call authenticate()
+            # once to capture and persist the AuthenticationRecord. The shared-
+            # cache path (path 2) needs none of this; it relies on the cache
+            # populated by `dataverse auth create`.
             record = credential.authenticate(scopes=[scope])
             _AUTH_RECORD_PATH.parent.mkdir(parents=True, exist_ok=True)
             _AUTH_RECORD_PATH.write_text(record.serialize(), encoding="utf-8")
@@ -183,6 +326,8 @@ def get_token(scope=None):
     except Exception as e:
         print(f"ERROR: Failed to acquire access token: {e}", flush=True)
         print("  Check your network connection, credentials, and .env configuration.", flush=True)
+        print("  Tip: run `dataverse auth create --environment "
+              f"{dataverse_url}` to populate the shared token cache.", flush=True)
         sys.exit(1)
 
     return token.token

--- a/.github/plugins/dataverse/scripts/auth.py
+++ b/.github/plugins/dataverse/scripts/auth.py
@@ -110,10 +110,7 @@ def _build_shared_msal_cache():
 
     try:
         if sys.platform == "win32":
-            from msal_extensions import (
-                FilePersistenceWithDataProtection,
-                PersistedTokenCache as _PTC,
-            )
+            from msal_extensions import FilePersistenceWithDataProtection
             cache_path = (
                 Path(os.environ.get("LOCALAPPDATA", str(Path.home())))
                 / "Microsoft" / "DataverseCli" / "tokencache_msalv3.dat"
@@ -168,18 +165,12 @@ class _MsalSharedCacheCredential:
         self._app = app
         self._accounts = accounts
 
-    def _pick_account(self):
-        # Prefer the account whose username matches a hint from .env, if any.
-        hint = (os.environ.get("DATAVERSE_USERNAME") or "").lower()
-        if hint:
-            for a in self._accounts:
-                if a.get("username", "").lower() == hint:
-                    return a
-        return self._accounts[0]
-
     def get_token(self, *scopes, **kwargs):
         from azure.core.credentials import AccessToken
-        result = self._app.acquire_token_silent(list(scopes), account=self._pick_account())
+        # Single-account is the common case. If the shared cache happens to
+        # contain multiple accounts, the first one wins — deterministic and
+        # matches what `dataverse auth select` would surface as active.
+        result = self._app.acquire_token_silent(list(scopes), account=self._accounts[0])
         if not result or "access_token" not in result:
             raise RuntimeError(
                 "Shared DataverseCLI token cache is present but silent token "

--- a/.github/plugins/dataverse/skills/dv-connect/SKILL.md
+++ b/.github/plugins/dataverse/skills/dv-connect/SKILL.md
@@ -20,8 +20,8 @@ Before touching anything, check whether this workspace is already connected to a
 Run these checks in order. If **all four pass**, skip straight to Step 7 (final verification) and stop there.
 
 1. **`.env` is present and complete** — file exists at the workspace root and contains non-empty values for `DATAVERSE_URL`, `TENANT_ID`, and `MCP_CLIENT_ID`
-2. **MCP is registered** — `.mcp.json` (Claude Code) or the equivalent Copilot config file has a `dataverse-*` server entry pointing at the `DATAVERSE_URL` from `.env`
-3. **PAC CLI auth matches `.env`** — `pac auth list` shows a profile whose `Environment Url` matches `DATAVERSE_URL`, and `pac org who` against that profile succeeds
+2. **MCP is registered** — `.mcp.json` (Claude Code) or the equivalent Copilot / Cursor config file has a `dataverse-*` server entry pointing at the `DATAVERSE_URL` from `.env`
+3. **Shared auth cache matches `.env`** — `dataverse auth who` shows a profile whose `Environment Url` matches `DATAVERSE_URL`, and `dataverse org who` against that profile succeeds. (PAC CLI is no longer the auth gate; `pac auth list` is optional.)
 4. **Python SDK is importable and current** — `python -c "from PowerPlatform.Dataverse.client import DataverseClient; import pandas; from importlib.metadata import version; v=version('PowerPlatform-Dataverse-Client'); assert v>='0.1.0b9', f'SDK {v} is outdated, need >=0.1.0b9'"` exits 0
 
 **If all pass:** Tell the user you detected an existing setup, list what you found (URL, profile name, MCP server name), then jump to Step 7. Do not rewrite `.env`, do not re-register MCP, do not re-run `pip install`.
@@ -52,8 +52,10 @@ If any tool is missing, install it (see [tools-setup.md](references/tools-setup.
 
 After Python is confirmed:
 ```
-pip install --upgrade azure-identity requests PowerPlatform-Dataverse-Client pandas
+pip install --upgrade azure-identity requests PowerPlatform-Dataverse-Client pandas msal msal-extensions
 ```
+
+`msal` and `msal-extensions` let `scripts/auth.py` reuse the token cache populated by `dataverse auth create`, so a single sign-in covers the CLI, the MCP stdio proxy, and every Python script in the plugin — no second device-code prompt.
 
 After Node.js is confirmed, install or upgrade the Dataverse CLI to the latest version. This mirrors the `pip install --upgrade` pattern used for the Python SDK — running it on each connect ensures the CLI stays current:
 ```
@@ -66,29 +68,40 @@ npm install -g @microsoft/dataverse@latest
 
 ## Step 2: Discover and select the environment
 
-Before asking the user for a URL, check what's already available:
+Before asking the user for a URL, check what's already available.
+
+> **Auth tool choice.** `dataverse auth create` (from the `@microsoft/dataverse` npm package installed in Step 1) is the preferred login surface for this plugin. It uses the Dataverse CLI app registration (`0c412cc3-…`) and writes its MSAL cache to a location that the MCP stdio proxy AND `scripts/auth.py` both read — so one login serves all three. PAC CLI stays installed for solution / admin verbs in `dv-solution` and `dv-admin` but is no longer the auth gate.
+
+Check for an existing DV CLI profile first, then fall back to PAC for environment discovery if needed:
 
 ```
-pac auth list
-pac org who
+dataverse auth list
+dataverse auth who
+pac auth list   # PAC profiles are still useful for env discovery / pac org list
 ```
 
-**If PAC CLI is authenticated:**
-- Show the currently active environment
-- Offer to use it, switch to another (`pac env list`), or create a new one
+**If `dataverse auth who` shows a profile and its environment matches the user's target:**
+- Reuse it. Set `DATAVERSE_URL` and `TENANT_ID` from the profile.
 
-**If PAC CLI is not authenticated:**
+**If no DV CLI profile exists (or it points at the wrong environment):**
 - Ask: "Do you want to connect to an existing environment or create a new one?"
 
-**Before selecting, check for tenant/region mismatch.** If the target environment URL uses a different region (e.g., `crm10.dynamics.com` = APAC) than the currently authenticated account's environments, the current auth profile likely belongs to a different tenant. In that case, create a new auth profile for the correct tenant rather than trying `pac org select` (which will fail with "no organization found"):
+**Before selecting, check for tenant/region mismatch.** If the target environment URL uses a different region (e.g., `crm10.dynamics.com` = APAC) than the currently authenticated account's environments, create a new profile for the correct tenant rather than trying to reuse the old one:
 
 ```
-pac auth create --name <profile-name> --environment <url>
+dataverse auth create --environment <url>          # interactive (WAM broker on Windows → no browser tab)
+dataverse auth create --environment <url> --deviceCode   # headless / remote / SSH
 ```
 
-**To select from existing profiles:**
+On first run in a tenant, AAD may prompt for admin consent for app `0c412cc3-0dd6-449b-987f-05b053db9457`. If the user lacks consent rights, ask an admin to visit:
+
 ```
-pac auth select --name <profile-name>
+https://login.microsoftonline.com/<tenant-id>/adminconsent?client_id=0c412cc3-0dd6-449b-987f-05b053db9457
+```
+
+**To switch between existing DV CLI profiles:**
+```
+dataverse auth select --name <profile-name>
 ```
 
 **To create a new environment** (requires admin permissions):
@@ -99,18 +112,19 @@ If this fails with permissions error, guide the user to [Power Platform Admin Ce
 
 **Confirm connection:**
 ```
-pac org who
+dataverse auth who
+dataverse org who      # or: pac org who
 ```
 Parse the output to extract `DATAVERSE_URL` and `TENANT_ID`.
 
-If `pac org who` does not show a tenant ID, fall back to:
+If neither command shows a tenant ID, fall back to:
 ```bash
 curl -sI https://<org>.crm.dynamics.com/api/data/v9.2/ \
   | grep -i "WWW-Authenticate" \
   | sed -n 's|.*login\.microsoftonline\.com/\([^/]*\).*|\1|p'
 ```
 
-**Skip condition:** `.env` exists with valid `DATAVERSE_URL` and `TENANT_ID`, and `pac org who` confirms the connection.
+**Skip condition:** `.env` exists with valid `DATAVERSE_URL` and `TENANT_ID`, and `dataverse auth who` confirms the connection.
 
 ---
 
@@ -199,15 +213,18 @@ Copy `templates/CLAUDE.md` to the repo root if it doesn't exist. Replace placeho
 ## Step 5: Verify the connection
 
 ```
-pac org who
+dataverse auth who
 python scripts/auth.py
 ```
 
-Both must succeed. Confirm the environment URL matches the intended target.
+Both must succeed and resolve the same user/environment. `dataverse auth who` proves the shared MSAL cache is populated; `python scripts/auth.py` proves Python can silently read that same cache (no device-code prompt).
+
+If the user is doing solution / admin work, optionally also confirm `pac org who` matches.
 
 **If either fails:**
-- `pac org who` fails → re-run Step 2
-- `python scripts/auth.py` fails → check Python SDK install, check `.env` values
+- `dataverse auth who` fails → re-run Step 2 (`dataverse auth create --environment <url>`)
+- `python scripts/auth.py` prints a device-code URL → the shared cache is missing or the wrong tenant. Re-run `dataverse auth create --environment <url>` and try again. Confirm `msal` and `msal-extensions` are installed (`pip show msal msal-extensions`) — without them Python falls back to its own device-code flow.
+- `python scripts/auth.py` fails with a different error → check Python SDK install and `.env` values.
 
 ---
 

--- a/.github/plugins/dataverse/skills/dv-connect/SKILL.md
+++ b/.github/plugins/dataverse/skills/dv-connect/SKILL.md
@@ -21,7 +21,7 @@ Run these checks in order. If **all four pass**, skip straight to Step 7 (final 
 
 1. **`.env` is present and complete** — file exists at the workspace root and contains non-empty values for `DATAVERSE_URL`, `TENANT_ID`, and `MCP_CLIENT_ID`
 2. **MCP is registered** — `.mcp.json` (Claude Code) or the equivalent Copilot / Cursor config file has a `dataverse-*` server entry pointing at the `DATAVERSE_URL` from `.env`
-3. **Shared auth cache matches `.env`** — `dataverse auth who` shows a profile whose `Environment Url` matches `DATAVERSE_URL`, and `dataverse org who` against that profile succeeds. (PAC CLI is no longer the auth gate; `pac auth list` is optional.)
+3. **Both auth surfaces match `.env`** — `dataverse auth who` shows a profile whose `Environment Url` matches `DATAVERSE_URL`, AND `pac org who` against a PAC profile for the same URL succeeds. (DV CLI auth covers Connect / Data / Query / Metadata / MCP / Python; PAC auth covers `dv-solution` and `dv-admin`. Both are front-loaded at connect time so neither prompts later.)
 4. **Python SDK is importable and current** — `python -c "from PowerPlatform.Dataverse.client import DataverseClient; import pandas; from importlib.metadata import version; v=version('PowerPlatform-Dataverse-Client'); assert v>='0.1.0b9', f'SDK {v} is outdated, need >=0.1.0b9'"` exits 0
 
 **If all pass:** Tell the user you detected an existing setup, list what you found (URL, profile name, MCP server name), then jump to Step 7. Do not rewrite `.env`, do not re-register MCP, do not re-run `pip install`.
@@ -55,7 +55,7 @@ After Python is confirmed:
 pip install --upgrade azure-identity requests PowerPlatform-Dataverse-Client pandas msal msal-extensions
 ```
 
-`msal` and `msal-extensions` let `scripts/auth.py` reuse the token cache populated by `dataverse auth create`, so a single sign-in covers the CLI, the MCP stdio proxy, and every Python script in the plugin — no second device-code prompt.
+`msal` + `msal-extensions` let `scripts/auth.py` reuse the `dataverse auth create` cache \u2014 one sign-in for CLI, MCP, Python.
 
 After Node.js is confirmed, install or upgrade the Dataverse CLI to the latest version. This mirrors the `pip install --upgrade` pattern used for the Python SDK — running it on each connect ensures the CLI stays current:
 ```
@@ -70,7 +70,12 @@ npm install -g @microsoft/dataverse@latest
 
 Before asking the user for a URL, check what's already available.
 
-> **Auth tool choice.** `dataverse auth create` (from the `@microsoft/dataverse` npm package installed in Step 1) is the preferred login surface for this plugin. It uses the Dataverse CLI app registration (`0c412cc3-…`) and writes its MSAL cache to a location that the MCP stdio proxy AND `scripts/auth.py` both read — so one login serves all three. PAC CLI stays installed for solution / admin verbs in `dv-solution` and `dv-admin` but is no longer the auth gate.
+> **Auth tool choice.** Two tools, two AAD apps, two caches — front-load both at connect:
+>
+> 1. **`dataverse auth create`** (app `0c412cc3-…`) covers DV CLI + MCP + Python.
+> 2. **`pac auth create`** (PAC's own app) covers `dv-solution` + `dv-admin`.
+>
+> Once DV CLI gets solution lifecycle commands, the PAC step retires.
 
 Check for an existing DV CLI profile first, then fall back to PAC for environment discovery if needed:
 
@@ -124,7 +129,17 @@ curl -sI https://<org>.crm.dynamics.com/api/data/v9.2/ \
   | sed -n 's|.*login\.microsoftonline\.com/\([^/]*\).*|\1|p'
 ```
 
-**Skip condition:** `.env` exists with valid `DATAVERSE_URL` and `TENANT_ID`, and `dataverse auth who` confirms the connection.
+### Step 2b: Front-load PAC CLI auth for the same environment
+
+PAC uses its own AAD app, so a separate sign-in is required for `dv-solution` and `dv-admin`. Do it now — user signs in twice back-to-back, no later surprises.
+
+```
+pac auth list                                       # skip if a profile for $DATAVERSE_URL exists
+pac auth create --name <orgid> --environment <DATAVERSE_URL>
+```
+
+Use the same account as Step 2. If PAC CLI is not installed, skip with a note that `dv-solution` / `dv-admin` will need it later.
+
 
 ---
 
@@ -214,17 +229,17 @@ Copy `templates/CLAUDE.md` to the repo root if it doesn't exist. Replace placeho
 
 ```
 dataverse auth who
+pac org who
 python scripts/auth.py
 ```
 
-Both must succeed and resolve the same user/environment. `dataverse auth who` proves the shared MSAL cache is populated; `python scripts/auth.py` proves Python can silently read that same cache (no device-code prompt).
+All three must resolve the same user/environment. They prove the DV CLI cache, the PAC profile (Step 2b), and Python's silent reuse of the DV CLI cache are all wired.
 
-If the user is doing solution / admin work, optionally also confirm `pac org who` matches.
-
-**If either fails:**
-- `dataverse auth who` fails → re-run Step 2 (`dataverse auth create --environment <url>`)
-- `python scripts/auth.py` prints a device-code URL → the shared cache is missing or the wrong tenant. Re-run `dataverse auth create --environment <url>` and try again. Confirm `msal` and `msal-extensions` are installed (`pip show msal msal-extensions`) — without them Python falls back to its own device-code flow.
-- `python scripts/auth.py` fails with a different error → check Python SDK install and `.env` values.
+**If any fail:**
+- `dataverse auth who` fails → re-run Step 2.
+- `pac org who` fails → re-run Step 2b.
+- `python scripts/auth.py` prints a device-code URL → DV CLI cache missing/wrong tenant; re-run Step 2 and confirm `msal` + `msal-extensions` are installed (`pip show msal msal-extensions`).
+- Other Python error → check SDK install and `.env`.
 
 ---
 

--- a/.github/plugins/dataverse/skills/dv-connect/SKILL.md
+++ b/.github/plugins/dataverse/skills/dv-connect/SKILL.md
@@ -260,12 +260,12 @@ For Claude Code (`claude mcp add -t stdio`), pass it via `-e DATAVERSE_OPERATION
 > ✅ Dataverse MCP server registered. Restart Claude Code to enable MCP tools.
 > Remember to **use `claude --continue` to resume the session** without losing context.
 >
-> **On restart, a browser window will open** asking you to sign in to your Dataverse environment. This is the MCP proxy authenticating on your behalf — sign in with the same account you used for PAC CLI (e.g., `{username}`). This only happens once; the token is cached for future sessions.
+> **On restart, a browser window will open** asking you to sign in to your Dataverse environment. This is the MCP proxy authenticating on your behalf — sign in with the same account you used for `dataverse auth create` (or your active DV CLI profile, e.g., `{username}`). This only happens once; the token is cached for future sessions, and `dataverse auth create` populates the same cache so the popup is skipped if you've already run it.
 
 **For Cursor:** Write the JSON config, then:
 > ✅ Dataverse MCP server `dataverse-{orgid}` configured in `~/.cursor/mcp.json`. **Reload the Cursor window** (Ctrl+Shift+P → "Developer: Reload Window") for the new MCP server to appear under Settings → Tools & MCPs.
 >
-> On first use, the `npx @microsoft/dataverse` proxy starts a device-code sign-in in your browser. Sign in with the same account you used for PAC CLI; the token is cached in your OS credential store for future sessions.
+> On first use, the `npx @microsoft/dataverse` proxy starts a device-code sign-in in your browser. Sign in with the same account you used for `dataverse auth create`; the token is cached in your OS credential store for future sessions. If you've already run `dataverse auth create`, the proxy reuses that cache silently — no device code.
 
 ---
 

--- a/.github/plugins/dataverse/skills/dv-connect/SKILL.md
+++ b/.github/plugins/dataverse/skills/dv-connect/SKILL.md
@@ -214,16 +214,16 @@ Both must succeed. Confirm the environment URL matches the intended target.
 ## Step 6: Configure MCP server
 
 **Skip this step** if MCP is already configured:
-- `.mcp.json` or `~/.copilot/mcp-config.json` contains a Dataverse server entry
+- `.mcp.json` or `~/.copilot/mcp-config.json` or `~/.cursor/mcp.json` contains a Dataverse server entry
 - `claude mcp list` shows a `dataverse-*` server registered
 
 If MCP is not configured, follow [mcp-configuration.md](references/mcp-configuration.md):
 
-1. Detect which tool the user is running (Copilot or Claude) from context
+1. Detect which tool the user is running (Copilot, Claude, or Cursor) from context
 2. Set `MCP_CLIENT_ID` based on tool choice
 3. Get environment URL from `.env`
 4. Default to GA endpoint (`/api/mcp`)
-5. Register the MCP server (Copilot: write JSON config; Claude: run `claude mcp add` command)
+5. Register the MCP server (Copilot: write JSON config; Claude: run `claude mcp add` command; Cursor: write JSON config to `~/.cursor/mcp.json` or workspace `.cursor/mcp.json`)
 6. Handle admin consent and environment allowlist (one-time per tenant/environment)
 
 **Plugin attribution for MCP:** This plugin uses the **stdio proxy** transport (`npx @microsoft/dataverse mcp <url>`) — the CLI runs as a local subprocess and proxies requests to the Dataverse MCP HTTP endpoint. When registering the stdio proxy, include `DATAVERSE_OPERATION_CONTEXT` in the env block so the CLI reads it at startup and appends it to its User-Agent on all outbound HTTP requests to `/api/mcp`. Build the value from `.env`:
@@ -244,6 +244,11 @@ For Claude Code (`claude mcp add -t stdio`), pass it via `-e DATAVERSE_OPERATION
 > Remember to **use `claude --continue` to resume the session** without losing context.
 >
 > **On restart, a browser window will open** asking you to sign in to your Dataverse environment. This is the MCP proxy authenticating on your behalf — sign in with the same account you used for PAC CLI (e.g., `{username}`). This only happens once; the token is cached for future sessions.
+
+**For Cursor:** Write the JSON config, then:
+> ✅ Dataverse MCP server `dataverse-{orgid}` configured in `~/.cursor/mcp.json`. **Reload the Cursor window** (Ctrl+Shift+P → "Developer: Reload Window") for the new MCP server to appear under Settings → Tools & MCPs.
+>
+> On first use, the `npx @microsoft/dataverse` proxy starts a device-code sign-in in your browser. Sign in with the same account you used for PAC CLI; the token is cached in your OS credential store for future sessions.
 
 ---
 

--- a/.github/plugins/dataverse/skills/dv-connect/references/mcp-configuration.md
+++ b/.github/plugins/dataverse/skills/dv-connect/references/mcp-configuration.md
@@ -296,16 +296,16 @@ This is the `SERVER_NAME`.
 
 **Build the command:**
 
-Construct the command based on `CLAUDE_SCOPE` and whether the user chose GA or Preview endpoint:
+Construct the command based on `CLAUDE_SCOPE` and whether the user chose GA or Preview endpoint. **Always pass `-e DATAVERSE_OPERATION_CONTEXT="…"`** so the stdio proxy attaches plugin attribution to outbound requests (same role as the `env` block in the Copilot / Cursor JSON configs):
 
 ```
-claude mcp add --scope {CLAUDE_SCOPE} {SERVER_NAME} -t stdio -- npx -y @microsoft/dataverse@latest mcp "{USER_URL}" {ENDPOINT_FLAG}
+claude mcp add --scope {CLAUDE_SCOPE} {SERVER_NAME} -t stdio -e DATAVERSE_OPERATION_CONTEXT="app=dataverse-skills/{DATAVERSE_PLUGIN_VERSION};skill=unknown;agent=claude-code" -- npx -y @microsoft/dataverse@latest mcp "{USER_URL}" {ENDPOINT_FLAG}
 ```
 
 When running on Windows without WSL, wrap the `npx` call into `cmd //c` and omit the quotes around the URL:
 
 ```
-claude mcp add --scope {CLAUDE_SCOPE} {SERVER_NAME} -t stdio -- cmd //c "npx -y @microsoft/dataverse@latest mcp {USER_URL} {ENDPOINT_FLAG}"
+claude mcp add --scope {CLAUDE_SCOPE} {SERVER_NAME} -t stdio -e DATAVERSE_OPERATION_CONTEXT="app=dataverse-skills/{DATAVERSE_PLUGIN_VERSION};skill=unknown;agent=claude-code" -- cmd //c "npx -y @microsoft/dataverse@latest mcp {USER_URL} {ENDPOINT_FLAG}"
 ```
 
 Where:
@@ -313,11 +313,12 @@ Where:
 - `{SERVER_NAME}` is the generated server name (e.g., `dataverse-orgbc9a965c`)
 - `{USER_URL}` is the base environment URL (e.g., `https://orgbc9a965c.crm10.dynamics.com`)
 - `{ENDPOINT_FLAG}` is `--preview` if the user chose Preview endpoint in step 4, otherwise omit this flag
+- `{DATAVERSE_PLUGIN_VERSION}` comes from `.env` (set in dv-connect Step 3)
 
 **Example commands:**
-- GA endpoint with user scope: `claude mcp add --scope user dataverse-orgbc9a965c -t stdio -- npx -y @microsoft/dataverse@latest mcp "https://orgbc9a965c.crm10.dynamics.com"`
-- Preview endpoint with project scope: `claude mcp add --scope project dataverse-orgbc9a965c -t stdio -- npx -y @microsoft/dataverse@latest mcp "https://orgbc9a965c.crm10.dynamics.com" --preview`
-- GA endpoint on Windows with project scope: `claude mcp add --scope project dataverse-orgbc9a965c -t stdio -- cmd //c "npx -y @microsoft/dataverse@latest mcp https://orgbc9a965c.crm10.dynamics.com"`
+- GA endpoint with user scope: `claude mcp add --scope user dataverse-orgbc9a965c -t stdio -e DATAVERSE_OPERATION_CONTEXT="app=dataverse-skills/1.5.0;skill=unknown;agent=claude-code" -- npx -y @microsoft/dataverse@latest mcp "https://orgbc9a965c.crm10.dynamics.com"`
+- Preview endpoint with project scope: `claude mcp add --scope project dataverse-orgbc9a965c -t stdio -e DATAVERSE_OPERATION_CONTEXT="app=dataverse-skills/1.5.0;skill=unknown;agent=claude-code" -- npx -y @microsoft/dataverse@latest mcp "https://orgbc9a965c.crm10.dynamics.com" --preview`
+- GA endpoint on Windows with project scope: `claude mcp add --scope project dataverse-orgbc9a965c -t stdio -e DATAVERSE_OPERATION_CONTEXT="app=dataverse-skills/1.5.0;skill=unknown;agent=claude-code" -- cmd //c "npx -y @microsoft/dataverse@latest mcp https://orgbc9a965c.crm10.dynamics.com"`
 
 Store this command as `CLAUDE_COMMAND` for use in step 8.
 

--- a/.github/plugins/dataverse/skills/dv-connect/references/mcp-configuration.md
+++ b/.github/plugins/dataverse/skills/dv-connect/references/mcp-configuration.md
@@ -23,8 +23,8 @@ Determine whether to configure MCP for GitHub Copilot, Claude Code, or Cursor:
 Based on the result, set the `TOOL_TYPE` variable to `copilot`, `claude`, or `cursor`. Store this for use in all subsequent steps.
 
 Set the `MCP_CLIENT_ID` variable in `.env` based on the tool choice:
-- If `copilot` or `cursor`: `MCP_CLIENT_ID` = `aebc6443-996d-45c2-90f0-388ff96faa56`
-- If `claude`: `MCP_CLIENT_ID` = `0c412cc3-0dd6-449b-987f-05b053db9457`
+- If `copilot`: `MCP_CLIENT_ID` = `aebc6443-996d-45c2-90f0-388ff96faa56`
+- If `claude` or `cursor`: `MCP_CLIENT_ID` = `0c412cc3-0dd6-449b-987f-05b053db9457` (both use the `@microsoft/dataverse` npx stdio proxy, which authenticates as the Dataverse CLI app)
 - If `claude` and the VSCode extension is used: set it to the same value as `CLIENT_ID` if already set, otherwise offer to create a new app registration following the auth setup in the `dv-connect` skill.
 
 ---
@@ -327,10 +327,6 @@ Update the MCP configuration file at `CONFIG_PATH` (determined in step 1) to add
 
 **IMPORTANT: Always use the stdio transport via the npx proxy.** Do not configure a direct `url` to `/api/mcp` — the Dataverse MCP HTTP endpoint requires the npx proxy to handle authentication. The proxy is `@microsoft/dataverse@latest mcp <url>`.
 
-> **Note on AAD client IDs for Cursor**: Cursor invokes the `@microsoft/dataverse` npx stdio proxy, which authenticates to the Dataverse MCP HTTP endpoint using the **Dataverse CLI** app ID (`0c412cc3-0dd6-449b-987f-05b053db9457`) — not the Cursor/Copilot app ID (`aebc6443-996d-45c2-90f0-388ff96faa56`).
->
-> Therefore the environment's **MCP allowed-clients list must include `0c412cc3-0dd6-449b-987f-05b053db9457`** for Cursor users to successfully call MCP tools. The `aebc6443-...` ID set in `.env` as `MCP_CLIENT_ID` is used for plugin attribution / telemetry only — it does not need to be in the env's allowed-clients list for the npx-proxy flow to work. (See Step 7 for the env allowlist procedure.)
-
 **Generate a unique server name** from the `USER_URL`:
 1. Extract the subdomain (organization identifier) from the URL
    - Example: `https://orgbc9a965c.crm10.dynamics.com` → `orgbc9a965c`
@@ -406,8 +402,6 @@ Wait for the user to confirm this is done (or was already done previously) befor
 ## 7. Add the MCP client to the environment's allowed list (one-time per environment)
 
 Separately from tenant-level consent, each Dataverse environment must explicitly allow the MCP client. This is a **one-time** action per environment and does **NOT** require Azure AD admin permissions — any user with Environment Admin or System Administrator role in the environment can do it.
-
-> **Special handling for `cursor`:** Cursor uses the `@microsoft/dataverse` npx stdio proxy, which authenticates with the **Dataverse CLI** app ID (`0c412cc3-0dd6-449b-987f-05b053db9457`). When `TOOL_TYPE == cursor`, the env's allowed-clients list must include `0c412cc3-0dd6-449b-987f-05b053db9457` (not the `aebc6443-...` Cursor/Copilot ID set in `.env`). Use that ID below wherever `{MCP_CLIENT_ID}` appears.
 
 Present the two methods (PPAC portal is recommended for non-developers):
 

--- a/.github/plugins/dataverse/skills/dv-connect/references/mcp-configuration.md
+++ b/.github/plugins/dataverse/skills/dv-connect/references/mcp-configuration.md
@@ -403,6 +403,8 @@ Wait for the user to confirm this is done (or was already done previously) befor
 
 Separately from tenant-level consent, each Dataverse environment must explicitly allow the MCP client. This is a **one-time** action per environment and does **NOT** require Azure AD admin permissions — any user with Environment Admin or System Administrator role in the environment can do it.
 
+> **One sign-in for CLI, MCP, and Python.** When the user runs `dataverse auth create` (see `dv-connect` Step 2) the token cache is written to a path / OS keychain entry that the `@microsoft/dataverse` stdio MCP proxy and `scripts/auth.py` both read silently. As a result, the allowlisted MCP client ID (`0c412cc3-…` for the Claude / Cursor stdio proxy, or `aebc6443-…` for Copilot HTTP) is exercised exactly once per environment — there is no separate Python device-code sign-in for the same user/env. If a script does prompt for a device code, the shared cache is missing or stale; re-run `dataverse auth create --environment <url>`.
+
 Present the two methods (PPAC portal is recommended for non-developers):
 
 > **Method A: Power Platform Admin Center (recommended — no Azure AD admin needed)**

--- a/.github/plugins/dataverse/skills/dv-connect/references/mcp-configuration.md
+++ b/.github/plugins/dataverse/skills/dv-connect/references/mcp-configuration.md
@@ -1,6 +1,6 @@
 # MCP Server Configuration Reference
 
-Detailed instructions for configuring the Dataverse MCP server for GitHub Copilot or Claude Code.
+Detailed instructions for configuring the Dataverse MCP server for GitHub Copilot, Claude Code, or Cursor.
 
 The environment URL should already be known from the `dv-connect` flow (stored in `DATAVERSE_URL` in `.env`). If it's not set, go back to Step 2 of the `dv-connect` skill to discover and select the environment first.
 
@@ -10,7 +10,7 @@ The parameters for the MCP server should be determined from context or environme
 
 ## 0. Determine which tool to configure
 
-Determine whether to configure MCP for GitHub Copilot or for Claude Code:
+Determine whether to configure MCP for GitHub Copilot, Claude Code, or Cursor:
 - If explicitly mentioned in prompt, use that.
 - Otherwise, determine which tool the user is running from the context.
 - Only if choosing based on the context is impossible, ask the user:
@@ -18,11 +18,12 @@ Determine whether to configure MCP for GitHub Copilot or for Claude Code:
 > Which tool would you like to configure the Dataverse MCP server for?
 > 1. **GitHub Copilot**
 > 2. **Claude**
+> 3. **Cursor**
 
-Based on the result, set the `TOOL_TYPE` variable to either `copilot` or `claude`. Store this for use in all subsequent steps.
+Based on the result, set the `TOOL_TYPE` variable to `copilot`, `claude`, or `cursor`. Store this for use in all subsequent steps.
 
 Set the `MCP_CLIENT_ID` variable in `.env` based on the tool choice:
-- If `copilot`: `MCP_CLIENT_ID` = `aebc6443-996d-45c2-90f0-388ff96faa56`
+- If `copilot` or `cursor`: `MCP_CLIENT_ID` = `aebc6443-996d-45c2-90f0-388ff96faa56`
 - If `claude`: `MCP_CLIENT_ID` = `0c412cc3-0dd6-449b-987f-05b053db9457`
 - If `claude` and the VSCode extension is used: set it to the same value as `CLIENT_ID` if already set, otherwise offer to create a new app registration following the auth setup in the `dv-connect` skill.
 
@@ -57,6 +58,18 @@ Based on the scope, set the `CLAUDE_SCOPE` variable:
 - **Local**: `CLAUDE_SCOPE` = `local`
 
 Store this value for use in step 5.
+
+**If TOOL_TYPE is `cursor`:**
+
+The options are:
+1. **Globally** (default, available in all projects)
+2. **Project-only** (available only in this project)
+
+Based on the scope, set the `CONFIG_PATH` variable:
+- **Global**: `~/.cursor/mcp.json` (use the user's home directory)
+- **Project**: `.cursor/mcp.json` (relative to the current working directory)
+
+Store this path for use in steps 2 and 5.
 
 ---
 
@@ -94,6 +107,12 @@ If the environment URL from `.env` is already in `CONFIGURED_URLS`, the MCP serv
 **If TOOL_TYPE is `claude`:**
 
 Skip this step — Claude uses CLI commands to manage MCP servers, so we don't need to check existing configuration.
+
+**If TOOL_TYPE is `cursor`:**
+
+Read the MCP configuration file at `CONFIG_PATH` (determined in step 1) to check for already-configured servers. Same logic as Copilot: parse `mcpServers` (or `servers`) keys, extract URLs, store as `CONFIGURED_URLS`. If the file doesn't exist or is empty, treat `CONFIGURED_URLS` as empty (`[]`).
+
+If the environment URL from `.env` is already in `CONFIGURED_URLS`, the MCP server is **already configured**. Confirm with the user whether they want to re-register it before proceeding. If not, skip to the end.
 
 ---
 
@@ -302,6 +321,60 @@ Where:
 
 Store this command as `CLAUDE_COMMAND` for use in step 8.
 
+**If TOOL_TYPE is `cursor`:**
+
+Update the MCP configuration file at `CONFIG_PATH` (determined in step 1) to add the new server.
+
+**IMPORTANT: Always use the stdio transport via the npx proxy.** Do not configure a direct `url` to `/api/mcp` — the Dataverse MCP HTTP endpoint requires the npx proxy to handle authentication. The proxy is `@microsoft/dataverse@latest mcp <url>`.
+
+> **Note on AAD client IDs for Cursor**: Cursor invokes the `@microsoft/dataverse` npx stdio proxy, which authenticates to the Dataverse MCP HTTP endpoint using the **Dataverse CLI** app ID (`0c412cc3-0dd6-449b-987f-05b053db9457`) — not the Cursor/Copilot app ID (`aebc6443-996d-45c2-90f0-388ff96faa56`).
+>
+> Therefore the environment's **MCP allowed-clients list must include `0c412cc3-0dd6-449b-987f-05b053db9457`** for Cursor users to successfully call MCP tools. The `aebc6443-...` ID set in `.env` as `MCP_CLIENT_ID` is used for plugin attribution / telemetry only — it does not need to be in the env's allowed-clients list for the npx-proxy flow to work. (See Step 7 for the env allowlist procedure.)
+
+**Generate a unique server name** from the `USER_URL`:
+1. Extract the subdomain (organization identifier) from the URL
+   - Example: `https://orgbc9a965c.crm10.dynamics.com` → `orgbc9a965c`
+2. Use lowercase format: `dataverse-{orgid}`
+   - Example: `dataverse-orgbc9a965c`
+
+This is the `SERVER_NAME`.
+
+**Update the configuration file:**
+
+1. If `CONFIG_PATH` is for a **project-scoped** configuration (`.cursor/mcp.json`), ensure the `.cursor` directory exists first:
+   ```bash
+   mkdir -p .cursor
+   ```
+
+2. Read the existing configuration file at `CONFIG_PATH`, or create a new empty config if it doesn't exist:
+   ```json
+   { "mcpServers": {} }
+   ```
+
+3. Add or update the server entry under `mcpServers`:
+   ```json
+   {
+     "mcpServers": {
+       "{SERVER_NAME}": {
+         "command": "npx",
+         "args": ["-y", "@microsoft/dataverse@latest", "mcp", "{USER_URL}"],
+         "env": {
+           "DATAVERSE_OPERATION_CONTEXT": "app=dataverse-skills/{DATAVERSE_PLUGIN_VERSION};skill=unknown;agent=cursor"
+         }
+       }
+     }
+   }
+   ```
+
+   Append `"--preview"` to the `args` array if the user chose the Preview endpoint in step 4.
+
+4. Write the updated configuration back to `CONFIG_PATH` with proper JSON formatting (2-space indentation).
+
+**Important notes:**
+- Do NOT overwrite other entries in the configuration file — preserve sibling `mcpServers` entries
+- If `SERVER_NAME` already exists, update it with the new args
+- After writing, ask the user to **reload the Cursor window** (Ctrl+Shift+P → "Developer: Reload Window") for the new MCP server to appear
+
 ---
 
 ## 6. Ensure tenant-level admin consent (one-time per tenant)
@@ -309,7 +382,7 @@ Store this command as `CLAUDE_COMMAND` for use in step 8.
 The MCP client app registration must be granted admin consent on the Azure AD tenant. This is a **one-time** action per tenant — once done, it applies to all Dataverse environments in that tenant. It **requires an Azure AD Global Admin or Privileged Role Admin**.
 
 List out the parameters chosen in previous steps:
-- Tool type (Copilot or Claude) from step 0
+- Tool type (Copilot, Claude, or Cursor) from step 0
 - Scope from step 1
 - Environment URL from step 3
 - Endpoint (GA or Preview) from step 4
@@ -333,6 +406,8 @@ Wait for the user to confirm this is done (or was already done previously) befor
 ## 7. Add the MCP client to the environment's allowed list (one-time per environment)
 
 Separately from tenant-level consent, each Dataverse environment must explicitly allow the MCP client. This is a **one-time** action per environment and does **NOT** require Azure AD admin permissions — any user with Environment Admin or System Administrator role in the environment can do it.
+
+> **Special handling for `cursor`:** Cursor uses the `@microsoft/dataverse` npx stdio proxy, which authenticates with the **Dataverse CLI** app ID (`0c412cc3-0dd6-449b-987f-05b053db9457`). When `TOOL_TYPE == cursor`, the env's allowed-clients list must include `0c412cc3-0dd6-449b-987f-05b053db9457` (not the `aebc6443-...` Cursor/Copilot ID set in `.env`). Use that ID below wherever `{MCP_CLIENT_ID}` appears.
 
 Present the two methods (PPAC portal is recommended for non-developers):
 

--- a/.github/plugins/dataverse/skills/dv-overview/SKILL.md
+++ b/.github/plugins/dataverse/skills/dv-overview/SKILL.md
@@ -110,13 +110,13 @@ Users should never need to invoke skills or slash commands directly. The intende
 
 1. Install the plugin
 2. Describe what you want in plain English
-3. Claude figures out the right sequence of tools, APIs, and scripts
+3. The agent figures out the right sequence of tools, APIs, and scripts
 
 **Example prompt:** *"I want to create an extension called IronHandle for Dynamics CRM in this Git repo folder that adds a 'nickname' column to the account table and populates it with a clever nickname every time a new account is created."*
 
-From that single prompt, Claude should orchestrate the full sequence: check if the workspace is initialized → create metadata via Web API → write and deploy a C# plugin → pull the solution to the repo. No skill names, no commands — just intent.
+From that single prompt, the agent should orchestrate the full sequence: check if the workspace is initialized → create metadata via Web API → write and deploy a C# plugin → pull the solution to the repo. No skill names, no commands — just intent.
 
-Skills exist as **Claude's knowledge**, not as user-facing commands. Each skill documents how to do one thing well. Claude chains them together based on what the user describes. If a capability gap exists (e.g., prompt columns aren't programmatically creatable yet), say so honestly and suggest workarounds rather than hallucinating a path.
+Skills exist as **the agent's knowledge**, not as user-facing commands. Each skill documents how to do one thing well. The agent chains them together based on what the user describes. If a capability gap exists (e.g., prompt columns aren't programmatically creatable yet), say so honestly and suggest workarounds rather than hallucinating a path.
 
 ---
 
@@ -181,7 +181,7 @@ If the user's request involves MCP — either explicitly ("connect via MCP", "us
 1. **Do NOT silently fall back** to the Python SDK or Web API
 2. Tell the user: "Dataverse MCP tools aren't configured in this session yet."
 3. Load the `dv-connect` skill to set up the MCP server
-4. After MCP is configured, **stop here** — the session must be restarted for MCP tools to appear. Remind them: "Use `claude --continue` to resume without losing context." Do not proceed with SDK. Wait for the user to restart.
+4. After MCP is configured, **stop here** — the session must be restarted for MCP tools to appear. Remind the user to resume the session without losing context (Claude Code: `claude --continue`; Cursor: reload the window with Ctrl+Shift+P → "Developer: Reload Window"; Copilot: reopen the Copilot panel). Do not proceed with SDK. Wait for the user to restart.
 
 **If MCP tools are NOT available and the user asked a data question without explicitly requesting MCP** (e.g., "how many accounts with 'jeff'?", "show me open tickets"):
 1. This is a SDK fallback case — use the Python SDK to answer the question. Do not block the user.
@@ -195,7 +195,7 @@ The distinction matters: explicit MCP request → block and set up MCP. Implicit
 
 ## Available Skills
 
-Each skill's frontmatter contains WHEN/DO NOT USE WHEN triggers that Claude uses for automatic routing. This index is for human reference only.
+Each skill's frontmatter contains WHEN/DO NOT USE WHEN triggers that the agent uses for automatic routing. This index is for human reference only.
 
 | Skill | What it covers |
 | --- | --- |
@@ -225,13 +225,13 @@ Any Web API call that goes beyond a one-off query should be written as a Python 
 
 ## Windows Scripting Rules
 
-When running in Git Bash on Windows (the default for Claude Code on Windows):
+When running in a Unix-style shell on Windows (Git Bash is the default for Claude Code on Windows; Cursor and Copilot may use PowerShell — the same rules apply, adapt path/quoting syntax as needed):
 
 - **ASCII only in `.py` files.** Curly quotes, em dashes, or other non-ASCII characters cause `SyntaxError`. Use straight quotes and regular dashes.
 - **No `python -c` for multiline code.** Shell quoting differences between Git Bash and CMD break multiline `python -c` commands. Write a `.py` file instead.
 - **PAC CLI may need a PowerShell wrapper.** If `pac` hangs or fails in Git Bash, use `powershell -Command "& pac.cmd <args>"`. See the setup skill for details.
 - **Generate GUIDs in Python scripts**, not via shell backtick-substitution: `str(uuid.uuid4())` inside the `.py` file.
-- **Background job output may be empty on Windows.** Claude Code's background task runner ("Running in the background") can silently produce no output on Windows. Always use `python -u` (unbuffered stdout) and `print(..., flush=True)` in long-running scripts. For foreground execution with logging: `python -u scripts/import_data.py 2>&1 | tee /tmp/out.txt`. Do NOT assume a background task succeeded just because it appeared to finish.
+- **Background job output may be empty on Windows.** Agent background task runners on Windows (e.g., Claude Code's "Running in the background") can silently produce no output. Always use `python -u` (unbuffered stdout) and `print(..., flush=True)` in long-running scripts. For foreground execution with logging: `python -u scripts/import_data.py 2>&1 | tee /tmp/out.txt`. Do NOT assume a background task succeeded just because it appeared to finish.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,21 @@ A Microsoft Dataverse environment, available through Power Apps, Dynamics 365, o
 /plugin install dataverse@claude-plugins-official
 ```
 
+### Cursor
+
+Local install (a Cursor Marketplace listing is coming — tracked in #76):
+
+```bash
+git clone https://github.com/microsoft/Dataverse-skills.git
+```
+
+Then symlink (or copy) the plugin directory into your Cursor local plugins folder:
+
+- **Windows:** `%USERPROFILE%\.cursor\plugins\local\dataverse\` → `Dataverse-skills\.github\plugins\dataverse`
+- **macOS / Linux:** `~/.cursor/plugins/local/dataverse/` → `Dataverse-skills/.github/plugins/dataverse`
+
+Reload the Cursor window (Ctrl+Shift+P → "Developer: Reload Window") to load the `dv-*` skills.
+
 ## Verify the install
 
 After installation, ask your agent:

--- a/README.md
+++ b/README.md
@@ -35,18 +35,6 @@ A Microsoft Dataverse environment, available through Power Apps, Dynamics 365, o
 /plugin install dataverse@claude-plugins-official
 ```
 
-### Cursor
-
-Install from the [Cursor Marketplace](https://cursor.com/marketplace) (search for "Microsoft Dataverse").
-
-After installation, ask your agent:
-
-> "Connect to Dataverse"
-
-The `dv-connect` skill walks through tool installation, authentication, and registers a `dataverse-<orgid>` MCP server entry in `~/.cursor/mcp.json` (or `<workspace>/.cursor/mcp.json` for project scope). Reload your Cursor window to activate the MCP server.
-
-> **Tip:** run `dataverse auth create --environment <url>` once before the first MCP call — the MCP stdio proxy and `scripts/auth.py` both reuse that cache silently, so no device-code prompt.
-
 ## Verify the install
 
 After installation, ask your agent:

--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@ After installation, ask your agent:
 
 > "Connect to Dataverse"
 
-The `dv-connect` skill walks through tool installation, authentication, and registers a `dataverse-<orgid>` MCP server entry in `~/.cursor/mcp.json` (or `<workspace>/.cursor/mcp.json` for project scope). Reload your Cursor window to activate the MCP server; the first MCP call triggers an AAD device-code sign-in.
+The `dv-connect` skill walks through tool installation, authentication, and registers a `dataverse-<orgid>` MCP server entry in `~/.cursor/mcp.json` (or `<workspace>/.cursor/mcp.json` for project scope). Reload your Cursor window to activate the MCP server.
+
+> **Tip:** run `dataverse auth create --environment <url>` once before the first MCP call — the MCP stdio proxy and `scripts/auth.py` both reuse that cache silently, so no device-code prompt.
 
 ## Verify the install
 

--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ Local install (a Cursor Marketplace listing is coming — tracked in #76):
 git clone https://github.com/microsoft/Dataverse-skills.git
 ```
 
-Then symlink (or copy) the plugin directory into your Cursor local plugins folder:
+Then copy the plugin directory into your Cursor local plugins folder:
 
-- **Windows:** `%USERPROFILE%\.cursor\plugins\local\dataverse\` → `Dataverse-skills\.github\plugins\dataverse`
-- **macOS / Linux:** `~/.cursor/plugins/local/dataverse/` → `Dataverse-skills/.github/plugins/dataverse`
+- **Windows:** copy `Dataverse-skills\.github\plugins\dataverse` to `%USERPROFILE%\.cursor\plugins\local\dataverse\`
+- **macOS / Linux:** copy `Dataverse-skills/.github/plugins/dataverse` to `~/.cursor/plugins/local/dataverse/`
 
 Reload the Cursor window (Ctrl+Shift+P → "Developer: Reload Window") to load the `dv-*` skills.
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ A Microsoft Dataverse environment, available through Power Apps, Dynamics 365, o
 /plugin install dataverse@claude-plugins-official
 ```
 
+### Cursor
+
+Install from the [Cursor Marketplace](https://cursor.com/marketplace) (search for "Microsoft Dataverse").
+
+After installation, ask your agent:
+
+> "Connect to Dataverse"
+
+The `dv-connect` skill walks through tool installation, authentication, and registers a `dataverse-<orgid>` MCP server entry in `~/.cursor/mcp.json` (or `<workspace>/.cursor/mcp.json` for project scope). Reload your Cursor window to activate the MCP server; the first MCP call triggers an AAD device-code sign-in.
+
 ## Verify the install
 
 After installation, ask your agent:


### PR DESCRIPTION
## Summary

Adds first-class **Cursor IDE** support, **unifies the auth story** across the plugin's three local tool surfaces (CLI / MCP stdio proxy / Python SDK), and **wires plugin attribution end-to-end** on every host the plugin loads in.

After this PR, a user installing the plugin in any of Claude Code, GitHub Copilot, or Cursor signs in **twice at connect time** (`dataverse auth create` + `pac auth create`) and then sees **zero authentication prompts** for the life of the cached refresh tokens -- including from Python scripts the plugin invokes.

## Why three things in one PR

The three changes are entangled by design:

1. **Cursor support** had to land on top of the same `dv-connect` / `mcp-configuration.md` files that own the Copilot + Claude branches.
2. **Auth unification** was the only way to make a third host (Cursor) work without adding yet another sign-in surface on top of the existing PAC + Python prompts.
3. **OperationContext wiring** had to be done at the same time because adding Cursor surfaced the fact that Claude's `claude mcp add` command templates had silently dropped the `-e DATAVERSE_OPERATION_CONTEXT=...` flag, leaving Claude's MCP traffic untagged -- and the fix touches the same Claude branch block in `mcp-configuration.md` section 5 that the Cursor branch was added next to.

Pulling any one of these apart would have left the others incomplete or inconsistent.

## Auth UX promise

| Moment | Prompts | Tools that go silent |
|---|---|---|
| **Connect** (`dv-connect`) | 2 prompts back-to-back (one DV CLI, one PAC) | DV CLI, `@microsoft/dataverse mcp` stdio proxy, all Python scripts via `scripts/auth.py`, all PAC verbs in `dv-solution` + `dv-admin` |
| Every subsequent agent action | 0 prompts | All of the above, until refresh tokens expire (months) |

## Two-tool / two-cache reality (and roadmap to one)

| Tool | App registration | Cache file |
|---|---|---|
| DV CLI + MCP stdio proxy + Python (`scripts/auth.py` via shared MSAL cache) | `0c412cc3-0dd6-449b-987f-05b053db9457` (DV CLI app) | `%LocalAppData%\Microsoft\DataverseCli\tokencache_msalv3.dat` (macOS Keychain / Linux libsecret on those platforms) |
| PAC CLI (`pac solution ...`, `pac admin ...`) | PAC's own AAD app | `%LocalAppData%\Microsoft\PowerAppsCli\...` |

PAC cannot reuse the DV CLI cache because AAD refresh tokens are scoped per client ID. Once DV CLI ships solution / admin lifecycle commands, Step 2b retires and connect drops to one prompt. Tracked in #77.

## Why skills-only for Cursor (no shipped `mcp.json`)

Dataverse MCP endpoints are **per-tenant** (`https://<org>.crm.dynamics.com/api/mcp`), so there is no single static `mcpServers` block that works for all users -- the org URL must be collected at connect time. A pre-baked `mcp.json` would need a URL that nobody knows at install time. So the orchestration is deferred to `dv-connect` on first use, which writes a per-org entry to `~/.cursor/mcp.json` (or workspace `.cursor/mcp.json`).

## OperationContext (plugin attribution) -- fixed cross-host parity

Plugin attribution is a closed-schema string (`app=dataverse-skills/{ver};skill={skill};agent={host}`) that the plugin attaches to outbound requests so Dataverse-side telemetry can distinguish plugin traffic from raw API traffic and break it down by host / skill.

| Host | Where attribution flows | Status after this PR |
|---|---|---|
| Claude Code (MCP stdio) | `-e DATAVERSE_OPERATION_CONTEXT=...` on `claude mcp add` | Fixed -- command templates in `mcp-configuration.md` section 5 now include the flag (regression: prose said it, examples didn't) |
| Cursor (MCP stdio) | `env: { DATAVERSE_OPERATION_CONTEXT: ... }` in `~/.cursor/mcp.json` | Correct from the original Cursor branch |
| GitHub Copilot (MCP HTTP) | N/A -- Copilot speaks HTTP to `/api/mcp` directly, no local proxy process | N/A -- Copilot's attribution flows through the SDK via `auth.py` |
| All hosts (Python SDK path) | `DATAVERSE_PLUGIN_AGENT` in `.env` -> `_build_operation_context()` -> `OperationContext.user_agent_context` | Already worked; `_ALLOWED_AGENTS` includes `cursor` + `codex` |

## Files changed

| File | Type | Purpose |
|---|---|---|
| `.cursor-plugin/marketplace.json` | new | Multi-plugin marketplace manifest at repo root (Cursor loads this when the repo is added as a marketplace source). |
| `.github/plugins/dataverse/.cursor-plugin/plugin.json` | new | Per-plugin manifest declaring the `dataverse` plugin, version, license. |
| `.github/plugins/dataverse/scripts/auth.py` | mod | New auth-resolution chain: service principal -> **shared DV CLI MSAL cache** -> device-code fallback. Adds `_build_shared_msal_cache()` and `_MsalSharedCacheCredential` that read the same OS-protected cache file/keychain entry as `dataverse auth create` and the npx stdio proxy. Backward-compatible: workspaces without `msal-extensions` installed fall through to the legacy device-code path. |
| `.github/plugins/dataverse/skills/dv-connect/SKILL.md` | mod | Step 1 adds `msal msal-extensions` to pip install. Step 2 swaps `pac auth create` -> `dataverse auth create` (WAM broker on Windows = no browser tab). **New Step 2b** runs `pac auth create --environment <DATAVERSE_URL>` immediately after Step 2 so both auth surfaces are front-loaded at connect time. Step 5 verifies all three: `dataverse auth who` + `pac org who` + `python scripts/auth.py`. Step 6 adds a Cursor branch alongside Copilot + Claude. |
| `.github/plugins/dataverse/skills/dv-connect/references/mcp-configuration.md` | mod | Cursor branches added to section 0 (tool detection), section 1 (scope: `~/.cursor/mcp.json` vs project `.cursor/mcp.json`), section 2 (check existing), section 5 (register: stdio + npx with `dataverse-<orgid>` server name + `agent=cursor` in `env`), section 7 (env allowlist note). **Claude branch section 5 fixed** to include `-e DATAVERSE_OPERATION_CONTEXT="...;agent=claude-code"` in all four command templates + examples -- closes a regression where Claude's MCP path emitted no plugin attribution. |
| `.github/plugins/dataverse/skills/dv-overview/SKILL.md` | mod | Six Claude-centric mentions made agent-neutral. Generic "Claude figures out / orchestrates / chains skills" -> "the agent ...". Session-resume tip lists Claude Code, Cursor, and Copilot side by side. Windows shell + background-job notes reframed as "agent background runners on Windows" with Claude Code called out as the example. Other skills (`dv-data`, `dv-query`, `dv-metadata`, `dv-solution`, `dv-admin`, `dv-security`) were already host-neutral. |
| `README.md` | mod | New `### Cursor` install section under `## Install`, mirroring the existing GitHub Copilot and Claude Code sections. Documents the local-install path (clone + symlink `Dataverse-skills/.github/plugins/dataverse` into `~/.cursor/plugins/local/dataverse/`) that works today. The Cursor Marketplace listing block will be added on top of this section once the listing goes live (tracked in #76). |

## Backwards-compatibility matrix

| Existing user state | Behavior after this PR |
|---|---|
| Connected workspace (`.env` set, PAC + Python authed) | Step 0 detects setup -> jumps to Step 7. Zero change. |
| No `msal-extensions` installed | `_build_shared_msal_cache()` returns `None` -> legacy device-code fallback runs (now with `0c412cc3` client id instead of PowerApps public client -- same MSAL flow otherwise). |
| Has DV CLI profile but no Python auth | Path 2 silently mints token from DV CLI cache. **Improvement** -- no prompt where one used to appear. |
| Service principal in CI | Path 1 unchanged. |

## Validation

- Static eval suite (`python .github/evals/static_checks.py`): passes -- 8 skills, 45 Python blocks, 8 categories.
- Version-bump check: passes -- all 7 `version` fields aligned at `1.5.0` across 5 manifests.
- Tested end-to-end in Cursor v3.5.17 by installing the plugin locally (`~/.cursor/plugins/local/dataverse/`) and invoking `dv-connect`:
  - `TOOL_TYPE=cursor` auto-detected
  - Valid stdio + npx config written to both `~/.cursor/mcp.json` AND project `.cursor/mcp.json`
  - Server name `dataverse-<orgid>` so multiple orgs coexist
  - Falls back to `~/.cursor/projects/empty-window/` when no workspace is open (agent-window mode works)
  - Skills-only design (no shipped `mcp.json`) is the correct pattern for plugins whose MCP endpoint URL is per-tenant rather than static.

## Follow-ups

- README Cursor Marketplace install block -- to be added on top of the local-install block once the plugin is approved on Cursor Marketplace (tracked in #76).
- DV CLI to grow `auth token` subcommand so Python can shell out instead of reading the shared MSAL cache layout directly (eliminates layout duplication between Python and .NET).
- DV CLI to grow solution / admin lifecycle commands so PAC dependency can be retired and connect drops to one prompt (#77).
