### PR TITLE
fix: keep marketplace metadata synchronized

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "dataverse",
-      "description": "Microsoft Dataverse plugin for coding agents — powering CRUD, bulk data operations, advanced queries, schema lifecycle, and environment management through intelligent skills that unify MCP, CLI, and SDK workflows.",
+      "description": "Microsoft Dataverse plugin for coding agents, covering record CRUD, bulk data operations, advanced queries, schema and metadata, administration, security, environment management, and solution lifecycle through MCP, CLI, and SDK workflows.",
       "source": "./.github/plugins/dataverse",
       "homepage": "https://github.com/microsoft/Dataverse-skills"
     }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -12,7 +12,7 @@
   "plugins": [
     {
       "name": "dataverse",
-      "description": "Microsoft Dataverse plugin for coding agents — powering CRUD, bulk data operations, advanced queries, schema lifecycle, and environment management through intelligent skills that unify MCP, CLI, and SDK workflows.",
+      "description": "Microsoft Dataverse plugin for coding agents, covering record CRUD, bulk data operations, advanced queries, schema and metadata, administration, security, environment management, and solution lifecycle through MCP, CLI, and SDK workflows.",
       "source": "./.github/plugins/dataverse",
       "version": "1.11.3",
       "homepage": "https://github.com/microsoft/Dataverse-skills"

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -3,7 +3,7 @@
   "name": "dataverse-skills",
   "metadata": {
     "description": "Official Dataverse plugin marketplace for Cursor",
-    "version": "1.10.0"
+    "version": "1.11.3"
   },
   "owner": {
     "name": "Microsoft",
@@ -14,7 +14,7 @@
       "name": "dataverse",
       "description": "Microsoft Dataverse plugin for coding agents — powering CRUD, bulk data operations, advanced queries, schema lifecycle, and environment management through intelligent skills that unify MCP, CLI, and SDK workflows.",
       "source": "./.github/plugins/dataverse",
-      "version": "1.10.0",
+      "version": "1.11.3",
       "homepage": "https://github.com/microsoft/Dataverse-skills"
     }
   ]

--- a/.github/evals/static_checks.py
+++ b/.github/evals/static_checks.py
@@ -572,16 +572,18 @@ SEMVER_PATTERN = re.compile(r"^\d+\.\d+\.\d+$")
 
 def check_version_consistency(repo_root):
     """
-    EVAL-VERSION-01: All six version fields match across manifest files.
+    EVAL-VERSION-01: All eight version fields match across manifest files.
     EVAL-VERSION-02: Version format is valid semver (x.y.z).
 
-    The six version fields live in five files:
+    The eight version fields live in six files:
       1. .github/plugin/marketplace.json -- metadata.version
       2. .github/plugin/marketplace.json -- plugins[0].version
       3. .github/plugins/dataverse/.claude-plugin/plugin.json -- version
       4. .github/plugins/dataverse/.github/plugin/plugin.json -- version
       5. .github/plugins/dataverse/.cursor-plugin/plugin.json -- version
       6. .github/plugins/dataverse/.codex-plugin/plugin.json -- version
+      7. .cursor-plugin/marketplace.json -- metadata.version
+      8. .cursor-plugin/marketplace.json -- plugins[0].version
     """
     failures = []
 
@@ -615,6 +617,16 @@ def check_version_consistency(repo_root):
             ".github/plugins/dataverse/.codex-plugin/plugin.json",
             lambda d: d.get("version"),
             "version",
+        ),
+        (
+            ".cursor-plugin/marketplace.json",
+            lambda d: d.get("metadata", {}).get("version"),
+            "metadata.version",
+        ),
+        (
+            ".cursor-plugin/marketplace.json",
+            lambda d: (d.get("plugins") or [{}])[0].get("version"),
+            "plugins[0].version",
         ),
     ]
 

--- a/.github/evals/static_checks.py
+++ b/.github/evals/static_checks.py
@@ -679,9 +679,9 @@ def check_version_consistency(repo_root):
 # CAT-9  Manifest Description Consistency
 # ---------------------------------------------------------------------------
 
