### PR TITLE
fix: check out LocalEvalRunner so eval Execute step finds its script

### DIFF
--- a/.azdo/DataversePluginEvals_PR.yml
+++ b/.azdo/DataversePluginEvals_PR.yml
@@ -71,6 +71,13 @@ steps:
   displayName: 'Checkout evaluator prompts'
   fetchDepth: 1
 
+# The Execute template runs an external script (execute-biceval.ps1) from the
+# LocalEvalRunner repo via scriptPath, so that repo must be present in the
+# workspace. Multi-repo checkout places it at $(Build.SourcesDirectory)/LocalEvalRunner.
+- checkout: LocalEvalRunner
+  displayName: 'Checkout LocalEvalRunner (eval scripts)'
+  fetchDepth: 1
+
 # Setup: .NET, NuGet auth, LocalEvalRunner install, Copilot CLI, auth token
 - template: .pipelines/templates/steps/BicEval-SetupTemplate.yml@LocalEvalRunner
   parameters:
@@ -99,6 +106,9 @@ steps:
     azureServiceConnection: ${{ parameters.azureServiceConnection }}
     concurrency: ${{ parameters.concurrency }}
     serviceName: 'DataverseSkillsPlugin'
+    # Resolve the external eval script from the checked-out LocalEvalRunner repo:
+    # $(Build.SourcesDirectory)/LocalEvalRunner/.pipelines/scripts/execute-biceval.ps1
+    scriptsDirectory: 'LocalEvalRunner/.pipelines/scripts'
 
 # Publish: test results + artifacts
 - template: .pipelines/templates/steps/BicEval-PublishTemplate.yml@LocalEvalRunner


### PR DESCRIPTION
## Summary

The offline eval PR gate (`.azdo/DataversePluginEvals_PR.yml`) began failing at the **Run evaluations** step with:

```
ENOENT: no such file or directory, stat '.../.pipelines/scripts/execute-biceval.ps1'
```

The reusable step templates this pipeline consumes were updated so the eval **Execute** step now runs an *external* PowerShell script (`execute-biceval.ps1`) via `scriptPath`, instead of an inline script. `scriptPath` requires that file to physically exist in the checked-out workspace.

This pipeline only checked out the plugin repo (`self`) and the evaluator-prompts repo, so the external script was never present in the workspace and the step failed with `ENOENT` before any evaluation ran. Nothing in this repo's skills or evals was wrong — the pipeline just needs to adopt the new external-script contract.

## Fix

- Check out the `LocalEvalRunner` repo (already declared as a pipeline resource) so its scripts land in the workspace. With multi-repo checkout, each repo is placed in a named subfolder under the sources directory.
- Pass `scriptsDirectory` to the Execute step template so `scriptPath` resolves to the checked-out copy at `<sources>/LocalEvalRunner/.pipelines/scripts/execute-biceval.ps1`.

No change to the evaluations themselves — this only restores the script path the step needs to run.

## Validation

- `python .github/evals/static_checks.py` -> PASSED (8 skill files, 45 Python blocks)
- Pipeline YAML parses cleanly
- This PR's own eval gate exercises the fixed path end-to-end
