### PR TITLE
docs: reflect CLI per-command update-check removal (issue #115)

### DIFF
--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -3,7 +3,7 @@
   "name": "dataverse-skills",
   "metadata": {
     "description": "Official Dataverse plugin marketplace for Cursor",
-    "version": "1.11.4"
+    "version": "1.11.5"
   },
   "owner": {
     "name": "Microsoft",
@@ -14,7 +14,7 @@
       "name": "dataverse",
       "description": "Microsoft Dataverse plugin for coding agents, covering record CRUD, bulk data operations, advanced queries, schema and metadata, administration, security, environment management, and solution lifecycle through MCP, CLI, and SDK workflows.",
       "source": "./.github/plugins/dataverse",
-      "version": "1.11.4",
+      "version": "1.11.5",
       "homepage": "https://github.com/microsoft/Dataverse-skills"
     }
   ]

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -3,7 +3,7 @@
   "name": "dataverse-skills",
   "metadata": {
     "description": "Official Dataverse plugin marketplace for Cursor",
-    "version": "1.11.5"
+    "version": "1.12.1"
   },
   "owner": {
     "name": "Microsoft",
@@ -14,7 +14,7 @@
       "name": "dataverse",
       "description": "Microsoft Dataverse plugin for coding agents, covering record CRUD, bulk data operations, advanced queries, schema and metadata, administration, security, environment management, and solution lifecycle through MCP, CLI, and SDK workflows.",
       "source": "./.github/plugins/dataverse",
-      "version": "1.11.5",
+      "version": "1.12.1",
       "homepage": "https://github.com/microsoft/Dataverse-skills"
     }
   ]

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "dataverse-skills",
   "metadata": {
     "description": "Official Dataverse plugin marketplace for agent-guided development",
-    "version": "1.11.4"
+    "version": "1.11.5"
   },
   "owner": {
     "name": "Microsoft",
@@ -13,7 +13,7 @@
       "name": "dataverse",
       "description": "Microsoft Dataverse plugin for coding agents, covering record CRUD, bulk data operations, advanced queries, schema and metadata, administration, security, environment management, and solution lifecycle through MCP, CLI, and SDK workflows.",
       "source": "./.github/plugins/dataverse",
-      "version": "1.11.4",
+      "version": "1.11.5",
       "homepage": "https://github.com/microsoft/Dataverse-skills"
     }
   ]

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "dataverse-skills",
   "metadata": {
     "description": "Official Dataverse plugin marketplace for agent-guided development",
-    "version": "1.11.5"
+    "version": "1.12.1"
   },
   "owner": {
     "name": "Microsoft",
@@ -13,7 +13,7 @@
       "name": "dataverse",
       "description": "Microsoft Dataverse plugin for coding agents, covering record CRUD, bulk data operations, advanced queries, schema and metadata, administration, security, environment management, and solution lifecycle through MCP, CLI, and SDK workflows.",
       "source": "./.github/plugins/dataverse",
-      "version": "1.11.5",
+      "version": "1.12.1",
       "homepage": "https://github.com/microsoft/Dataverse-skills"
     }
   ]

--- a/.github/plugins/dataverse/.claude-plugin/plugin.json
+++ b/.github/plugins/dataverse/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dataverse",
   "description": "Microsoft Dataverse plugin for coding agents, covering record CRUD, bulk data operations, advanced queries, schema and metadata, administration, security, environment management, and solution lifecycle through MCP, CLI, and SDK workflows.",
