### PR TITLE
add: Add Business Skills consumption (catalog at connect)

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "dataverse-skills",
   "metadata": {
     "description": "Official Dataverse plugin marketplace for agent-guided development",
-    "version": "1.6.0"
+    "version": "1.6.1"
   },
   "owner": {
     "name": "Microsoft",
@@ -13,7 +13,7 @@
       "name": "dataverse",
       "description": "Microsoft Dataverse plugin for coding agents — powering CRUD, bulk data operations, advanced queries, schema lifecycle, and environment management through intelligent skills that unify MCP, CLI, and SDK workflows.",
       "source": "./.github/plugins/dataverse",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "homepage": "https://github.com/microsoft/Dataverse-skills"
     }
   ]

--- a/.github/plugins/dataverse/.claude-plugin/plugin.json
+++ b/.github/plugins/dataverse/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dataverse",
   "description": "Microsoft Dataverse plugin for coding agents — powering CRUD, bulk data operations, advanced queries, schema lifecycle, and environment management through intelligent skills that unify MCP, CLI, and SDK workflows.",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "author": {
     "name": "Microsoft",
     "url": "https://www.microsoft.com"

--- a/.github/plugins/dataverse/.codex-plugin/plugin.json
+++ b/.github/plugins/dataverse/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dataverse",
   "description": "Microsoft Dataverse plugin for coding agents — powering CRUD, bulk data operations, advanced queries, schema lifecycle, and environment management through intelligent skills that unify MCP, CLI, and SDK workflows.",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "author": {
     "name": "Microsoft",
     "url": "https://www.microsoft.com"

--- a/.github/plugins/dataverse/.cursor-plugin/plugin.json
+++ b/.github/plugins/dataverse/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "dataverse",
   "displayName": "Microsoft Dataverse",
   "description": "Microsoft Dataverse plugin for coding agents — powering CRUD, bulk data operations, advanced queries, schema lifecycle, and environment management through intelligent skills that unify MCP, CLI, and SDK workflows.",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "author": {
     "name": "Microsoft",
     "url": "https://www.microsoft.com"

--- a/.github/plugins/dataverse/.github/plugin/plugin.json
+++ b/.github/plugins/dataverse/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dataverse",
   "description": "Microsoft Dataverse plugin for coding agents — powering CRUD, bulk data operations, advanced queries, schema lifecycle, and environment management through intelligent skills that unify MCP, CLI, and SDK workflows.",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "author": {
     "name": "Microsoft",
     "url": "https://www.microsoft.com"

--- a/.github/plugins/dataverse/skills/dv-connect/SKILL.md
+++ b/.github/plugins/dataverse/skills/dv-connect/SKILL.md
@@ -316,14 +316,9 @@ This exercises two Dataverse MCP endpoints with a fresh authentication handshake
 - **GA / Production endpoint** — `{DATAVERSE_URL}/api/mcp`. This is the one the plugin actually uses at runtime.
 - **Preview endpoint** — `{DATAVERSE_URL}/api/mcp_preview`. Opt-in per environment; not used by the plugin.
 
-**Do not use `--validate` as a success gate on first-time setup.** On a freshly configured workspace, the token cache hasn't warmed up, so `--validate` can fail with `MsalClientException` or `403` while MCP is actually working fine on subsequent real calls. Reserve `--validate` for diagnosing a confirmed failure in Check 1 or Check 2.
+**Do not use `--validate` as a success gate on first-time setup.** On a fresh workspace the token cache hasn't warmed up, so `--validate` can fail with `MsalClientException` or `403` while MCP works fine on real calls. Reserve it for diagnosing a confirmed Check 1 / Check 2 failure.
 
-**How to read `--validate` output:**
-
-- **Look at the GA / Production endpoint (`/api/mcp`) result first.** If this passes, MCP will work for normal plugin usage regardless of what the Preview endpoint reports.
-- **A `403 Forbidden` on the Preview endpoint (`/api/mcp_preview`) is expected for most environments.** Preview is opt-in per environment; if your environment hasn't enabled it, the Preview check will always fail. This does not indicate a broken setup.
-- **Ignore the overall exit code and the `⚠ Partial success` warning in this case.** The validator returns exit code `1` (failure) unless BOTH `/api/mcp` and `/api/mcp_preview` pass. Because most environments don't enable the Preview endpoint, `--validate` will exit `1` even when MCP is fully functional via the GA endpoint. Focus on per-endpoint results, not the aggregate status.
-- **If the GA endpoint (`/api/mcp`) fails:** that's the real signal to investigate — auth, tenant consent, environment allowlist, or endpoint reachability.
+**How to read `--validate` output:** Judge by the **GA endpoint (`/api/mcp`)** result alone — if it passes, MCP works for normal usage. A `403` on the **Preview endpoint (`/api/mcp_preview`)** is expected (it's opt-in per environment), and the validator still exits `1` whenever Preview fails — so ignore the aggregate exit code and the `⚠ Partial success` warning. If the GA endpoint itself fails, that's the real signal to investigate: auth, tenant consent, environment allowlist, or endpoint reachability.
 
 ### MCP Server Capabilities
 
@@ -349,6 +344,14 @@ After verifying MCP works, tell the user:
 >
 > To create your first solution, see the `dv-solution` skill.
 > To load sample data (accounts, contacts, opportunities), ask: "Load demo data into my Dataverse environment."
+
+---
+
+## Step 8: Load Business Skills catalog (once per session)
+
+Some environments define **Business Skills** — `skill` records holding org-specific instructions. After the connection is verified, check once whether the org has any; if so, load the catalog (`skillid`, `name`, `description`) into context for the session, so the agent can pull a skill's `body` on demand when a request matches. Most orgs have none — then skip.
+
+See [`references/business-skills.md`](references/business-skills.md) for the probe and how to consult.
 
 ---
 

--- a/.github/plugins/dataverse/skills/dv-connect/references/business-skills.md
+++ b/.github/plugins/dataverse/skills/dv-connect/references/business-skills.md
@@ -1,0 +1,63 @@
+# Business Skills — consuming org-specific guidance
+
+**Business Skills** are records in the `skill` entity that hold **org-specific domain
+instructions** — playbooks like refund handling, lead qualification, or case escalation. They
+are *environment-specific*: authored and curated per Dataverse environment, so they differ
+across orgs (unlike the bundled `dv-*` skills, which are the same everywhere). **Most
+environments have none.**
+
+This reference covers **consuming existing** Business Skills. Authoring and managing them
+(create/update/delete, file resources) is out of scope here.
+
+## The model: load the catalog once, pull bodies on demand
+
+A skill's `body` is the full instruction content and can be large, so don't load bodies
+wholesale, and don't query the `skill` entity on every operation. Instead:
+
+1. **Once per session** (at `dv-connect`, after the connection is verified), check whether the
+   org has any skills. If it does, load the lightweight **catalog** — `skillid`, `name`,
+   `description` only — into context and keep it for the session. If none, stop here.
+2. **On demand:** when a user request matches a catalog entry's `description`, fetch just that
+   skill's `body` and follow its instructions.
+
+The catalog is cheap: name + description is ~40–60 tokens per skill, so even a few dozen skills
+is ~1k tokens loaded once — negligible. Matching is done by the agent reading the descriptions,
+not by keyword search, so natural-language requests ("qualify this lead") resolve to the right
+skill (e.g. `Lead-Qualifier`) even when the names don't share words.
+
+### Setup
+
+```python
+import os, sys
+sys.path.insert(0, os.path.join(os.getcwd(), "scripts"))
+from auth import get_client
+
+client = get_client("dv-connect")
+```
+
+### Load the catalog (once per session)
+
+```python
+# Lightweight index — names + descriptions, no bodies.
+catalog = client.records.get("skill", select="skillid,name,description")
+# If empty, the org has no Business Skills — skip consultation for the rest of the session.
+```
+
+### Consult a skill (on demand, when a request matches)
+
+```python
+# The agent picks the matching skill from the catalog by description, then pulls its body:
+skill = client.records.get("skill", select="name,body",
+                           filter="skillid eq '<id-from-catalog>'")
+# Incorporate skill[0]["body"] as domain context before generating the operation.
+```
+
+Finding no relevant skill is fine — the org may only have skills for unrelated domains. Proceed
+with standard SDK/MCP work.
+
+## When the org has many skills
+
+Loading the full catalog stays comfortable into the low hundreds of skills. Past that, the
+catalog itself gets heavy and discovery should move to a server-side retrieval channel (e.g. the
+MCP server's per-org `instructions`) rather than preloading every description. That's a future
+enhancement — not needed for the common single- to double-digit case.

--- a/.github/plugins/dataverse/skills/dv-data/SKILL.md
+++ b/.github/plugins/dataverse/skills/dv-data/SKILL.md
@@ -27,6 +27,8 @@ Use the official Microsoft Power Platform Dataverse Client Python SDK for all da
 
 **If MCP tools are available** (`create_record`, `update_record`) and the task is ≤10 records, **use MCP directly — no script needed.** Only write a Python script when the task requires: bulk operations (10+ records), data transformation, retry logic, CSV import, or operations the SDK supports that MCP cannot (upsert, file uploads). Sequential MCP tool calls are not "multi-step logic" — use MCP for those.
 
+**Business Skills:** If a Business Skills catalog was loaded at connect (see dv-connect Step 8) and one governs this write — e.g. a refund or escalation rule — consult that skill's `body` from the **already-loaded catalog** before generating code. Don't re-query the `skill` entity per operation. See [`../dv-connect/references/business-skills.md`](../dv-connect/references/business-skills.md).
+
 ## SDK-First Rule
 
 **If an operation is in the "supports" list below, you MUST use the SDK — not `urllib`, `requests`, or raw HTTP.**

--- a/.github/plugins/dataverse/skills/dv-query/SKILL.md
+++ b/.github/plugins/dataverse/skills/dv-query/SKILL.md
@@ -11,6 +11,8 @@ description: Bulk reads, multi-page iteration, and analytics over Dataverse data
 
 **All reads use the SDK — not `urllib`, `requests`, or raw HTTP.** This is the same rule as dv-data's SDK-First Rule, applied to reads. If you find yourself writing `urllib.request` or `get_token()` for a query, STOP — the SDK handles it. The only exceptions are `$apply` aggregation and N:N `$expand`, documented below.
 
+**Business Skills:** If a Business Skills catalog was loaded at connect (see dv-connect Step 8) and one governs this read — e.g. an org rule for what counts as "open" or "high-priority" — consult that skill's `body` from the **already-loaded catalog** before generating the query. Don't re-query the `skill` entity per operation. See [`../dv-connect/references/business-skills.md`](../dv-connect/references/business-skills.md).
+
 ## How to Answer Data Questions
 
 When the user asks a question about their data, pick the approach by **what they're asking**, not by which API you know:


### PR DESCRIPTION
## Summary

Adds **consumption** support for Dataverse Business Skills (`skill` entity records holding org-specific domain instructions) without taxing the majority of environments that have none.

The agent detects once per session, at connect, whether the org defines any Business Skills. If it does, it loads a lightweight catalog (`skillid`, `name`, `description`) into context for the session and pulls a skill's full `body` on demand when a request matches one by description. If the org has none — the common case — the capability stays dormant: no per-operation queries, no added context cost.

## What changed

- **dv-connect** — a step to detect and load the Business Skills catalog once per session, plus `references/business-skills.md` covering the model, the probe query, and how to consult a skill. (The `--validate` troubleshooting block was condensed to keep the skill within its token budget.)
- **dv-data / dv-query** — a short, conditional reminder to consult the already-loaded catalog when an operation is governed by a Business Skill. This is explicitly **not** a per-operation re-query.
- Version bump 1.6.0 → 1.6.1.

## Scope

Consumption only. Authoring and management of Business Skills (create/update/delete, file resources, validation, publishing) is intentionally out of scope here.

## Design notes

- Matching is done by the agent reading catalog **descriptions**, not by keyword search, so natural-language requests resolve to the right skill even when names differ.
- Loading the full catalog is cheap into the low hundreds of skills; beyond that, discovery should move to a server-side retrieval channel (future enhancement).

## TODO — evaluations (follow-up)

Behavioral evals are required before this is considered validated; `static_checks` only covers structure. Planned as a `business-skills.biceval.json` ablation suite plus a regression pass:

- **Efficacy (org _with_ skills):**
  - A governed request (e.g. "import refunds following our process") loads the catalog at connect and consults the matching skill's `body`.
  - A natural-language request resolves to the correct skill by description, not keyword.
  - An unrelated request injects no skill body (precision).
  - The catalog probe fires once per session, not per operation.
- **Safety (org _without_ skills, and existing scenarios):**
  - No-skill orgs perform data/query operations with **no** `skill`-entity query and no added context — behavior identical to baseline (guards against re-introducing a per-op tax via the dv-data/dv-query reminders).
  - Re-run existing dv-data / dv-query suites on this branch vs baseline; no score regression on any test.
- **Fixtures:** requires a test environment seeded with sample Business Skills and a clean one with none (or mocked skill-table responses).
- **Post-ship:** confirm via telemetry that `skill`-entity read volume rises only in orgs that have skills, and that dv-data / dv-query latency is unchanged for orgs without.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
