### PR TITLE
docs(readme): add Cursor local-install section

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,21 @@ A Microsoft Dataverse environment, available through Power Apps, Dynamics 365, o
 /plugin install dataverse@claude-plugins-official
 ```
 
+### Cursor
+
+Local install (a Cursor Marketplace listing is coming — tracked in #76):
+
+```bash
+git clone https://github.com/microsoft/Dataverse-skills.git
+```
+
+Then symlink (or copy) the plugin directory into your Cursor local plugins folder:
+
+- **Windows:** `%USERPROFILE%\.cursor\plugins\local\dataverse\` → `Dataverse-skills\.github\plugins\dataverse`
+- **macOS / Linux:** `~/.cursor/plugins/local/dataverse/` → `Dataverse-skills/.github/plugins/dataverse`
+
+Reload the Cursor window (Ctrl+Shift+P → "Developer: Reload Window") to load the `dv-*` skills.
+
 ## Verify the install
 
 After installation, ask your agent:


### PR DESCRIPTION
Mirrors the existing GitHub Copilot and Claude Code sections under `## Install`.

A Cursor Marketplace listing is on the roadmap (tracked in #76); until then, users can install locally by cloning the repo and symlinking `Dataverse-skills/.github/plugins/dataverse` into their `~/.cursor/plugins/local/dataverse/` folder.

`dv-connect` already detects Cursor as the host (added in #68) and writes the per-org MCP entry to `~/.cursor/mcp.json` on first `Connect to Dataverse`, so no other changes are needed.

## Validation

- `python .github/evals/static_checks.py`: passes (8 skills, 45 Python blocks).
- Wording follows the same `### <Host>` + minimal code block pattern as the Copilot and Claude sections immediately above it.

## Related

- #68 -- Cursor plugin support (the work this README addition documents)
- #76 -- README Cursor Marketplace section (separate follow-up, will lead the local-install section once the listing goes live)