-  "version": "1.11.5",
+  "version": "1.12.1",
   "author": {
     "name": "Microsoft",
     "url": "https://www.microsoft.com"

--- a/.github/plugins/dataverse/.claude-plugin/plugin.json
+++ b/.github/plugins/dataverse/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dataverse",
   "description": "Microsoft Dataverse plugin for coding agents, covering record CRUD, bulk data operations, advanced queries, schema and metadata, administration, security, environment management, and solution lifecycle through MCP, CLI, and SDK workflows.",
-  "version": "1.11.4",
+  "version": "1.11.5",
   "author": {
     "name": "Microsoft",
     "url": "https://www.microsoft.com"

--- a/.github/plugins/dataverse/.codex-plugin/plugin.json
+++ b/.github/plugins/dataverse/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dataverse",
   "description": "Microsoft Dataverse plugin for coding agents, covering record CRUD, bulk data operations, advanced queries, schema and metadata, administration, security, environment management, and solution lifecycle through MCP, CLI, and SDK workflows.",
-  "version": "1.11.5",
+  "version": "1.12.1",
   "author": {
     "name": "Microsoft",
     "url": "https://www.microsoft.com"

--- a/.github/plugins/dataverse/.codex-plugin/plugin.json
+++ b/.github/plugins/dataverse/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dataverse",
   "description": "Microsoft Dataverse plugin for coding agents, covering record CRUD, bulk data operations, advanced queries, schema and metadata, administration, security, environment management, and solution lifecycle through MCP, CLI, and SDK workflows.",
-  "version": "1.11.4",
+  "version": "1.11.5",
   "author": {
     "name": "Microsoft",
     "url": "https://www.microsoft.com"

--- a/.github/plugins/dataverse/.cursor-plugin/plugin.json
+++ b/.github/plugins/dataverse/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "dataverse",
   "displayName": "Microsoft Dataverse",
   "description": "Microsoft Dataverse plugin for coding agents, covering record CRUD, bulk data operations, advanced queries, schema and metadata, administration, security, environment management, and solution lifecycle through MCP, CLI, and SDK workflows.",
-  "version": "1.11.4",
+  "version": "1.11.5",
   "author": {
     "name": "Microsoft",
     "url": "https://www.microsoft.com"

--- a/.github/plugins/dataverse/.cursor-plugin/plugin.json
+++ b/.github/plugins/dataverse/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "dataverse",
   "displayName": "Microsoft Dataverse",
   "description": "Microsoft Dataverse plugin for coding agents, covering record CRUD, bulk data operations, advanced queries, schema and metadata, administration, security, environment management, and solution lifecycle through MCP, CLI, and SDK workflows.",
-  "version": "1.11.5",
+  "version": "1.12.1",
   "author": {
     "name": "Microsoft",
     "url": "https://www.microsoft.com"

--- a/.github/plugins/dataverse/.github/plugin/plugin.json
+++ b/.github/plugins/dataverse/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dataverse",
   "description": "Microsoft Dataverse plugin for coding agents, covering record CRUD, bulk data operations, advanced queries, schema and metadata, administration, security, environment management, and solution lifecycle through MCP, CLI, and SDK workflows.",
-  "version": "1.11.5",
+  "version": "1.12.1",
   "author": {
     "name": "Microsoft",
     "url": "https://www.microsoft.com"

--- a/.github/plugins/dataverse/.github/plugin/plugin.json
+++ b/.github/plugins/dataverse/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dataverse",
   "description": "Microsoft Dataverse plugin for coding agents, covering record CRUD, bulk data operations, advanced queries, schema and metadata, administration, security, environment management, and solution lifecycle through MCP, CLI, and SDK workflows.",
-  "version": "1.11.4",
+  "version": "1.11.5",
   "author": {
     "name": "Microsoft",
     "url": "https://www.microsoft.com"

--- a/.github/plugins/dataverse/skills/dv-connect/references/tools-setup.md
+++ b/.github/plugins/dataverse/skills/dv-connect/references/tools-setup.md
@@ -59,7 +59,7 @@ pip install --upgrade azure-identity requests PowerPlatform-Dataverse-Client pan
 
 ### Corporate-managed / restricted devices: package registry
 
-On corporate-managed devices, direct access to the public npm registry (and sometimes PyPI) may be blocked by device policy. Symptom: repeated **"This content is blocked by your IT admin"** / npm-URL-block popups during `npm install` or `npx` — which `dv-connect` (`npm install -g @microsoft/dataverse`) and the MCP proxy (`npx @microsoft/dataverse mcp`) invoke, so they fire on every connect/auth.
+On corporate-managed devices, direct access to the public npm registry (and sometimes PyPI) may be blocked by device policy. Symptom: repeated **"This content is blocked by your IT admin"** / npm-URL-block popups during `npm install` or `npx` -- which `dv-connect` (`npm install -g @microsoft/dataverse`) and the MCP proxy (`npx @microsoft/dataverse mcp`) invoke. The install runs once at connect; the MCP proxy's `npx @latest` runs when the stdio server launches (about once per session, not per tool call).
 
 The plugin never overrides your registry — it honors your `.npmrc`. The fix is device-level: point npm at your organization's approved internal feed.
 
@@ -74,7 +74,7 @@ The plugin never overrides your registry — it honors your `.npmrc`. The fix is
    Also remove any explicit `registry=https://registry.npmjs.org/` line from `~/.npmrc` that shadows the managed default.
 3. `npx` follows npm's registry config; if it still resolves stale, clear its cache (`npm-cache/_npx`) and retry.
 
-Install the Dataverse CLI **once** (when missing) and upgrade **explicitly** when you want a newer version -- do NOT re-fetch `@latest` on every connect. Each `@latest` resolution hits the npm registry, which managed-device policy blocks with a security prompt; point npm at your org's approved feed (steps above) for the one-time install/upgrade to succeed. (Note: the Dataverse CLI also runs its own npm version check on every command -- a separate CLI-level source of the same prompt, tracked in issue #115.)
+Install the Dataverse CLI **once** (when missing) and upgrade **explicitly** when you want a newer version. Each `npm install` / `npx @latest` resolution hits the npm registry, which managed-device policy blocks with a security prompt; point npm at your org's approved feed (steps above) so the one-time install/upgrade and the MCP proxy's per-session `npx @latest` both resolve silently. (The Dataverse CLI no longer runs a per-command npm version check -- that separate per-command popup source, tracked in issue #115, was removed. The only remaining registry touches are this install/upgrade and the once-per-session MCP proxy launch.)
 
 ---
 


### PR DESCRIPTION
## Summary

Companion docs change for the Dataverse CLI fix in [bic/DataverseCLI#89](https://microsoft.ghe.com/bic/DataverseCLI/pull/89), which removes the CLI's per-command npm update check (the raw `https.get` to `registry.npmjs.org` that fired on every `dataverse` command and triggered the managed-device security-popup storm in #115).

This PR updates the plugin's managed-device guidance so it matches the CLI's new behavior.

## What changed

`skills/dv-connect/references/tools-setup.md`:

- The old note claimed *"the Dataverse CLI also runs its own npm version check on every command"* -- that per-command check has been removed, so the note is corrected.
- Clarifies the actual remaining npm-registry cadence: the one-time `npm install -g` at connect, and the MCP proxy's `npx @latest` which resolves **when the stdio server launches (about once per session), not per tool call**. Both resolve silently once npm points at the org's approved feed.

Plugin version bumped to **1.12.1** (patch over the current `main` at 1.12.0 -- documentation clarification, no routing or behavior change), applied across all eight version fields.

## Why the registration still uses `npx @latest`

Keeping `npx -y @microsoft/dataverse@latest mcp` for the MCP server is intentional: it is what keeps returning users (auth cached, `dv-connect` skipped) on the latest CLI, refreshed once per session at server launch. Switching to a pinned installed binary would remove that refresh and let returning users drift stale. On corporate devices the correct way to make that per-session resolution silent is the approved-feed configuration already documented in this file -- not removing the refresh.

## Merge with main

`main` advanced while this PR was open (now at 1.12.0, adding the `erp-xpp` skill). `main` has been merged in and the version-field conflicts resolved to **1.12.1**. The only files this PR changes relative to `main` are `tools-setup.md` and the eight version fields.

## Checks

- `python .github/evals/version_bump_check.py` -> PASSED (`1.11.4 -> 1.12.1`, minor bump satisfied by the merged `erp-xpp` skill).
- `python .github/evals/static_checks.py` -> reports 2 `EVAL-BUDGET-02` failures in `dv-metadata` and `dv-overview` skill bodies (over the 5000-token cap). These are **pre-existing on `main`** and unrelated to this change, which touches only `tools-setup.md` and the version fields. This PR introduces no new static-check failures.

Addresses #115 (CLI-side removal is in bic/DataverseCLI#89).
