### PR TITLE
docs: update Cursor install for the GA Marketplace listing

### DIFF
--- a/.github/plugins/dataverse/skills/dv-security/SKILL.md
+++ b/.github/plugins/dataverse/skills/dv-security/SKILL.md
@@ -120,4 +120,3 @@ Before running `pac admin self-elevate`, the agent MUST:
 - **Always confirm** before assigning System Administrator role
 - Show the list of target environments before batch operations
 - Self-elevation is logged and auditable — warn the user
-

--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ codex plugin marketplace upgrade dataverse-skills
 
 ### Cursor
 
-Local install (a Cursor Marketplace listing is coming — tracked in #76):
+Install from the [Cursor Marketplace](https://cursor.com/marketplace/microsoft-dataverse) — open the listing and click **Add**, or inside Cursor go to **Settings → Plugins**, search for **Dataverse**, and install **Microsoft Dataverse**.
+
+**Install from source (development)**
 
 ```bash
 git clone https://github.com/microsoft/Dataverse-skills.git

--- a/README.md
+++ b/README.md
@@ -60,9 +60,19 @@ codex plugin marketplace upgrade dataverse-skills
 
 ### Cursor
 
+**From the marketplace UI**
+
 1. Open **Settings → Plugins** in Cursor.
 2. Search the Marketplace for **Dataverse**.
-3. Open **Microsoft Dataverse** and select **Install**.
+3. Open **Microsoft Dataverse** and select **Add to Cursor**.
+
+**From agent chat**
+
+Type the install command in the Cursor agent chat:
+
+```text
+/add-plugin dataverse
+```
 
 The listing is published at [cursor.com/marketplace/microsoft-dataverse](https://cursor.com/marketplace/microsoft-dataverse).
 

--- a/README.md
+++ b/README.md
@@ -66,19 +66,6 @@ codex plugin marketplace upgrade dataverse-skills
 
 The listing is published at [cursor.com/marketplace/microsoft-dataverse](https://cursor.com/marketplace/microsoft-dataverse).
 
-**Install from source (development)**
-
-```bash
-git clone https://github.com/microsoft/Dataverse-skills.git
-```
-
-Then copy the plugin directory into your Cursor local plugins folder:
-
-- **Windows:** copy `Dataverse-skills\.github\plugins\dataverse` to `%USERPROFILE%\.cursor\plugins\local\dataverse\`
-- **macOS / Linux:** copy `Dataverse-skills/.github/plugins/dataverse` to `~/.cursor/plugins/local/dataverse/`
-
-Reload the Cursor window (Ctrl+Shift+P → "Developer: Reload Window") to load the `dv-*` skills.
-
 ## Verify the install
 
 After installation, ask your agent:

--- a/README.md
+++ b/README.md
@@ -60,7 +60,11 @@ codex plugin marketplace upgrade dataverse-skills
 
 ### Cursor
 
-Install from the [Cursor Marketplace](https://cursor.com/marketplace/microsoft-dataverse) — open the listing and click **Add**, or inside Cursor go to **Settings → Plugins**, search for **Dataverse**, and install **Microsoft Dataverse**.
+1. Open **Settings → Plugins** in Cursor.
+2. Search the Marketplace for **Dataverse**.
+3. Open **Microsoft Dataverse** and select **Install**.
+
+The listing is published at [cursor.com/marketplace/microsoft-dataverse](https://cursor.com/marketplace/microsoft-dataverse).
 
 **Install from source (development)**
 

--- a/README.md
+++ b/README.md
@@ -60,19 +60,17 @@ codex plugin marketplace upgrade dataverse-skills
 
 ### Cursor
 
+**From agent chat**
+
+```bash
+/add-plugin dataverse
+```
+
 **From the marketplace UI**
 
 1. Open **Settings → Plugins** in Cursor.
 2. Search the Marketplace for **Dataverse**.
 3. Open **Microsoft Dataverse** and select **Add to Cursor**.
-
-**From agent chat**
-
-Type the install command in the Cursor agent chat:
-
-```text
-/add-plugin dataverse
-```
 
 The listing is published at [cursor.com/marketplace/microsoft-dataverse](https://cursor.com/marketplace/microsoft-dataverse).
 


### PR DESCRIPTION
## What

Updates the **Cursor** install instructions in the README now that the **Microsoft Dataverse** plugin is **generally available** on the Cursor Marketplace: https://cursor.com/marketplace/microsoft-dataverse

## Changes

- Lead the Cursor section with the **Marketplace install** — add from the listing, or inside Cursor go to **Settings → Plugins**, search **Dataverse**, and install **Microsoft Dataverse**.
- Keep the **from-source** steps as a development fallback (relabeled, no longer the primary path).
- Remove the outdated "a Cursor Marketplace listing is coming" note.

## Why

The listing went GA, so the README should point users at the one-click Marketplace install instead of the manual local-copy workflow. This matches how the sibling `microsoft/azure-skills` README documents its Cursor Marketplace install.

## Testing

- `python .github/evals/static_checks.py` → PASSED (8 skill files, 45 Python blocks, 10 categories).
- Docs-only change; no skill files touched, so no version bump required.
