### PR TITLE
docs: Add assets for dataverse plugin publishing for Cursor Marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "dataverse",
-      "description": "Agent skills for building on, analyzing, and managing Microsoft Dataverse — with Dataverse MCP, PAC CLI, and Python SDK.",
+      "description": "Microsoft Dataverse plugin for coding agents — powering CRUD, bulk data operations, advanced queries, schema lifecycle, and environment management through intelligent skills.",
       "source": "./.github/plugins/dataverse",
       "homepage": "https://github.com/microsoft/Dataverse-skills"
     }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -12,7 +12,7 @@
   "plugins": [
     {
       "name": "dataverse",
-      "description": "Agent skills for building on, analyzing, and managing Microsoft Dataverse — with Dataverse MCP, PAC CLI, and Python SDK.",
+      "description": "Microsoft Dataverse plugin for coding agents — powering CRUD, bulk data operations, advanced queries, schema lifecycle, and environment management through intelligent skills.",
       "source": "./.github/plugins/dataverse",
       "version": "1.5.0",
       "homepage": "https://github.com/microsoft/Dataverse-skills"

--- a/.github/evals/static_checks.py
+++ b/.github/evals/static_checks.py
@@ -75,6 +75,19 @@ CAT-8  Skill Token Budget (Anthropic Skills spec)
        EVAL-BUDGET-02  Body       <= 5,000 tokens (Level 2 cap)
        EVAL-BUDGET-03  Skills with body > 4,000 tokens must have a `references/`
                        subfolder (forces Level 3 split before Level 2 fills up)
+
+CAT-9  Manifest Description Consistency
+       Checks that the plugin description matches across all plugin.json
+       manifests and the plugins[0].description of every marketplace.json,
+       so a description edit can't land in one manifest and miss the others.
+       (The marketplace-level metadata.description is intentionally distinct
+       and is not compared.)
+       EVAL-DESC-01  Plugin description identical across all manifests
+
+CAT-10 Manifest Asset References
+       Checks that relative 'logo' paths in plugin manifests resolve to files
+       that actually exist, so an icon can't silently 404 in the marketplace.
+       EVAL-ASSET-01  Every relative logo path points to an existing file
 """
 
 import argparse
@@ -561,6 +574,109 @@ def check_version_consistency(repo_root):
 
 
 # ---------------------------------------------------------------------------
+# CAT-9  Manifest Description Consistency
+# ---------------------------------------------------------------------------
+
+# The plugin description appears in three plugin.json manifests (one per
+# marketplace format) and the plugins[0] entry of three marketplace.json
+# catalogs. All six describe the same plugin and must match. The
+# marketplace-level metadata.description is intentionally different (it
+# describes the marketplace, not the plugin) and is deliberately excluded.
+_DESCRIPTION_SOURCES = [
+    (".github/plugins/dataverse/.cursor-plugin/plugin.json",
+     lambda d: d.get("description"), "description"),
+    (".github/plugins/dataverse/.claude-plugin/plugin.json",
+     lambda d: d.get("description"), "description"),
+    (".github/plugins/dataverse/.github/plugin/plugin.json",
+     lambda d: d.get("description"), "description"),
+    (".github/plugin/marketplace.json",
+     lambda d: (d.get("plugins") or [{}])[0].get("description"), "plugins[0].description"),
+    (".claude-plugin/marketplace.json",
+     lambda d: (d.get("plugins") or [{}])[0].get("description"), "plugins[0].description"),
+    (".cursor-plugin/marketplace.json",
+     lambda d: (d.get("plugins") or [{}])[0].get("description"), "plugins[0].description"),
+]
+
+
+def check_description_consistency(repo_root):
+    """
+    EVAL-DESC-01: The plugin description must match across all plugin.json
+    manifests and the plugins[0].description of every marketplace.json catalog.
+    Catches drift when a description edit lands in one manifest but not the
+    others (the marketplace-level metadata.description is excluded by design).
+    """
+    failures = []
+    found = []
+    for rel_path, extractor, field in _DESCRIPTION_SOURCES:
+        full_path = repo_root / rel_path
+        if not full_path.exists():
+            continue  # the manifest set varies; skip absent files
+        try:
+            data = json.loads(full_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as e:
+            failures.append(f"EVAL-DESC-01 [{rel_path}] invalid JSON: {e}")
+            continue
+        desc = extractor(data)
+        if desc is None:
+            failures.append(f"EVAL-DESC-01 [{rel_path}] missing '{field}' field")
+            continue
+        found.append((rel_path, field, desc))
+
+    unique = {d for _, _, d in found}
+    if len(unique) > 1:
+        detail = "; ".join(f"{rp}:{f}={d!r}" for rp, f, d in found)
+        failures.append(
+            f"EVAL-DESC-01 plugin description mismatch across manifests -- {detail}"
+        )
+
+    return failures
+
+
+# ---------------------------------------------------------------------------
+# CAT-10  Manifest Asset References
+# ---------------------------------------------------------------------------
+
+# plugin.json manifests live under the plugin root; a relative logo path
+# resolves against that root.
+_PLUGIN_ROOT = ".github/plugins/dataverse"
+_LOGO_MANIFESTS = [
+    ".github/plugins/dataverse/.cursor-plugin/plugin.json",
+    ".github/plugins/dataverse/.claude-plugin/plugin.json",
+    ".github/plugins/dataverse/.github/plugin/plugin.json",
+]
+
+
+def check_manifest_assets(repo_root):
+    """
+    EVAL-ASSET-01: Every relative 'logo' path declared in a plugin manifest must
+    point to a file that exists (resolved against the plugin root). Absolute URLs
+    (http/https) are not checked. Catches a logo path that names a file the repo
+    does not contain -- the icon would silently 404 in the marketplace.
+    """
+    failures = []
+    plugin_root = repo_root / _PLUGIN_ROOT
+    for rel_path in _LOGO_MANIFESTS:
+        full_path = repo_root / rel_path
+        if not full_path.exists():
+            continue
+        try:
+            data = json.loads(full_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            continue  # JSON errors are reported by the description/version checks
+        logo = data.get("logo")
+        if not logo or logo.startswith(("http://", "https://")):
+            continue
+        rel = logo[2:] if logo.startswith("./") else logo
+        if not (plugin_root / rel).is_file():
+            failures.append(
+                f"EVAL-ASSET-01 [{rel_path}] logo '{logo}' does not resolve to an "
+                f"existing file (expected at {_PLUGIN_ROOT}/{rel})"
+            )
+
+    return failures
+
+
+# ---------------------------------------------------------------------------
 # CAT-7  auth.py _ALLOWED_SKILLS sync
 # ---------------------------------------------------------------------------
 
@@ -704,6 +820,10 @@ def main():
     repo_root = skills_dir.parent.parent.parent.parent
     all_failures.extend(check_version_consistency(repo_root))
 
+    # Manifest description consistency + asset references
+    all_failures.extend(check_description_consistency(repo_root))
+    all_failures.extend(check_manifest_assets(repo_root))
+
     # auth.py _ALLOWED_SKILLS sync — check against actual skill directories
     all_failures.extend(check_allowed_skills_sync(repo_root, all_skill_names))
 
@@ -725,7 +845,7 @@ def main():
         print(
             f"PASSED -- {len(skill_files)} skill files, "
             f"{python_block_count} Python blocks, "
-            f"8 categories checked"
+            f"10 categories checked"
         )
 
 

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -11,7 +11,7 @@
   "plugins": [
     {
       "name": "dataverse",
-      "description": "Agent skills for building on, analyzing, and managing Microsoft Dataverse — with Dataverse MCP, PAC CLI, and Python SDK.",
+      "description": "Microsoft Dataverse plugin for coding agents — powering CRUD, bulk data operations, advanced queries, schema lifecycle, and environment management through intelligent skills.",
       "source": "./.github/plugins/dataverse",
       "version": "1.5.0",
       "homepage": "https://github.com/microsoft/Dataverse-skills"

--- a/.github/plugins/dataverse/.claude-plugin/plugin.json
+++ b/.github/plugins/dataverse/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dataverse",
-  "description": "Agent skills for building on, analyzing, and managing Microsoft Dataverse — with Dataverse MCP, PAC CLI, and Python SDK.",
+  "description": "Microsoft Dataverse plugin for coding agents — powering CRUD, bulk data operations, advanced queries, schema lifecycle, and environment management through intelligent skills.",
   "version": "1.5.0",
   "author": {
     "name": "Microsoft",

--- a/.github/plugins/dataverse/.cursor-plugin/plugin.json
+++ b/.github/plugins/dataverse/.cursor-plugin/plugin.json
@@ -16,5 +16,6 @@
     "dynamics-365",
     "microsoft"
   ],
+  "logo": "./assets/azure-logo.svg",
   "license": "MIT"
 }

--- a/.github/plugins/dataverse/.cursor-plugin/plugin.json
+++ b/.github/plugins/dataverse/.cursor-plugin/plugin.json
@@ -1,6 +1,5 @@
 {
   "name": "dataverse",
-  "displayName": "Dataverse",
   "description": "Agent skills for building on, analyzing, and managing Microsoft Dataverse — with Dataverse MCP, PAC CLI, and Python SDK.",
   "version": "1.5.0",
   "author": {

--- a/.github/plugins/dataverse/.cursor-plugin/plugin.json
+++ b/.github/plugins/dataverse/.cursor-plugin/plugin.json
@@ -16,7 +16,7 @@
     "dynamics-365",
     "microsoft"
   ],
-  "logo": "./assets/dataverse-logo.svg",
-  "skills": "./skills/",
+  "logo": "assets/dataverse-logo.svg",
+  "skills": ["skills/"],
   "license": "MIT"
 }

--- a/.github/plugins/dataverse/.cursor-plugin/plugin.json
+++ b/.github/plugins/dataverse/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dataverse",
-  "description": "Agent skills for building on, analyzing, and managing Microsoft Dataverse — with Dataverse MCP, PAC CLI, and Python SDK.",
+  "description": "Microsoft Dataverse plugin for coding agents — powering CRUD, bulk data operations, advanced queries, schema lifecycle, and environment management through intelligent skills.",
   "version": "1.5.0",
   "author": {
     "name": "Microsoft",

--- a/.github/plugins/dataverse/.cursor-plugin/plugin.json
+++ b/.github/plugins/dataverse/.cursor-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "dataverse",
+  "displayName": "Microsoft Dataverse",
   "description": "Microsoft Dataverse plugin for coding agents — powering CRUD, bulk data operations, advanced queries, schema lifecycle, and environment management through intelligent skills.",
   "version": "1.5.0",
   "author": {

--- a/.github/plugins/dataverse/.cursor-plugin/plugin.json
+++ b/.github/plugins/dataverse/.cursor-plugin/plugin.json
@@ -17,5 +17,6 @@
     "microsoft"
   ],
   "logo": "./assets/azure-logo.svg",
+  "skills": "./skills/",
   "license": "MIT"
 }

--- a/.github/plugins/dataverse/.cursor-plugin/plugin.json
+++ b/.github/plugins/dataverse/.cursor-plugin/plugin.json
@@ -16,7 +16,7 @@
     "dynamics-365",
     "microsoft"
   ],
-  "logo": "./assets/azure-logo.svg",
+  "logo": "./assets/dataverse-logo.svg",
   "skills": "./skills/",
   "license": "MIT"
 }

--- a/.github/plugins/dataverse/.github/plugin/plugin.json
+++ b/.github/plugins/dataverse/.github/plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dataverse",
-  "description": "Agent skills for building on, analyzing, and managing Microsoft Dataverse — with Dataverse MCP, PAC CLI, and Python SDK.",
+  "description": "Microsoft Dataverse plugin for coding agents — powering CRUD, bulk data operations, advanced queries, schema lifecycle, and environment management through intelligent skills.",
   "version": "1.5.0",
   "author": {
     "name": "Microsoft",

--- a/.github/plugins/dataverse/assets/dataverse-logo.svg
+++ b/.github/plugins/dataverse/assets/dataverse-logo.svg
@@ -1,0 +1,60 @@
+<svg width="96" height="96" viewBox="0 0 96 96" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_4303_1230)">
+<g clip-path="url(#clip1_4303_1230)">
+<g clip-path="url(#clip2_4303_1230)">
+<path d="M13.8776 21.8242C29.1033 8.13791 49.7501 8.1861 62.955 18.9134C74.9816 28.6836 77.4697 44.3159 70.851 55.7801C64.2321 67.2443 52.5277 70.1455 39.5011 62.6247L31.7286 76.087L31.7234 76.0862C27.4181 83.5324 17.8937 86.0828 10.4437 81.7817C7.45394 80.0556 5.25322 77.4879 3.96665 74.551L3.96096 74.5511C-4.07832 55.7804 0.200745 34.1184 13.8776 21.8242Z" fill="url(#paint0_radial_4303_1230)"/>
+<path d="M13.8776 21.8242C29.1033 8.13791 49.7501 8.1861 62.955 18.9134C74.9816 28.6836 77.4697 44.3159 70.851 55.7801C64.2321 67.2443 52.5277 70.1455 39.5011 62.6247L31.7286 76.087L31.7234 76.0862C27.4181 83.5324 17.8937 86.0828 10.4437 81.7817C7.45394 80.0556 5.25322 77.4879 3.96665 74.551L3.96096 74.5511C-4.07832 55.7804 0.200745 34.1184 13.8776 21.8242Z" fill="url(#paint1_radial_4303_1230)" fill-opacity="0.8"/>
+<path d="M85.4327 14.2231C88.4528 15.9668 90.6686 18.569 91.9494 21.5433L91.9533 21.5444C99.9406 40.2943 95.6533 61.9068 81.9983 74.1814C66.7726 87.8677 46.1257 87.8196 32.9209 77.0923C20.8945 67.3221 18.4062 51.6897 25.0249 40.2256C31.6438 28.7614 43.3482 25.8601 56.3748 33.381L64.1434 19.9255L64.1482 19.9249C68.4516 12.4736 77.9805 9.92084 85.4327 14.2231Z" fill="url(#paint2_radial_4303_1230)"/>
+<path d="M85.4327 14.2231C88.4528 15.9668 90.6686 18.569 91.9494 21.5433L91.9533 21.5444C99.9406 40.2943 95.6533 61.9068 81.9983 74.1814C66.7726 87.8677 46.1257 87.8196 32.9209 77.0923C20.8945 67.3221 18.4062 51.6897 25.0249 40.2256C31.6438 28.7614 43.3482 25.8601 56.3748 33.381L64.1434 19.9255L64.1482 19.9249C68.4516 12.4736 77.9805 9.92084 85.4327 14.2231Z" fill="url(#paint3_radial_4303_1230)" fill-opacity="0.9"/>
+<path d="M39.5041 62.6261C52.5307 70.1469 64.2352 67.2456 70.8541 55.7814C77.2488 44.7055 75.1426 29.7389 64.147 19.9271L56.3791 33.3814L39.5041 62.6261Z" fill="url(#paint4_radial_4303_1230)"/>
+<path d="M56.3794 33.3815C43.3528 25.8607 31.6482 28.762 25.0294 40.2262C18.6347 51.3021 20.7409 66.2687 31.7364 76.0806L39.5043 62.6262L56.3794 33.3815Z" fill="url(#paint5_radial_4303_1230)"/>
+<path d="M33.3215 56.4453C37.9837 64.5204 48.3094 67.2872 56.3846 62.625C64.4598 57.9628 67.2266 47.6371 62.5643 39.5619C57.9021 31.4867 47.5764 28.72 39.5013 33.3822C31.4261 38.0444 28.6593 48.3701 33.3215 56.4453Z" fill="url(#paint6_radial_4303_1230)"/>
+</g>
+</g>
+</g>
+<defs>
+<radialGradient id="paint0_radial_4303_1230" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(46.0001 49.4996) rotate(-148.717) scale(46.2195 47.5359)">
+<stop offset="0.465088" stop-color="#09442A"/>
+<stop offset="0.70088" stop-color="#136C6C"/>
+<stop offset="1" stop-color="#22918B"/>
+</radialGradient>
+<radialGradient id="paint1_radial_4303_1230" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(50.0001 32.4996) rotate(123.57) scale(66.0095 46.5498)">
+<stop offset="0.718705" stop-color="#1A7F7C" stop-opacity="0"/>
+<stop offset="1" stop-color="#16BBDA"/>
+</radialGradient>
+<radialGradient id="paint2_radial_4303_1230" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(50.4999 44.5001) rotate(30.75) scale(45.9618 44.5095)">
+<stop offset="0.358097" stop-color="#136C6C"/>
+<stop offset="0.789474" stop-color="#42B870"/>
+<stop offset="1" stop-color="#76D45E"/>
+</radialGradient>
+<radialGradient id="paint3_radial_4303_1230" cx="0" cy="0" r="1" gradientTransform="matrix(42.5 -36.0002 31.1824 36.8127 49.4998 55.5001)" gradientUnits="userSpaceOnUse">
+<stop offset="0.583166" stop-color="#76D45E" stop-opacity="0"/>
+<stop offset="1" stop-color="#C8F5B7"/>
+</radialGradient>
+<radialGradient id="paint4_radial_4303_1230" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(47.5 48) rotate(-58.9042) scale(32.6898)">
+<stop offset="0.486266" stop-color="#22918B"/>
+<stop offset="0.729599" stop-color="#42B870"/>
+<stop offset="1" stop-color="#43E5CA"/>
+</radialGradient>
+<radialGradient id="paint5_radial_4303_1230" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(47.3833 49.0077) rotate(119.859) scale(31.1328 29.4032)">
+<stop offset="0.459553" stop-color="#08494E"/>
+<stop offset="0.742242" stop-color="#1A7F7C"/>
+<stop offset="1" stop-color="#309C61"/>
+</radialGradient>
+<radialGradient id="paint6_radial_4303_1230" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(52.5 40) rotate(120.784) scale(27.3542)">
+<stop stop-color="#C8F5B7"/>
+<stop offset="0.24583" stop-color="#98F0B0"/>
+<stop offset="0.643961" stop-color="#52D17C"/>
+<stop offset="1" stop-color="#119FC5"/>
+</radialGradient>
+<clipPath id="clip0_4303_1230">
+<rect width="96" height="96" fill="white"/>
+</clipPath>
+<clipPath id="clip1_4303_1230">
+<rect width="96" height="96" fill="white"/>
+</clipPath>
+<clipPath id="clip2_4303_1230">
+<rect width="95.9998" height="96" fill="white"/>
+</clipPath>
+</defs>
+</svg>


### PR DESCRIPTION
## What

Adds the Dataverse plugin icon and keeps the plugin metadata consistent across the marketplace manifests.

## Changes

- **Icon** — `assets/dataverse-logo.svg` (square, transparent), referenced from `.cursor-plugin/plugin.json` via the `logo` field.
- **displayName** — `"Microsoft Dataverse"` for the Cursor listing.
- **Description** — one shared plugin description across all `plugin.json` and `marketplace.json` manifests.
- **Static checks** — `EVAL-DESC-01` (plugin description matches across manifests) and `EVAL-ASSET-01` (relative `logo` paths resolve to a real file).
