### PR TITLE
fix: correct Codex plugin.json defaultPrompt count and shortDescription length

### DIFF
--- a/.github/plugins/dataverse/.codex-plugin/plugin.json
+++ b/.github/plugins/dataverse/.codex-plugin/plugin.json
@@ -13,7 +13,7 @@
   "skills": "./skills/",
   "interface": {
     "displayName": "Microsoft Dataverse",
-    "shortDescription": "Build, query, and manage Microsoft Dataverse from your coding agent.",
+    "shortDescription": "Build & manage Dataverse",
     "longDescription": "Microsoft Dataverse plugin for coding agents — powering CRUD, bulk data operations, advanced queries, schema lifecycle, and environment management through intelligent skills that unify MCP, CLI, and SDK workflows.",
     "developerName": "Microsoft",
     "category": "Developer Tools",

--- a/.github/plugins/dataverse/.codex-plugin/plugin.json
+++ b/.github/plugins/dataverse/.codex-plugin/plugin.json
@@ -24,8 +24,7 @@
     "defaultPrompt": [
       "Show me my open deals over $100K closing this quarter",
       "Import this CSV into the contacts table",
-      "Create a customer feedback table with name, rating, and comment columns",
-      "Pull the schema and pack it into a solution"
+      "Create a customer feedback table with name, rating, and comment columns"
     ],
     "brandColor": "#22918B",
     "composerIcon": "./assets/dataverse-logo.svg",

--- a/.github/plugins/dataverse/.codex-plugin/plugin.json
+++ b/.github/plugins/dataverse/.codex-plugin/plugin.json
@@ -13,7 +13,7 @@
   "skills": "./skills/",
   "interface": {
     "displayName": "Microsoft Dataverse",
-    "shortDescription": "Build & manage Dataverse",
+    "shortDescription": "Build and manage Dataverse",
     "longDescription": "Microsoft Dataverse plugin for coding agents — powering CRUD, bulk data operations, advanced queries, schema lifecycle, and environment management through intelligent skills that unify MCP, CLI, and SDK workflows.",
     "developerName": "Microsoft",
     "category": "Developer Tools",


### PR DESCRIPTION
Fixes two Codex manifest validation issues in `.github/plugins/dataverse/.codex-plugin/plugin.json` surfaced by the Codex plugin detail page.

## Changes
- **`interface.defaultPrompt`** — trimmed from 4 to 3 entries. Codex renders at most 3 starter prompts in the Examples section, so the 4th ("Pull the schema and pack it into a solution") was silently dropped.
- **`interface.shortDescription`** — shortened to "Build and manage Dataverse" (26 chars). Codex enforces a 30-character subtitle limit; the previous value (63 chars) triggered a "Subtitle must be 30 characters or fewer" error.

## Validation
- `python .github/evals/static_checks.py` passes.
