### PR TITLE
fix: auto-enable workspace token cache on headless hosts (device code once per conversation)

### DIFF
--- a/.github/evals/test_auth.py
+++ b/.github/evals/test_auth.py
@@ -316,7 +316,9 @@ class InteractiveTierSelection(_AuthTestBase):
         self.assertIsInstance(cred, _FakeInteractiveBrowser)
         self.assertEqual(kind, "interactive-browser")
 
-    def test_headless_uses_device_code(self):
+    def test_device_code_when_no_workspace_cache(self):
+        # When no workspace cache can be built (opt-out, or path build failure),
+        # a headless host falls back to the legacy device-code credential.
         with tempfile.TemporaryDirectory() as tmp:
             record_path = Path(tmp) / "record.json"
             with mock.patch.object(auth, "_is_ci", lambda: False):
@@ -520,6 +522,47 @@ class WorkspaceTokenCachePath(_AuthTestBase):
                         os.chdir(cwd)
         self.assertIsNotNone(results[0])
         self.assertEqual(results[0], results[1])
+
+
+class WorkspaceCacheAutoDefault(_AuthTestBase):
+    """#117: on a headless, non-CI host with no explicit DATAVERSE_TOKEN_CACHE_DIR,
+    the cache auto-defaults into <workspace>/.dataverse so device code is once per
+    conversation. Desktop / CI keep the OS default cache; an opt-out value disables it.
+    """
+
+    def _resolve(self, env, browser, ci=False):
+        with tempfile.TemporaryDirectory() as anchor:
+            (Path(anchor) / "scripts").mkdir(parents=True)
+            fake_auth = str(Path(anchor) / "scripts" / "auth.py")
+            with mock.patch.object(auth, "__file__", fake_auth), \
+                    mock.patch.object(auth, "_host_has_browser", lambda: browser), \
+                    mock.patch.object(auth, "_is_ci", lambda: ci), \
+                    mock.patch.dict(os.environ, env, clear=True):
+                return auth._workspace_token_cache_path()
+
+    def test_headless_no_env_defaults_to_workspace(self):
+        path = self._resolve({}, browser=False)
+        self.assertIsNotNone(path)
+        self.assertEqual(path.parent.name, ".dataverse")
+        self.assertEqual(path.name, "tokencache_msalv3.dat")
+
+    def test_desktop_no_env_keeps_os_cache(self):
+        self.assertIsNone(self._resolve({}, browser=True))
+
+    def test_ci_no_env_keeps_os_cache(self):
+        self.assertIsNone(self._resolve({}, browser=False, ci=True))
+
+    def test_opt_out_keeps_os_cache_even_headless(self):
+        for val in ("off", "false", "0", "no", "none", "OFF"):
+            self.assertIsNone(
+                self._resolve({"DATAVERSE_TOKEN_CACHE_DIR": val}, browser=False),
+                msg=f"{val!r} should opt out of the workspace cache",
+            )
+
+    def test_explicit_env_used_even_on_headless(self):
+        path = self._resolve({"DATAVERSE_TOKEN_CACHE_DIR": "mycache"}, browser=False)
+        self.assertIsNotNone(path)
+        self.assertEqual(path.parent.name, "mycache")
 
 
 if __name__ == "__main__":

--- a/.github/evals/test_auth.py
+++ b/.github/evals/test_auth.py
@@ -565,5 +565,35 @@ class WorkspaceCacheAutoDefault(_AuthTestBase):
         self.assertEqual(path.parent.name, "mycache")
 
 
