### PR TITLE
docs: recommend --data-file for cross-platform / agent JSON writes

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "dataverse-skills",
   "metadata": {
     "description": "Official Dataverse plugin marketplace for agent-guided development",
-    "version": "1.11.0"
+    "version": "1.11.1"
   },
   "owner": {
     "name": "Microsoft",
@@ -13,7 +13,7 @@
       "name": "dataverse",
       "description": "Microsoft Dataverse plugin for coding agents — powering CRUD, bulk data operations, advanced queries, schema lifecycle, and environment management through intelligent skills that unify MCP, CLI, and SDK workflows.",
       "source": "./.github/plugins/dataverse",
-      "version": "1.11.0",
+      "version": "1.11.1",
       "homepage": "https://github.com/microsoft/Dataverse-skills"
     }
   ]

--- a/.github/plugins/dataverse/.claude-plugin/plugin.json
+++ b/.github/plugins/dataverse/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dataverse",
   "description": "Microsoft Dataverse plugin for coding agents — powering CRUD, bulk data operations, advanced queries, schema lifecycle, and environment management through intelligent skills that unify MCP, CLI, and SDK workflows.",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "author": {
     "name": "Microsoft",
     "url": "https://www.microsoft.com"

--- a/.github/plugins/dataverse/.codex-plugin/plugin.json
+++ b/.github/plugins/dataverse/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dataverse",
   "description": "Microsoft Dataverse plugin for coding agents — powering CRUD, bulk data operations, advanced queries, schema lifecycle, and environment management through intelligent skills that unify MCP, CLI, and SDK workflows.",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "author": {
     "name": "Microsoft",
     "url": "https://www.microsoft.com"

--- a/.github/plugins/dataverse/.cursor-plugin/plugin.json
+++ b/.github/plugins/dataverse/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "dataverse",
   "displayName": "Microsoft Dataverse",
   "description": "Microsoft Dataverse plugin for coding agents — powering CRUD, bulk data operations, advanced queries, schema lifecycle, and environment management through intelligent skills that unify MCP, CLI, and SDK workflows.",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "author": {
     "name": "Microsoft",
     "url": "https://www.microsoft.com"

--- a/.github/plugins/dataverse/.github/plugin/plugin.json
+++ b/.github/plugins/dataverse/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dataverse",
   "description": "Microsoft Dataverse plugin for coding agents — powering CRUD, bulk data operations, advanced queries, schema lifecycle, and environment management through intelligent skills that unify MCP, CLI, and SDK workflows.",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "author": {
     "name": "Microsoft",
     "url": "https://www.microsoft.com"

--- a/.github/plugins/dataverse/skills/dv-data/references/erp-writes.md
+++ b/.github/plugins/dataverse/skills/dv-data/references/erp-writes.md
@@ -5,15 +5,22 @@ When the env is ERP-linked — ERP (Finance and Operations) provisioned on the s
 1. **ERP MCP** for simple, interactive writes — if `dataverse mcp <erpUrl>` is wired up as an MCP server. Same `create_record` / `update_record` / `delete_record` shape as Dataverse MCP.
 2. **Dataverse CLI `--target erp`** for scripted single-record writes:
 
+   **Shell escaping note.** On bash / zsh (`--data '{"key":"value"}'`) works as shown. On Windows cmd and some PowerShell versions the outer single-quotes are passed through literally and JSON parsing fails. For automation and cross-platform agent use, prefer `--data-file <path.json>`.
+
 ```bash
 # Create
 dataverse data create --target erp --table CustomerGroups \
   --data '{"dataAreaId":"usmf","CustomerGroupId":"demo","Description":"demo group"}'
+# Cross-platform / agent-preferred: same create from a JSON file
+dataverse data create --target erp --table CustomerGroups --data-file body.json
 
 # Update (composite key)
 dataverse data update --target erp --table CustomerGroups \
   --key "dataAreaId='usmf',CustomerGroupId='demo'" \
   --data '{"Description":"demo group (updated)"}'
+# Cross-platform / agent-preferred: same update from a JSON file
+dataverse data update --target erp --table CustomerGroups \
+  --key "dataAreaId='usmf',CustomerGroupId='demo'" --data-file body.json
 
 # Delete (suppress interactive confirm in scripts)
 dataverse data delete --target erp --table CustomerGroups \

--- a/.github/plugins/dataverse/skills/dv-overview/references/erp-target.md
+++ b/.github/plugins/dataverse/skills/dv-overview/references/erp-target.md
@@ -77,13 +77,20 @@ What's different from Dataverse OData:
 
 For single-record CRUD, prefer ERP MCP (≤10 records). For programmatic / scripted writes, use the CLI:
 
+**Shell escaping note.** On bash / zsh (`--data '{"key":"value"}'`) works as shown. On Windows cmd and some PowerShell versions the outer single-quotes are passed through literally and JSON parsing fails. For automation and cross-platform agent use, prefer `--data-file <path.json>`.
+
 ```bash
 dataverse data create --target erp --table CustomerGroups \
   --data '{"dataAreaId":"usmf","CustomerGroupId":"demo","Description":"demo group"}'
+# Cross-platform / agent-preferred: same create from a JSON file
+dataverse data create --target erp --table CustomerGroups --data-file body.json
 
 dataverse data update --target erp --table CustomerGroups \
   --key "dataAreaId='usmf',CustomerGroupId='demo'" \
   --data '{"Description":"demo group (updated)"}'
+# Cross-platform / agent-preferred: same update from a JSON file
+dataverse data update --target erp --table CustomerGroups \
+  --key "dataAreaId='usmf',CustomerGroupId='demo'" --data-file body.json
 
 dataverse data delete --target erp --table CustomerGroups \
   --key "dataAreaId='usmf',CustomerGroupId='demo'" --no-confirm


### PR DESCRIPTION
## Problem

`dataverse data create` / `update` / `delete` write examples in the skill docs only show the
bash single-quote form `--data '{...}'`. On Windows cmd and some PowerShell versions the outer
single-quotes are passed through literally, so JSON parsing fails. Telemetry shows `data update`
failing overwhelmingly for Windows users generating invalid JSON via `--data`, while the
shell-safe alternative `--data-file` was documented **zero** times across the repo.

## Fix

For each ERP-write worked example that uses `--data '{...}'`, add:

- A short **Shell escaping note** paragraph immediately above the example explaining the
  Windows single-quote pitfall and recommending `--data-file <path.json>` for automation and
  cross-platform agent use.
- A `--data-file` variant of the create and update examples (existing `--data '{...}'` examples
  are kept -- they are correct on bash / zsh).

Touched files:

- `.github/plugins/dataverse/skills/dv-data/references/erp-writes.md`
- `.github/plugins/dataverse/skills/dv-overview/references/erp-target.md`

`dv-data/SKILL.md` was intentionally **not** changed: it contains no `--data` examples to
annotate and is already near the 5000-token Level 2 cap, so the guidance stays in the
references (Level 3), per the repo's SKILL.md budget rule.

## Version

Patch bump 1.11.0 -> 1.11.1 across all six version fields (skill-file change; docs-only, no
behavior or routing change). `version_bump_check.py` passes (patch required).

## Non-goals

- No new skills, no new example-data files, no restructuring.
- No other skills or references touched.

## Verification

- `grep --data-file` under `skills/` returns 6 matches (was 0).
- `version_bump_check.py`: PASSED (1.11.0 -> 1.11.1, patch).
- Only the two reference files and the six version fields changed.
- Note: `static_checks.py` reports 3 pre-existing `EVAL-BUDGET-02` failures on
  `dv-connect` / `dv-metadata` / `dv-overview` SKILL.md bodies. These exist on `main`
  unchanged (verified with this branch's edits stashed) and are unrelated to this PR.
