### PR TITLE
fix: [DDC-Agent] select PR evaluation agent model explicitly

### DIFF
--- a/.azdo/DataversePluginEvals_PR.yml
+++ b/.azdo/DataversePluginEvals_PR.yml
@@ -45,6 +45,11 @@ parameters:
     type: number
     default: 1
 
+  - name: agentModel
+    displayName: 'Model for the agent under test'
+    type: string
+    default: 'claude-sonnet-5'
+
 resources:
   repositories:
   - repository: LocalEvalRunner
@@ -91,6 +96,7 @@ steps:
     testFilePath: 'evals/tests/${{ parameters.testFile }}'
     evaluatorRepoName: 'BIC-Evaluations-Service'
     pluginDir: '.github/plugins/dataverse'
+    agentModel: ${{ parameters.agentModel }}
 
 # Execute: run localevalrunner with CopilotCliAgent
 - template: .pipelines/templates/steps/BicEval-ExecuteTemplate.yml@LocalEvalRunner


### PR DESCRIPTION
## Summary

The pull-request evaluation pipeline inherits its agent model from a shared template. That default currently selects `claude-sonnet-4.6`, which the worker rejects as unavailable before any of the three evaluation prompts can execute.

Add an explicit `agentModel` pipeline parameter, defaulting to `claude-sonnet-5`, and pass it to the agent-configuration preparation template. Manual runs can override the agent model without editing YAML or waiting for a shared-template default change.

## Scope

- One pipeline file, six added lines, based directly on `main`.
- No dependency on other open evaluation PRs or changes to the shared template.
- No changes to evaluator models, pass thresholds, test cases, authentication, or plugin behavior.
- Harness migration and additional test coverage are deliberately separate.

## Validation

- Repository static checks passed: 9 skill files, 51 Python blocks, 12 categories.
- YAML contract checks passed for the default, template forwarding, and unchanged suite selection.
- Executed the actual shared preparation template: the inherited default generated `claude-sonnet-4.6`, the pipeline default generated `claude-sonnet-5`, and a supplied override was preserved. All three configuration checks passed.
- The PR evaluation run succeeded: all three prompts executed successfully, all three tests passed, and execution errors were zero. Results and report publication also succeeded.
- Static skill checks, PR metadata checks, CodeQL, and CLA checks passed.

## Merge Note

After merging a pipeline YAML change, maintainers may need to approve or re-enable the updated Azure DevOps PR validation configuration, as described by the repository's automated warning.

AI-assisted change: DDC-Agent.