+class WorkspaceCacheDecision(_AuthTestBase):
+    """The pure _should_use_workspace_cache() predicate is the single source of truth
+    for both _workspace_token_cache_path (path building) and _run_diagnose (tier
+    reporting), so the two cannot drift.
+    """
+
+    def _decide(self, env, browser, ci=False):
+        with mock.patch.object(auth, "_host_has_browser", lambda: browser), \
+                mock.patch.object(auth, "_is_ci", lambda: ci), \
+                mock.patch.dict(os.environ, env, clear=True):
+            return auth._should_use_workspace_cache()
+
+    def test_explicit_env_regardless_of_host(self):
+        self.assertEqual(self._decide({"DATAVERSE_TOKEN_CACHE_DIR": ".dv"}, browser=True), "explicit")
+        self.assertEqual(self._decide({"DATAVERSE_TOKEN_CACHE_DIR": ".dv"}, browser=False), "explicit")
+
+    def test_headless_no_env_defaults(self):
+        self.assertEqual(self._decide({}, browser=False), "default")
+
+    def test_desktop_no_env_is_none(self):
+        self.assertIsNone(self._decide({}, browser=True))
+
+    def test_ci_no_env_is_none(self):
+        self.assertIsNone(self._decide({}, browser=False, ci=True))
+
+    def test_opt_out_is_none_even_headless(self):
+        for val in ("off", "false", "0", "no", "none", "OFF"):
+            self.assertIsNone(self._decide({"DATAVERSE_TOKEN_CACHE_DIR": val}, browser=False), msg=val)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "dataverse-skills",
   "metadata": {
     "description": "Official Dataverse plugin marketplace for agent-guided development",
-    "version": "1.11.0"
+    "version": "1.11.1"
   },
   "owner": {
     "name": "Microsoft",
@@ -13,7 +13,7 @@
       "name": "dataverse",
       "description": "Microsoft Dataverse plugin for coding agents — powering CRUD, bulk data operations, advanced queries, schema lifecycle, and environment management through intelligent skills that unify MCP, CLI, and SDK workflows.",
       "source": "./.github/plugins/dataverse",
-      "version": "1.11.0",
+      "version": "1.11.1",
       "homepage": "https://github.com/microsoft/Dataverse-skills"
     }
   ]