-# The plugin description appears in four plugin.json manifests (one per
-# harness/marketplace format) and the plugins[0] entry of three marketplace.json
-# catalogs. All seven describe the same plugin and must match. The
+# The plugin description appears in five plugin manifest fields (including
+# Codex's long description) and the plugins[0] entry of three marketplace.json
+# catalogs. All eight describe the same plugin and must match. The
 # marketplace-level metadata.description is intentionally different (it
 # describes the marketplace, not the plugin) and is deliberately excluded.
 _DESCRIPTION_SOURCES = [
@@ -691,6 +691,9 @@ _DESCRIPTION_SOURCES = [
      lambda d: d.get("description"), "description"),
     (".github/plugins/dataverse/.codex-plugin/plugin.json",
      lambda d: d.get("description"), "description"),
+    (".github/plugins/dataverse/.codex-plugin/plugin.json",
+     lambda d: (d.get("interface") or {}).get("longDescription"),
+     "interface.longDescription"),
     (".github/plugins/dataverse/.github/plugin/plugin.json",
      lambda d: d.get("description"), "description"),
     (".github/plugin/marketplace.json",

--- a/.github/evals/static_checks.py
+++ b/.github/evals/static_checks.py
@@ -64,7 +64,7 @@ CAT-6  dv-admin Allowlist Enforcement
 CAT-7  Manifest Version Consistency
        Checks that the plugin version matches across all marketplace and plugin
        manifest files, preventing drift when version bumps miss a file.
-       EVAL-VERSION-01  All six version fields match (5 files, 6 fields total)
+       EVAL-VERSION-01  All eight version fields match (6 files, 8 fields total)
        EVAL-VERSION-02  Version format is valid semver (x.y.z)
 
 CAT-8  Skill Token Budget (Anthropic Skills spec)

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -11,7 +11,7 @@
   "plugins": [
     {
       "name": "dataverse",
-      "description": "Microsoft Dataverse plugin for coding agents — powering CRUD, bulk data operations, advanced queries, schema lifecycle, and environment management through intelligent skills that unify MCP, CLI, and SDK workflows.",
+      "description": "Microsoft Dataverse plugin for coding agents, covering record CRUD, bulk data operations, advanced queries, schema and metadata, administration, security, environment management, and solution lifecycle through MCP, CLI, and SDK workflows.",
       "source": "./.github/plugins/dataverse",
       "version": "1.11.3",
       "homepage": "https://github.com/microsoft/Dataverse-skills"

--- a/.github/plugins/dataverse/.claude-plugin/plugin.json
+++ b/.github/plugins/dataverse/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dataverse",
-  "description": "Microsoft Dataverse plugin for coding agents — powering CRUD, bulk data operations, advanced queries, schema lifecycle, and environment management through intelligent skills that unify MCP, CLI, and SDK workflows.",
+  "description": "Microsoft Dataverse plugin for coding agents, covering record CRUD, bulk data operations, advanced queries, schema and metadata, administration, security, environment management, and solution lifecycle through MCP, CLI, and SDK workflows.",
   "version": "1.11.3",
   "author": {
     "name": "Microsoft",

--- a/.github/plugins/dataverse/.codex-plugin/plugin.json
+++ b/.github/plugins/dataverse/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dataverse",
-  "description": "Microsoft Dataverse plugin for coding agents — powering CRUD, bulk data operations, advanced queries, schema lifecycle, and environment management through intelligent skills that unify MCP, CLI, and SDK workflows.",
+  "description": "Microsoft Dataverse plugin for coding agents, covering record CRUD, bulk data operations, advanced queries, schema and metadata, administration, security, environment management, and solution lifecycle through MCP, CLI, and SDK workflows.",
   "version": "1.11.3",
   "author": {
     "name": "Microsoft",
@@ -14,7 +14,7 @@
   "interface": {
     "displayName": "Microsoft Dataverse",
     "shortDescription": "Build and manage Dataverse",
-    "longDescription": "Microsoft Dataverse plugin for coding agents — powering CRUD, bulk data operations, advanced queries, schema lifecycle, and environment management through intelligent skills that unify MCP, CLI, and SDK workflows.",
+    "longDescription": "Microsoft Dataverse plugin for coding agents, covering record CRUD, bulk data operations, advanced queries, schema and metadata, administration, security, environment management, and solution lifecycle through MCP, CLI, and SDK workflows.",
     "developerName": "Microsoft",
     "category": "Developer Tools",
     "capabilities": ["Read", "Write"],

--- a/.github/plugins/dataverse/.cursor-plugin/plugin.json
+++ b/.github/plugins/dataverse/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dataverse",
   "displayName": "Microsoft Dataverse",
-  "description": "Microsoft Dataverse plugin for coding agents — powering CRUD, bulk data operations, advanced queries, schema lifecycle, and environment management through intelligent skills that unify MCP, CLI, and SDK workflows.",
+  "description": "Microsoft Dataverse plugin for coding agents, covering record CRUD, bulk data operations, advanced queries, schema and metadata, administration, security, environment management, and solution lifecycle through MCP, CLI, and SDK workflows.",
   "version": "1.11.3",
   "author": {
     "name": "Microsoft",

--- a/.github/plugins/dataverse/.github/plugin/plugin.json
+++ b/.github/plugins/dataverse/.github/plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dataverse",
-  "description": "Microsoft Dataverse plugin for coding agents — powering CRUD, bulk data operations, advanced queries, schema lifecycle, and environment management through intelligent skills that unify MCP, CLI, and SDK workflows.",
+  "description": "Microsoft Dataverse plugin for coding agents, covering record CRUD, bulk data operations, advanced queries, schema and metadata, administration, security, environment management, and solution lifecycle through MCP, CLI, and SDK workflows.",
   "version": "1.11.3",
   "author": {
     "name": "Microsoft",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,7 +150,7 @@ Contributors who aren't on the maintainers team need two team members to review.
 
 ## Version Bumping
 
-When a PR changes skill files (`.github/plugins/dataverse/skills/**`), bump the plugin version before merging. Version must be updated in all six fields (across five files):
+When a PR changes skill files (`.github/plugins/dataverse/skills/**`), bump the plugin version before merging. Version must be updated in all eight fields (across six files):
 
 1. `.github/plugin/marketplace.json` — top-level `metadata.version`
 2. `.github/plugin/marketplace.json` — plugin entry `version`
@@ -158,8 +158,10 @@ When a PR changes skill files (`.github/plugins/dataverse/skills/**`), bump the 
 4. `.github/plugins/dataverse/.github/plugin/plugin.json` — `version`
 5. `.github/plugins/dataverse/.cursor-plugin/plugin.json` — `version`
 6. `.github/plugins/dataverse/.codex-plugin/plugin.json` — `version`
+7. `.cursor-plugin/marketplace.json` — top-level `metadata.version`
+8. `.cursor-plugin/marketplace.json` — plugin entry `version`
 
-All six must match. The static eval (`python .github/evals/static_checks.py`) verifies version consistency and will fail if any of the six fields drift.
+All eight must match. The static eval (`python .github/evals/static_checks.py`) verifies version consistency and will fail if any of the eight fields drift.
 
 Run the PR-level bump check to verify the bump level matches the structural changes in your branch:
 


### PR DESCRIPTION
## What

Synchronize Dataverse plugin metadata across Cursor, GitHub, Claude, and Codex, and bring the Cursor catalog forward from `1.10.0` to the repository release `1.11.3`.

## Why

The public Cursor Marketplace listing is behind the repository release. Its plugin summary and individual skill cards also show older capability descriptions.

Recent aggregate production telemetry reinforces the update need: during August 14-20, 2026 UTC, Cursor-attributed Dataverse traffic predominantly reported plugin version `1.6.0`. That value is persisted in project `.env` configuration and can remain stale after an installation update, so it is a directional signal rather than authoritative proof of the installed marketplace version.

The existing repository checks did not cover the two root Cursor catalog version fields or Codex `interface.longDescription`, allowing marketplace metadata to drift silently.

## Key changes

- update the Cursor marketplace catalog version from `1.10.0` to `1.11.3`
- update the Cursor plugin summary to the current Dataverse capability scope
- use one current plugin description across all eight public description fields in seven manifests
- include both Cursor catalog version fields in release-version consistency validation
- include Codex `interface.longDescription` in description-parity validation
- preserve GitHub collection-level marketplace metadata because it describes the collection, not the Dataverse plugin

## Publication follow-up

This PR updates repository source metadata and validation only. After merge, the existing public Cursor Marketplace listing must be resubmitted for Cursor review and republication from the latest `main` branch.

Expected publication outcome:

- public Cursor plugin version is `1.11.3`
- the plugin summary reflects the current capability scope
- all eight skill cards are re-indexed from their current `SKILL.md` frontmatter

Cursor listing: https://cursor.com/marketplace/microsoft-dataverse

## Reviewer action

1. Confirm the mirrored metadata fields represent the same plugin release and capability scope.
2. Merge this PR after repository checks pass.
3. Follow up with the Cursor Marketplace team to review and publish the refreshed listing.

## Verification

- `python .github/evals/static_checks.py`
  - `PASSED -- 8 skill files, 51 Python blocks, 12 categories checked`
- `python .github/evals/version_bump_check.py --base origin/main`
  - `PASSED -- no version bump needed (no structural skill changes)`
- negative regression check confirms a stale Cursor version fails `EVAL-VERSION-01`
- all eight public description fields resolve to one unique value
- `git diff --check`
- PR validation, static skill checks, CodeQL, CLA, and plugin eval checks are green
