### PR TITLE
[Draft – DO NOT MERGE] validation: build LER from PR #416 to verify DeterministicAssertionEvaluator fix

### DIFF
--- a/.azdo/DataversePluginEvals_PR.yml
+++ b/.azdo/DataversePluginEvals_PR.yml
@@ -56,7 +56,10 @@ resources:
     type: github
     endpoint: bic-proxima-shared-stamp
     name: bic/LocalEvalRunner
-    ref: refs/heads/main
+    # Temporary: pinned to LER PR #416 branch to validate the
+    # DeterministicAssertionEvaluator service-only routing fix end-to-end.
+    # Revert to refs/heads/main before merge.
+    ref: refs/heads/users/sbadenkal/service-only-deterministic-assertion
   - repository: BicEvalsService
     type: github
     endpoint: bic-proxima-shared-stamp
@@ -67,15 +70,21 @@ steps:
 - checkout: self
   displayName: 'Checkout Dataverse-skills'
 
+- checkout: LocalEvalRunner
+  displayName: 'Checkout LocalEvalRunner source (for build-from-source)'
+  fetchDepth: 1
+
 - checkout: BicEvalsService
   displayName: 'Checkout evaluator prompts'
   fetchDepth: 1
 
-# Setup: .NET, NuGet auth, LocalEvalRunner install, Copilot CLI, auth token
+# Setup: .NET, NuGet auth, LocalEvalRunner BUILD FROM SOURCE, Copilot CLI, auth token
 - template: .pipelines/templates/steps/BicEval-SetupTemplate.yml@LocalEvalRunner
   parameters:
     cliAgent: 'copilot'
     cliAgentTokenVariable: 'COPILOT_GH_PAT'
+    useBuildFromSource: true
+    sourceRepoPath: '$(Build.SourcesDirectory)/LocalEvalRunner'
 
 # Configure: merge replacements, prepare agent config
 - template: .pipelines/templates/steps/BicEval-ConfigureTemplate.yml@LocalEvalRunner

--- a/evals/tests/dv_data.biceval.json
+++ b/evals/tests/dv_data.biceval.json
@@ -15,6 +15,11 @@
       "name": "CortexConfigurations:Common/Skills/correctness.prompty",
       "passing_score": 3,
       "priority": 1
+    },
+    {
+      "name": "CortexConfigurations:Common/SEVAL/LMChecklist.prompty",
+      "passing_score": 1,
+      "priority": 1
     }
   ],
   "tests": [

--- a/evals/tests/dv_data.biceval.json
+++ b/evals/tests/dv_data.biceval.json
@@ -4,6 +4,14 @@
   "description": "Verifies SDK patterns for record creation in Dataverse tables.",
   "enabled_evaluators": [
     {
+      "name": "CortexConfigurations:Common/DeterministicAssertionEvaluator",
+      "passing_score": 3,
+      "priority": 1,
+      "settings": {
+        "supported_verbs": "CONTAINS,NOT_CONTAINS,SKILL_LOADED"
+      }
+    },
+    {
       "name": "CortexConfigurations:Common/Skills/correctness.prompty",
       "passing_score": 3,
       "priority": 1


### PR DESCRIPTION
# [Draft – DO NOT MERGE] Validate LocalEvalRunner PR #416 fix end-to-end

This is a **throwaway validation PR**. It exists solely to run `DVSkillsPlugin-Evals-PR` against LER built from [bic/LocalEvalRunner#416](https://microsoft.ghe.com/bic/LocalEvalRunner/pull/416) so we can confirm the `DeterministicAssertionEvaluator` service-only routing fix unblocks the new test format end-to-end. Will be closed unmerged once the validation run finishes.

## Sibling PRs

- [microsoft/Dataverse-skills#70](https://github.com/microsoft/Dataverse-skills/pull/70) — the actual test-files PR (untouched by this validation work)
- [bic/LocalEvalRunner#416](https://microsoft.ghe.com/bic/LocalEvalRunner/pull/416) — the LER fix being validated

## What this PR changes

1. **`.azdo/DataversePluginEvals_PR.yml`**
   - `resources.repositories.LocalEvalRunner.ref` → `refs/heads/users/sbadenkal/service-only-deterministic-assertion` (PR #416 branch).
   - Adds `- checkout: LocalEvalRunner` so the LER source is on the agent.
   - Passes `useBuildFromSource: true` and `sourceRepoPath: '$(Build.SourcesDirectory)/LocalEvalRunner'` to `BicEval-SetupTemplate` so the agent builds LER from the PR #416 branch instead of installing the published NuGet (which doesn't have the fix).
   - The `sourceRepoPath` parameter itself is added by PR #416 — its default is `$(Build.SourcesDirectory)` so existing callers (LER-as-self) are unaffected.
2. **`evals/tests/dv_data.biceval.json`** — copied verbatim from PR #70 so the run exercises the `CortexConfigurations:Common/DeterministicAssertionEvaluator` + `settings.supported_verbs` path that crashed [build 20283404](https://dev.azure.com/dynamicscrm/OneCRM/_build/results?buildId=20283404).

## Expected outcome

- ❌ Before #416: `BadEvalRunnerInputException: Local CortexConfigurations evaluator not found` at evaluator load — 0/0 tests run.
- ✅ With #416: LER routes `DeterministicAssertionEvaluator` as service-only, forwards the request to BICEP, and the pipeline grades the dv_data tests normally.

## After validation

- If the run goes green → comment evidence on PR #416 and PR #70, then **close this PR unmerged**.
- If the run still fails → diagnose, push fixes to PR #416, re-run here.
- The Dataverse-skills `main` branch never sees these `.azdo` changes.