--- a/.github/plugins/dataverse/.claude-plugin/plugin.json
+++ b/.github/plugins/dataverse/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dataverse",
   "description": "Microsoft Dataverse plugin for coding agents — powering CRUD, bulk data operations, advanced queries, schema lifecycle, and environment management through intelligent skills that unify MCP, CLI, and SDK workflows.",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "author": {
     "name": "Microsoft",
     "url": "https://www.microsoft.com"

--- a/.github/plugins/dataverse/.codex-plugin/plugin.json
+++ b/.github/plugins/dataverse/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dataverse",
   "description": "Microsoft Dataverse plugin for coding agents — powering CRUD, bulk data operations, advanced queries, schema lifecycle, and environment management through intelligent skills that unify MCP, CLI, and SDK workflows.",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "author": {
     "name": "Microsoft",
     "url": "https://www.microsoft.com"

--- a/.github/plugins/dataverse/.cursor-plugin/plugin.json
+++ b/.github/plugins/dataverse/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "dataverse",
   "displayName": "Microsoft Dataverse",
   "description": "Microsoft Dataverse plugin for coding agents — powering CRUD, bulk data operations, advanced queries, schema lifecycle, and environment management through intelligent skills that unify MCP, CLI, and SDK workflows.",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "author": {
     "name": "Microsoft",
     "url": "https://www.microsoft.com"

--- a/.github/plugins/dataverse/.github/plugin/plugin.json
+++ b/.github/plugins/dataverse/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dataverse",
   "description": "Microsoft Dataverse plugin for coding agents — powering CRUD, bulk data operations, advanced queries, schema lifecycle, and environment management through intelligent skills that unify MCP, CLI, and SDK workflows.",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "author": {
     "name": "Microsoft",
     "url": "https://www.microsoft.com"

--- a/.github/plugins/dataverse/scripts/auth.py
+++ b/.github/plugins/dataverse/scripts/auth.py
@@ -250,38 +250,59 @@ _DEFAULT_WORKSPACE_CACHE_DIRNAME = ".dataverse"
 _CACHE_DIR_OPT_OUT = frozenset({"off", "0", "false", "no", "none", "disable", "disabled"})
 
 
-def _workspace_token_cache_path():
-    """Return the MSAL v3 cache file path used to persist the device-code refresh
-    token across separate Python processes, or None to keep the OS default cache.
-
-    Resolution:
-      - DATAVERSE_TOKEN_CACHE_DIR set to a path -> use it (a relative dir is anchored
-        to the workspace root, matching how load_env finds .env).
-      - DATAVERSE_TOKEN_CACHE_DIR set to an opt-out value (off/false/0/no/none) -> None.
-      - unset on a HEADLESS, non-CI host (ChatGPT web / Codex sandbox / SSH / container)
-        -> DEFAULT to ``<workspace>/.dataverse``. On these hosts the OS default cache
-        lives under $HOME, which the sandbox wipes between Python processes, so device
-        code would re-prompt every process; putting the cache in the persisted
-        workspace makes sign-in once per conversation.
-      - unset on a desktop host -> None (keep the secure OS cache: Windows DPAPI /
-        macOS Keychain / Linux desktop keyring -- no behavior change).
-
-    Security: on headless Linux the cache holds a PLAINTEXT refresh token (no keyring).
-    The directory is created owner-only (0700 on POSIX) with a self-contained
-    `.gitignore` (`*`) so the token is excluded from version control, and an ephemeral
-    sandbox is torn down after the session. To keep the OS default cache instead, set
-    DATAVERSE_TOKEN_CACHE_DIR=off.
+def _should_use_workspace_cache():
+    """Pure decision (no I/O): whether the persisted workspace token cache is used,
+    and via which source. This is the SINGLE source of truth so
+    _workspace_token_cache_path (which builds the path) and _run_diagnose (which
+    reports the tier) can never drift. Returns:
+      "explicit" -- DATAVERSE_TOKEN_CACHE_DIR is set to a usable path.
+      "default"  -- unset on a HEADLESS, non-CI host -> auto-default to <workspace>/.dataverse.
+      None       -- keep the OS default cache (desktop, CI, or an explicit opt-out).
     """
     cache_dir = os.environ.get("DATAVERSE_TOKEN_CACHE_DIR")
     if cache_dir is not None and cache_dir.strip().lower() in _CACHE_DIR_OPT_OUT:
         return None  # explicit opt-out -- keep the per-process OS default cache
-    if not cache_dir:
-        # No explicit setting: auto-default ONLY where the OS cache will not survive --
-        # a headless, non-CI host. Desktop hosts keep their secure default cache; CI
-        # never reaches an interactive tier (service principal is terminal earlier).
-        if _host_has_browser() or _is_ci():
-            return None
-        cache_dir = _DEFAULT_WORKSPACE_CACHE_DIRNAME
+    if cache_dir:
+        return "explicit"
+    # No explicit setting: auto-default ONLY where the OS cache will not survive --
+    # a headless, non-CI host. Desktop hosts keep their secure default cache; CI
+    # never reaches an interactive tier (service principal is terminal earlier).
+    if _host_has_browser() or _is_ci():
+        return None
+    return "default"
+
+
+def _workspace_token_cache_path():
+    """Return the MSAL v3 cache file path used to persist the device-code refresh
+    token across separate Python processes, or None to keep the OS default cache.
+    The use/skip decision is _should_use_workspace_cache(); this function only turns
+    a positive decision into a concrete, git-ignored, owner-only file path.
+
+    Resolution (see _should_use_workspace_cache):
+      - DATAVERSE_TOKEN_CACHE_DIR set to a path -> use it (a relative dir is anchored
+        to the workspace root, matching how load_env finds .env).
+      - opt-out value (off/false/0/no/none) -> None.
+      - unset on a HEADLESS, non-CI host (ChatGPT web / Codex sandbox / SSH / container)
+        -> DEFAULT to ``<workspace>/.dataverse`` (the OS cache lives under $HOME, which
+        the sandbox wipes between Python processes, so device code would re-prompt every
+        process; the persisted workspace cache makes sign-in once per conversation).
+      - unset on a desktop host -> None (keep the secure OS cache: Windows DPAPI /
+        macOS Keychain / Linux desktop keyring -- no behavior change).
+
+    Security: on non-Windows hosts (Linux, and macOS over SSH) the cache holds a
+    PLAINTEXT refresh token (no keyring; Windows uses DPAPI). The directory is created
+    owner-only (0700 on POSIX) with a self-contained `.gitignore` (`*`) so the token is
+    excluded from version control, and an ephemeral sandbox is torn down after the
+    session. To keep the OS default cache instead, set DATAVERSE_TOKEN_CACHE_DIR=off.
+    """
+    decision = _should_use_workspace_cache()
+    if decision is None:
+        return None
+    cache_dir = (
+        os.environ.get("DATAVERSE_TOKEN_CACHE_DIR")
+        if decision == "explicit"
+        else _DEFAULT_WORKSPACE_CACHE_DIRNAME
+    )
     try:
         path = Path(cache_dir)
         if not path.is_absolute():
@@ -852,7 +873,7 @@ def _run_diagnose():
     except ImportError:
         rows.append(("azure-cli", "n/a", "azure-identity not installed"))
 
-    if os.environ.get("DATAVERSE_TOKEN_CACHE_DIR"):
+    if _should_use_workspace_cache() is not None:
         kind = "workspace-device-code"
     elif _host_has_browser():
         kind = "interactive-browser"

--- a/.github/plugins/dataverse/scripts/auth.py
+++ b/.github/plugins/dataverse/scripts/auth.py
@@ -241,25 +241,47 @@ class _MsalSharedCacheCredential:
         pass
 
 
+# Default workspace cache dir used on headless/ephemeral hosts when the user has not
+# set DATAVERSE_TOKEN_CACHE_DIR (see _workspace_token_cache_path).
+_DEFAULT_WORKSPACE_CACHE_DIRNAME = ".dataverse"
+
+# Explicit opt-out values for DATAVERSE_TOKEN_CACHE_DIR: keep the OS default cache
+# (do not write a plaintext refresh token into the workspace).
+_CACHE_DIR_OPT_OUT = frozenset({"off", "0", "false", "no", "none", "disable", "disabled"})
+
+
 def _workspace_token_cache_path():
-    """Return an explicit MSAL v3 cache file path when DATAVERSE_TOKEN_CACHE_DIR is set.
+    """Return the MSAL v3 cache file path used to persist the device-code refresh
+    token across separate Python processes, or None to keep the OS default cache.
 
-    Opt-in. On ephemeral hosts (ChatGPT web / Codex sandbox) the process $HOME is
-    wiped between turns while the workspace directory persists within a conversation.
-    Setting DATAVERSE_TOKEN_CACHE_DIR (e.g. ".dataverse") relocates the device-code
-    token cache into the persisted workspace, so the first sign-in is silently reused
-    on later turns. Returns None when the var is unset, which leaves capable hosts
-    (Windows DPAPI / macOS Keychain / Linux desktop keyring) on their default secure
-    cache with NO behavior change.
+    Resolution:
+      - DATAVERSE_TOKEN_CACHE_DIR set to a path -> use it (a relative dir is anchored
+        to the workspace root, matching how load_env finds .env).
+      - DATAVERSE_TOKEN_CACHE_DIR set to an opt-out value (off/false/0/no/none) -> None.
+      - unset on a HEADLESS, non-CI host (ChatGPT web / Codex sandbox / SSH / container)
+        -> DEFAULT to ``<workspace>/.dataverse``. On these hosts the OS default cache
+        lives under $HOME, which the sandbox wipes between Python processes, so device
+        code would re-prompt every process; putting the cache in the persisted
+        workspace makes sign-in once per conversation.
+      - unset on a desktop host -> None (keep the secure OS cache: Windows DPAPI /
+        macOS Keychain / Linux desktop keyring -- no behavior change).
 
-    Security hardening: the cache holds a refresh token (plaintext on headless Linux;
-    DPAPI-encrypted on Windows -- see _get_credential). The directory is created
-    owner-only (0700 on POSIX) with a self-contained `.gitignore` (`*`) so the token
-    is excluded from version control even if the repo-root .gitignore misses it.
+    Security: on headless Linux the cache holds a PLAINTEXT refresh token (no keyring).
+    The directory is created owner-only (0700 on POSIX) with a self-contained
+    `.gitignore` (`*`) so the token is excluded from version control, and an ephemeral
+    sandbox is torn down after the session. To keep the OS default cache instead, set
+    DATAVERSE_TOKEN_CACHE_DIR=off.
     """
     cache_dir = os.environ.get("DATAVERSE_TOKEN_CACHE_DIR")
+    if cache_dir is not None and cache_dir.strip().lower() in _CACHE_DIR_OPT_OUT:
+        return None  # explicit opt-out -- keep the per-process OS default cache
     if not cache_dir:
-        return None
+        # No explicit setting: auto-default ONLY where the OS cache will not survive --
+        # a headless, non-CI host. Desktop hosts keep their secure default cache; CI
+        # never reaches an interactive tier (service principal is terminal earlier).
+        if _host_has_browser() or _is_ci():
+            return None
+        cache_dir = _DEFAULT_WORKSPACE_CACHE_DIRNAME
     try:
         path = Path(cache_dir)
         if not path.is_absolute():
@@ -465,9 +487,10 @@ def _build_interactive_tier(tenant_id):
 
     kind is one of ``workspace-device-code`` / ``interactive-browser`` /
     ``device-code``. Selection:
-      - DATAVERSE_TOKEN_CACHE_DIR set -> workspace-cache device-code (self-persisting).
-      - desktop host with a browser   -> InteractiveBrowserCredential (system browser).
-      - headless host                 -> DeviceCodeCredential (legacy).
+      - workspace cache available (DATAVERSE_TOKEN_CACHE_DIR set, or auto-defaulted on
+        a headless non-CI host) -> workspace-cache device-code (self-persisting).
+      - desktop host with a browser -> InteractiveBrowserCredential (system browser).
+      - headless host with no buildable workspace cache -> DeviceCodeCredential (legacy).
     The azure-identity interactive tiers persist an AuthenticationRecord on first
     login so a later process refreshes silently. Called ONLY after every silent
     tier is exhausted, so the eager first-login prompt here is never premature.


### PR DESCRIPTION
## What

On a **headless, non-CI** host (ChatGPT web / Codex sandbox / SSH / container) with no explicit `DATAVERSE_TOKEN_CACHE_DIR`, `auth.py` now defaults the MSAL device-code cache to `<workspace>/.dataverse` instead of leaving it on the OS default. Result: **device code once per conversation** instead of once per Python process.

Fixes #117.

## Why

The OS default token cache lives under `$HOME`, which ephemeral sandboxes wipe between separate Python processes. So the legacy device-code credential re-authenticated on every process, and a multi-step task (connect -> inspect -> create -> verify) prompted the user 3-5 times. Observed live on the published 1.11.0 plugin in ChatGPT: four device codes for one "create a table" task, silent only after `DATAVERSE_TOKEN_CACHE_DIR` was set by hand. The persisted workspace cache (the "sign in once" experience 1.11 ships) was opt-in, so on ephemeral hosts it defaulted off.

## Change

`_workspace_token_cache_path()` resolution:
- `DATAVERSE_TOKEN_CACHE_DIR` set to a path -> use it (relative anchored to the workspace root).
- set to an **opt-out** value (`off` / `false` / `0` / `no` / `none`) -> `None` (keep the OS default cache).
- **unset on a headless, non-CI host** -> default to `<workspace>/.dataverse`.
- unset on a desktop host -> `None` (Windows DPAPI / macOS Keychain / Linux desktop keyring, unchanged).
- unset on CI -> `None` (service principal is the terminal tier earlier; interactive never runs).

## Security tradeoff

On non-Windows hosts (Linux, and macOS over SSH) the workspace cache holds a **plaintext refresh token** (no keyring; Windows uses DPAPI) -- the reason 1.11 made it opt-in. Mitigations (already in the code): the dir is created **0700 (owner-only)** with a self-written `.gitignore` (`*`), and an ephemeral sandbox is torn down after the session. The alternative default -- a device code every process -- is a far worse UX. `DATAVERSE_TOKEN_CACHE_DIR=off` preserves the strict-security posture for anyone who wants it.

## Reviewer action

- Confirm you're comfortable defaulting the plaintext-token workspace cache **on** for headless non-CI hosts (desktop/CI unchanged), given the 0700 + gitignore + ephemeral-teardown mitigations and the `=off` opt-out.

## Verification

- `python .github/evals/test_auth.py` -- 39/39 (new `WorkspaceCacheAutoDefault` matrix: headless-default / desktop-none / CI-none / opt-out / explicit-env).
- `python .github/evals/static_checks.py` -- passes (8 skills, 11 categories).
- `python .github/evals/version_bump_check.py --base origin/main` -- 1.11.0 -> 1.11.1 (patch).
