### PR TITLE
refactor: extract non-critical reference detail to create skill headroom

### DIFF
--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -3,7 +3,7 @@
   "name": "dataverse-skills",
   "metadata": {
     "description": "Official Dataverse plugin marketplace for Cursor",
-    "version": "1.6.0"
+    "version": "1.6.1"
   },
   "owner": {
     "name": "Microsoft",
@@ -14,7 +14,7 @@
       "name": "dataverse",
       "description": "Microsoft Dataverse plugin for coding agents — powering CRUD, bulk data operations, advanced queries, schema lifecycle, and environment management through intelligent skills that unify MCP, CLI, and SDK workflows.",
       "source": "./.github/plugins/dataverse",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "homepage": "https://github.com/microsoft/Dataverse-skills"
     }
   ]

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "dataverse-skills",
   "metadata": {
     "description": "Official Dataverse plugin marketplace for agent-guided development",
-    "version": "1.6.0"
+    "version": "1.6.1"
   },
   "owner": {
     "name": "Microsoft",
@@ -13,7 +13,7 @@
       "name": "dataverse",
       "description": "Microsoft Dataverse plugin for coding agents — powering CRUD, bulk data operations, advanced queries, schema lifecycle, and environment management through intelligent skills that unify MCP, CLI, and SDK workflows.",
       "source": "./.github/plugins/dataverse",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "homepage": "https://github.com/microsoft/Dataverse-skills"
     }
   ]

--- a/.github/plugins/dataverse/.claude-plugin/plugin.json
+++ b/.github/plugins/dataverse/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dataverse",
   "description": "Microsoft Dataverse plugin for coding agents — powering CRUD, bulk data operations, advanced queries, schema lifecycle, and environment management through intelligent skills that unify MCP, CLI, and SDK workflows.",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "author": {
     "name": "Microsoft",
     "url": "https://www.microsoft.com"

--- a/.github/plugins/dataverse/.codex-plugin/plugin.json
+++ b/.github/plugins/dataverse/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dataverse",
   "description": "Microsoft Dataverse plugin for coding agents — powering CRUD, bulk data operations, advanced queries, schema lifecycle, and environment management through intelligent skills that unify MCP, CLI, and SDK workflows.",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "author": {
     "name": "Microsoft",
     "url": "https://www.microsoft.com"

--- a/.github/plugins/dataverse/.cursor-plugin/plugin.json
+++ b/.github/plugins/dataverse/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "dataverse",
   "displayName": "Microsoft Dataverse",
   "description": "Microsoft Dataverse plugin for coding agents — powering CRUD, bulk data operations, advanced queries, schema lifecycle, and environment management through intelligent skills that unify MCP, CLI, and SDK workflows.",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "author": {
     "name": "Microsoft",
     "url": "https://www.microsoft.com"

--- a/.github/plugins/dataverse/.github/plugin/plugin.json
+++ b/.github/plugins/dataverse/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dataverse",
   "description": "Microsoft Dataverse plugin for coding agents — powering CRUD, bulk data operations, advanced queries, schema lifecycle, and environment management through intelligent skills that unify MCP, CLI, and SDK workflows.",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "author": {
     "name": "Microsoft",
     "url": "https://www.microsoft.com"

--- a/.github/plugins/dataverse/skills/dv-admin/SKILL.md
+++ b/.github/plugins/dataverse/skills/dv-admin/SKILL.md
@@ -216,24 +216,7 @@ Step 3: pac data retention set --entity activitypointer --criteria "<fetchxml>..
 Step 4: pac data retention show --id <config-id>
 ```
 
-### Commands
-
-```bash
-pac data retention enable-entity --entity activitypointer --environment https://myorg.crm.dynamics.com
-pac data retention set --entity activitypointer \
-    --criteria "<fetch><entity name='activitypointer'><filter><condition attribute='createdon' operator='lt' value='2023-01-01'/></filter></entity></fetch>"
-pac data retention list --environment https://myorg.crm.dynamics.com
-pac data retention show --id <config-id>
-pac data retention status --id <operation-id>
-```
-
-| Argument | Alias | Required | Description |
-|----------|-------|----------|-------------|
-| `--entity` | `-e` | Yes | Logical name of the table |
-| `--criteria` | `-c` | Yes | FetchXML defining which records to archive |
-| `--start-time` | `-st` | No | ISO 8601 start time. Defaults to now |
-| `--recurrence` | `-r` | No | RFC 5545 recurrence pattern |
-| `--environment` | `-env` | No | Target environment URL |
+For the full `pac data retention` command syntax (`enable-entity` / `set` / `list` / `show` / `status`) and the argument reference table, see [`references/retention.md`](references/retention.md).
 
 ### Retention vs Bulk Delete
 

--- a/.github/plugins/dataverse/skills/dv-admin/references/retention.md
+++ b/.github/plugins/dataverse/skills/dv-admin/references/retention.md
@@ -1,0 +1,24 @@
+# Data Retention / Archival — `pac data retention` command reference
+
+Data retention moves old records to long-term storage without permanently deleting them. This is the full command syntax and argument reference for the `dv-admin` retention flow.
+
+## Commands
+
+```bash
+pac data retention enable-entity --entity activitypointer --environment https://myorg.crm.dynamics.com
+pac data retention set --entity activitypointer \
+    --criteria "<fetch><entity name='activitypointer'><filter><condition attribute='createdon' operator='lt' value='2023-01-01'/></filter></entity></fetch>"
+pac data retention list --environment https://myorg.crm.dynamics.com
+pac data retention show --id <config-id>
+pac data retention status --id <operation-id>
+```
+
+## Argument reference (`pac data retention set`)
+
+| Argument | Alias | Required | Description |
+|----------|-------|----------|-------------|
+| `--entity` | `-e` | Yes | Logical name of the table |
+| `--criteria` | `-c` | Yes | FetchXML defining which records to archive |
+| `--start-time` | `-st` | No | ISO 8601 start time. Defaults to now |
+| `--recurrence` | `-r` | No | RFC 5545 recurrence pattern |
+| `--environment` | `-env` | No | Target environment URL |

--- a/.github/plugins/dataverse/skills/dv-connect/SKILL.md
+++ b/.github/plugins/dataverse/skills/dv-connect/SKILL.md
@@ -311,19 +311,7 @@ Only when **both** checks pass is the setup verified.
 ```
 npx @microsoft/dataverse mcp {DATAVERSE_URL} --validate
 ```
-This exercises two Dataverse MCP endpoints with a fresh authentication handshake and reports detailed errors (auth, allowlist, consent, endpoint reachability):
-
-- **GA / Production endpoint** — `{DATAVERSE_URL}/api/mcp`. This is the one the plugin actually uses at runtime.
-- **Preview endpoint** — `{DATAVERSE_URL}/api/mcp_preview`. Opt-in per environment; not used by the plugin.
-
-**Do not use `--validate` as a success gate on first-time setup.** On a freshly configured workspace, the token cache hasn't warmed up, so `--validate` can fail with `MsalClientException` or `403` while MCP is actually working fine on subsequent real calls. Reserve `--validate` for diagnosing a confirmed failure in Check 1 or Check 2.
-
-**How to read `--validate` output:**
-
-- **Look at the GA / Production endpoint (`/api/mcp`) result first.** If this passes, MCP will work for normal plugin usage regardless of what the Preview endpoint reports.
-- **A `403 Forbidden` on the Preview endpoint (`/api/mcp_preview`) is expected for most environments.** Preview is opt-in per environment; if your environment hasn't enabled it, the Preview check will always fail. This does not indicate a broken setup.
-- **Ignore the overall exit code and the `⚠ Partial success` warning in this case.** The validator returns exit code `1` (failure) unless BOTH `/api/mcp` and `/api/mcp_preview` pass. Because most environments don't enable the Preview endpoint, `--validate` will exit `1` even when MCP is fully functional via the GA endpoint. Focus on per-endpoint results, not the aggregate status.
-- **If the GA endpoint (`/api/mcp`) fails:** that's the real signal to investigate — auth, tenant consent, environment allowlist, or endpoint reachability.
+**Do NOT use `--validate` as a success gate on first-time setup.** On a cold token cache it can fail with `MsalClientException` or `403` while MCP works fine on subsequent real calls. Reserve it for diagnosing a confirmed Check 1 or Check 2 failure. It exercises two endpoints — the GA `/api/mcp` (what the plugin uses) and the opt-in Preview `/api/mcp_preview` (expected to `403` on most envs, making the aggregate exit code `1` even when MCP is healthy). For how to read the per-endpoint output, see [mcp-configuration.md](references/mcp-configuration.md#reading---validate-output).
 
 ### MCP Server Capabilities
 

--- a/.github/plugins/dataverse/skills/dv-connect/references/mcp-configuration.md
+++ b/.github/plugins/dataverse/skills/dv-connect/references/mcp-configuration.md
@@ -609,3 +609,19 @@ If something goes wrong, help the user check:
   - If `--validate` returns **403 Forbidden** on the GA endpoint, the client isn't allowlisted yet — run `dataverse mcp allow {MCP_CLIENT_ID}` (Step 7, Method A), then re-validate.
   - Confirm the server entry exists: look for `[mcp_servers.{SERVER_NAME}]` in `~/.codex/config.toml` (global) or `.codex/config.toml` (project).
   - If `npx` can't be found when Codex launches the server, ensure Node.js 18+ is on PATH; on Windows the proxy command may need `cmd /c` wrapping (see Step 5).
+
+---
+
+## Reading `--validate` output
+
+`npx @microsoft/dataverse mcp {DATAVERSE_URL} --validate` exercises two Dataverse MCP endpoints with a fresh authentication handshake and reports detailed errors (auth, allowlist, consent, endpoint reachability):
+
+- **GA / Production endpoint** — `{DATAVERSE_URL}/api/mcp`. This is the one the plugin actually uses at runtime.
+- **Preview endpoint** — `{DATAVERSE_URL}/api/mcp_preview`. Opt-in per environment; not used by the plugin.
+
+How to interpret the results:
+
+- **Look at the GA / Production endpoint (`/api/mcp`) result first.** If this passes, MCP will work for normal plugin usage regardless of what the Preview endpoint reports.
+- **A `403 Forbidden` on the Preview endpoint (`/api/mcp_preview`) is expected for most environments.** Preview is opt-in per environment; if your environment hasn''t enabled it, the Preview check will always fail. This does not indicate a broken setup.
+- **Ignore the overall exit code and the `Partial success` warning in this case.** The validator returns exit code `1` (failure) unless BOTH `/api/mcp` and `/api/mcp_preview` pass. Because most environments don''t enable the Preview endpoint, `--validate` will exit `1` even when MCP is fully functional via the GA endpoint. Focus on per-endpoint results, not the aggregate status.
+- **If the GA endpoint (`/api/mcp`) fails:** that''s the real signal to investigate — auth, tenant consent, environment allowlist, or endpoint reachability.

--- a/.github/plugins/dataverse/skills/dv-overview/SKILL.md
+++ b/.github/plugins/dataverse/skills/dv-overview/SKILL.md
@@ -225,13 +225,7 @@ Any Web API call that goes beyond a one-off query should be written as a Python 
 
 ## Windows Scripting Rules
 
-When running in a Unix-style shell on Windows (Git Bash is the default for Claude Code on Windows; Cursor and Copilot may use PowerShell — the same rules apply, adapt path/quoting syntax as needed):
-
-- **ASCII only in `.py` files.** Curly quotes, em dashes, or other non-ASCII characters cause `SyntaxError`. Use straight quotes and regular dashes.
-- **No `python -c` for multiline code.** Shell quoting differences between Git Bash and CMD break multiline `python -c` commands. Write a `.py` file instead.
-- **PAC CLI may need a PowerShell wrapper.** If `pac` hangs or fails in Git Bash, use `powershell -Command "& pac.cmd <args>"`. See the setup skill for details.
-- **Generate GUIDs in Python scripts**, not via shell backtick-substitution: `str(uuid.uuid4())` inside the `.py` file.
-- **Background job output may be empty on Windows.** Agent background task runners on Windows (e.g., Claude Code's "Running in the background") can silently produce no output. Always use `python -u` (unbuffered stdout) and `print(..., flush=True)` in long-running scripts. For foreground execution with logging: `python -u scripts/import_data.py 2>&1 | tee /tmp/out.txt`. Do NOT assume a background task succeeded just because it appeared to finish.
+Running Python / PAC CLI on Windows has platform gotchas: ASCII-only `.py` files, no multiline `python -c`, a PowerShell wrapper for `pac` when Git Bash hangs, in-script GUID generation, and unbuffered output (`python -u`, `flush=True`) for background jobs. Before writing or running scripts on Windows, see [`references/windows-scripting.md`](references/windows-scripting.md).
 
 ---
 

--- a/.github/plugins/dataverse/skills/dv-overview/references/windows-scripting.md
+++ b/.github/plugins/dataverse/skills/dv-overview/references/windows-scripting.md
@@ -1,0 +1,9 @@
+# Windows Scripting Rules
+
+When running Python or PAC CLI in a Unix-style shell on Windows (Git Bash is the default for Claude Code on Windows; Cursor and Copilot may use PowerShell — the same rules apply, adapt path/quoting syntax as needed):
+
+- **ASCII only in `.py` files.** Curly quotes, em dashes, or other non-ASCII characters cause `SyntaxError`. Use straight quotes and regular dashes.
+- **No `python -c` for multiline code.** Shell quoting differences between Git Bash and CMD break multiline `python -c` commands. Write a `.py` file instead.
+- **PAC CLI may need a PowerShell wrapper.** If `pac` hangs or fails in Git Bash, use `powershell -Command "& pac.cmd <args>"`. See the `dv-connect` setup skill for details.
+- **Generate GUIDs in Python scripts**, not via shell backtick-substitution: `str(uuid.uuid4())` inside the `.py` file.
+- **Background job output may be empty on Windows.** Agent background task runners on Windows (e.g., Claude Code's "Running in the background") can silently produce no output. Always use `python -u` (unbuffered stdout) and `print(..., flush=True)` in long-running scripts. For foreground execution with logging: `python -u scripts/import_data.py 2>&1 | tee /tmp/out.txt`. Do NOT assume a background task succeeded just because it appeared to finish.


### PR DESCRIPTION
## What

Behavior-neutral refactor that frees token headroom in the three at-capacity skill bodies so that ERP (Finance & Operations) support can be added in a follow-up PR without breaching the 5000-token `SKILL.md` body cap enforced by `EVAL-BUDGET-02`.

No new capability, no routing change, no auth change — this is a pure Level-2 → Level-3 extraction following Anthropic's progressive-disclosure guidance and the repo's own `CLAUDE.md` token-budget rules.

## Why

Measured body token counts (tiktoken `cl100k_base`, the counter the CI eval uses) on `main` left almost no room to add content:

| Skill | Before | After |
|---|---|---|
| dv-connect | 4996 (**4** free) | 4747 (**253** free) |
| dv-admin | 4961 (**39** free) | 4783 (**217** free) |
| dv-overview | 4864 (**136** free) | 4655 (**345** free) |

## Extraction discipline

Only **reference-lookup** material was moved. All **decision logic and safety rules stay inline** in the body, because small-model agents sometimes read a reference link's filename and stop without opening it — so anything the agent needs to decide correctly or act safely must remain in Level 2.

- **dv-connect** — moved the `--validate` two-endpoint output *interpretation* into `references/mcp-configuration.md`. The critical rule ("do NOT use `--validate` as a first-time success gate") stays inline.
- **dv-admin** — moved the `pac data retention` command syntax + argument table into a new `references/retention.md`. The agentic flow and the retention-vs-bulk-delete *decision* table stay inline. No safety-callout content touched.
- **dv-overview** — moved the Windows scripting rules (operational detail, not routing) into a new `references/windows-scripting.md`.

## Validation

- `python .github/evals/static_checks.py` → **PASSED** (8 skill files, 45 Python blocks, 10 categories)
- `python .github/evals/version_bump_check.py` → **PASSED** (1.6.0 → 1.6.1, patch bump)
- Version bumped in all 8 fields across 6 files (PATCH — no user-visible behavior change).

## Follow-up

The ERP support content (from the earlier ERP PRs) will land in a separate PR on top of this base, using thin gated routers inline + the ERP how-to detail in `references/erp-*.md`.
